### PR TITLE
versions table and print helper

### DIFF
--- a/lua/helpers.lua
+++ b/lua/helpers.lua
@@ -32,7 +32,7 @@ function defineEngineCommand(idx, name, fmt)
    end
    body = string.sub(body, 0, -2) -- bodyip trailing ','
    body = body .. ' )'
-	  
+
    defineFunction(target, args, body)
 end
 

--- a/lua/norns.lua
+++ b/lua/norns.lua
@@ -1,11 +1,13 @@
---[[ 
-   norns.lua 
+--[[
+   norns.lua
    startup script for norns lua environment.
 
    NB: removal of any function/module definitions will break the C->lua glue.
    in other respects, feel free to customize.
 --]]
 
+version = {}
+version.norns = "0.0.1"
 
 -- utilities and helpers
 dofile('lua/helpers.lua')
@@ -23,12 +25,12 @@ startup = function()
 
    -- joystick and sample cutter demo
    dofile('lua/stickcut.lua')
-   
+
 end
 
 --------------------------
 -- define default event handlers.
--- user scripts should redefine. 
+-- user scripts should redefine.
 
 -- tbale of encoder event handlers
 encoder = {}
@@ -81,12 +83,12 @@ joystick.ball = function(stick, ball, xrel, yrel)
 end
 
 -- mouse/KB
---... 
+--...
 
 -- MIDI
--- ... 
+-- ...
 
--- table 
+-- table
 
 -- table of handlers for descriptor reports
 report = {}
@@ -94,7 +96,7 @@ report = {}
 report.engines = function(names, count)
    print(count .. " engines: ")
    for i=1,count do
-	  print(i .. ": "..names[i]) 
+	  print(i .. ": "..names[i])
    end
 end
 
@@ -111,4 +113,10 @@ e = engine
 -- FIXME? : could be a table if that is preferable.
 timer = function(idx, count)
    print("timer " .. idx .. " : " .. count)
+end
+
+versions = function()
+  for key,value in pairs(version) do
+    print(key .. ": "  .. value)
+  end
 end

--- a/lua/stickcut.lua
+++ b/lua/stickcut.lua
@@ -3,6 +3,8 @@
    trivial demo showing how to use the 'Cutter' engine
 --]]
 
+version.stickcut = "0.0.1"
+
 print("\n --- \n hello stickcut.lua \n --- \n")
 
 --[[
@@ -14,7 +16,7 @@ report.commands = function(commands, count)
    print("handling command report... \n")
    addEngineCommands(commands, count)
    e = engine;
-   
+
    -- load a soundfile into first buffer
    e.read(1, '/snd/hurt.wav') -- oh yes i did
    -- twll the first 4 playback voices to use the first buffer
@@ -22,7 +24,7 @@ report.commands = function(commands, count)
    e.buf(2, 1)
    e.buf(3, 1)
    e.buf(4, 1)
-   
+
    -- set the first 4 voices to different playback rates
    e.rate(1, 0.5)
    e.rate(2, 1.0)
@@ -50,7 +52,7 @@ report.commands = function(commands, count)
 		 end
 	  end
    end
-   
+
 end -- report handler
 
 -- handler is set; load the engine

--- a/lua/sticksine.lua
+++ b/lua/sticksine.lua
@@ -1,4 +1,4 @@
---[[ 
+--[[
    sticksine.lua
 
    basic demo script showing how to connect inputs to audio params.
@@ -16,10 +16,12 @@
 
    joystick axis 3 controls amplitude.
    joystick axis 4 bends the base pitch.
-  
+
    holding 'up' on the d-pad engages a timer to randomly walk through pitch intervals.
 
 --]]
+
+version.sticksine = "0.0.1"
 
 print('running sticksine.lua')
 
@@ -81,7 +83,7 @@ amp = {
    set = function(x)
 	  print('amp ' .. x)
 	  amp.val = x
-	  e.amp(x)	  
+	  e.amp(x)
    end
 }
 
@@ -142,7 +144,7 @@ function map_axis(x, bipolar)
    if y < -1.0 then y = -1.0 end
    return y
 end
-   
+
 
 -- similarly for joystick axis functions
 axfunc = {
@@ -160,7 +162,7 @@ axfunc = {
    function(val)
 	  pitch.base = 220.0 * (2 ^ (map_axis(val, true)))
 	  pitch.update()
-   end   
+   end
 }
 
 -- finally, glue our function tables to the handlers defined in norns.lua
@@ -174,7 +176,7 @@ end
 
 -- assign d-pad (aka 'hat') to timer stop/start
 -- each direction is represented as a bitfield
--- so we need to store the state and compare 
+-- so we need to store the state and compare
 local hat_state = false
 joystick.hat = function(stick, hat, val)
    if (val & 0x1) > 0 then


### PR DESCRIPTION
easing in here.

eventually we'll want to be able to print versions to the screen, so figure i'd add something as a start.

could theoretically track matron/maiden and sc engines as well. possibly overkill. most important is for users to track versions of their own things?

also seems my text editor cleaned up a bunch of trailing spaces