### PR TITLE
timer fixes

### DIFF
--- a/lua/norns.lua
+++ b/lua/norns.lua
@@ -27,7 +27,10 @@ startup = function()
    -- dofile('lua/timertest.lua')
 
    -- joystick and sample cutter demo
-   dofile('lua/stickcut.lua')
+   -- dofile('lua/stickcut.lua')
+
+   -- testing grid/timer sequence
+   dofile('lua/test128.lua')
 
 end
 
@@ -114,8 +117,8 @@ e = engine
 
 -- timer handler
 -- FIXME? : could be a table if that is preferable.
-timer = function(idx, count)
-   print("timer " .. idx .. " : " .. count)
+timer = function(idx, stage)
+   print("timer " .. idx .. " stage " .. stage)
 end
 
 versions = function()

--- a/lua/stickcut.lua
+++ b/lua/stickcut.lua
@@ -36,7 +36,7 @@ report.commands = function(commands, count)
 
    joystick.axis = function(stick, ax, val)
 	  if(ax == 1) then
-		 pos = ((val / 32767) + 1.0) * 16.0
+		 pos = ((val / 32767) + 1.0) * 160.
 		 print("pos: " .. pos)
 	  end
    end

--- a/lua/sticksine.lua
+++ b/lua/sticksine.lua
@@ -183,13 +183,13 @@ joystick.hat = function(stick, hat, val)
 	  if not hat_state then
 		 hat_state = true
 		 -- start timer 1 with a period of 1/8s, infinite repeats
-		 start_timer(1, 0.125, -1)
+		 timer_start(1, 0.125, -1)
 	  end
    else
 	  if hat_state then
 		 hat_state = false
 		 -- stop timer 1
-		 stop_timer(1)
+		 timer_stop(1)
 	  end
    end
 end

--- a/lua/test128.lua
+++ b/lua/test128.lua
@@ -1,0 +1,30 @@
+
+version.test128 = "0.0.1"
+
+local displaystage = 1;
+
+grid.press = function(x, y)
+   local seconds = y / 16;
+   local stage = x;
+   print("\n----\n start timer, period " .. seconds .. " stage " .. stage)
+   timer_start(1, seconds, -1, stage) 
+end
+
+
+grid.lift = function(x, y)
+   -- noop
+end
+
+timer = function(idx, stage)
+   if(idx ==1) then
+	  -- turn off the old stage
+	  grid_set_led(displaystage, 1, 0)
+	  -- turn on the new stage
+	  displaystage = stage
+	  while displaystage > 16 do
+		 displaystage = displaystage - 16
+	  end
+	  grid_set_led(displaystage, 1, 1)
+	  print("timer callback, stage " .. stage .. ", display stage " .. displaystage)
+   end
+end

--- a/matron/src/events.c
+++ b/matron/src/events.c
@@ -11,7 +11,7 @@
 //--- types, variables
 
 typedef struct {
-  // nb: we have to do some evil casts from SDL_UserEvent.
+  // NB: we have to do some evil casts from SDL_UserEvent.
   // we are basically making our own event struct.
   // these first 4 fields must match UserEvent
   Uint32 type;     
@@ -124,14 +124,14 @@ void events_handle_error(const char* msg) {
 static inline void
 handle_grid_press(SDL_Event* ev) {
   SDL_MonomeGridEvent* mev = (SDL_MonomeGridEvent*)ev;
-  printf("handling grid lift event: (%d, %d)\n", mev->x, mev->y);
+  //  printf("handling grid press event: (%d, %d)\n", mev->x, mev->y);
   w_handle_grid_press(mev->x, mev->y);
 }
 
 static inline void
 handle_grid_lift(SDL_Event* ev) {
   SDL_MonomeGridEvent* mev = (SDL_MonomeGridEvent*)ev;
-  printf("handling grid lift event: (%d, %d)\n", mev->x, mev->y);
+  //  printf("handling grid lift event: (%d, %d)\n", mev->x, mev->y);
   w_handle_grid_lift(mev->x, mev->y);
 }
 
@@ -172,7 +172,11 @@ void handle_command_report(void) {
 }
 
 void handle_timer(SDL_UserEvent* uev) {
-  w_handle_timer(*((int*)uev->data1), *((int*)uev->data2));
+  int idx = *((int*)uev->data1);
+  int stage = *((int*)uev->data2);
+  free(uev->data1);
+  free(uev->data2);
+  w_handle_timer(idx, stage);
 }
 
 //---- raw SDL
@@ -190,11 +194,9 @@ void handle_user_event(SDL_Event* ev) {
 	handle_command_report();
 	break;
   case EVENT_GRID_PRESS:
-	printf("handle_user_event(): got EVENT_GRID_PRESS \n");
 	handle_grid_press(ev);
 	break;
   case EVENT_GRID_LIFT:
-	printf("handle_user_event(): got EVENT_GRID_PRESS \n");
 	handle_grid_lift(ev);
 	break;
   case EVENT_TIMER:

--- a/matron/src/lua_eval.c
+++ b/matron/src/lua_eval.c
@@ -261,7 +261,6 @@ static int try_statement(lua_State *L) {
   if(continuing) {
 	buf = malloc(saveBufLen + 1 + strlen(line) + 1); /* add to saved */
 	sprintf(buf, "%s\n%s", saveBuf, line);
-	//	printf("-- new chunk: --- \n %s \n ------", buf); 
 	len += saveBufLen + 1;
   } else {
 	buf = line;
@@ -269,7 +268,6 @@ static int try_statement(lua_State *L) {
   status = luaL_loadbuffer(L, buf,  len, "=stdin");  /* try it */
 
   if(incomplete(L, status)) {
-	//	printf("incomplete chunk; saving line\n");
 	status = STATUS_INCOMPLETE;
 	save_statement_buffer(buf);
   } else {
@@ -277,7 +275,6 @@ static int try_statement(lua_State *L) {
 	// remove line from stack, leaving compiled chunk
 	lua_remove(L, -2);
   }
-  //  printf("try_statement() : return %d\n", status);
   return status;
 }
 

--- a/matron/src/m.c
+++ b/matron/src/m.c
@@ -15,24 +15,24 @@ unsigned int m_leds[16][16] = { [0 ... 15][0 ... 15] = 0 };
 pthread_t tid;
 
 static void* m_run(void* p) {
-  printf("running the monome event loop \n"); fflush(stdout);
+  //  printf("running the monome event loop \n"); fflush(stdout);
   monome_event_loop(m);
 }
 
 // grid event handlers
 void m_handle_press(const monome_event_t *e, void* p) {
-  printf("m_handle_press(): posting event\n"); fflush(stdout);
+  //  printf("m_handle_press(): posting event\n"); fflush(stdout);
   event_post_monome_grid(EVENT_GRID_PRESS, e->grid.x, e->grid.y);
 }
 
 void m_handle_lift(const monome_event_t *e, void* p) {
-  printf("m_handle_lift(): posting event\n"); fflush(stdout);
+  //  printf("m_handle_lift(): posting event\n"); fflush(stdout);
   event_post_monome_grid(EVENT_GRID_LIFT, e->grid.x, e->grid.y);
 }
 
 void m_init() {
   const char* dev = args_monome_path();
-  printf("starting libmonome\n"); fflush(stdout);
+  //  printf("starting libmonome\n"); fflush(stdout);
   m = monome_open(dev);
   if( m == NULL) { 
 	printf("m_init(): couldn't open monome device (%s)\n", dev); fflush(stdout);
@@ -62,16 +62,15 @@ void m_init() {
 
 }
 
-// FIXME: hey, call this sometime huh?
 void m_deinit() {
    if (m != NULL) {
-	 printf("cancelling monome thread() \n"); fflush(stdout);
+	 // printf("cancelling monome thread \n"); fflush(stdout);
 	 pthread_cancel(tid);
    }
 }
 
 // set hardware
-void m_grid_set_led(int x, int y,  int val) {
+void m_grid_set_led(int x, int y, int val) {
   m_leds[x][y] = val;
   if(m != NULL) { 
 	monome_led_set(m, x, y, m_leds[x][y]);

--- a/matron/src/timers.c
+++ b/matron/src/timers.c
@@ -9,6 +9,7 @@
 #include <pthread.h>
 #include <stdio.h>
 #include <stdint.h>
+#include <stdlib.h>
 #include <time.h>
 
 #include "events.h"
@@ -17,19 +18,22 @@
 #define MAX_NUM_TIMERS_OK 32
 
 enum {
-  RUNNING,
-  STOPPED
+  TIMER_STATUS_RUNNING,
+  TIMER_STATUS_STOPPED
 };
 
 const int MAX_NUM_TIMERS = MAX_NUM_TIMERS_OK;
 struct timer {
   int idx;         // timer index
-  int state;       // running/stoppeb*d status
+  int status;       // running/stopped status
+  double seconds;  // period in seconds
   uint64_t count;  // total iterations ( <0 -> infinite )
-  uint64_t cur;    // current count of iterations
+  uint64_t stage;    // current count of iterations
   uint64_t time;   // current time (in nsec)
   uint64_t delta;  // current delta (in nsec)
   pthread_t tid;   // thread id
+  pthread_mutex_t stage_lock; // mutex protecting stage number
+  pthread_mutex_t status_lock; // mutex protecting status
 };
 
 struct timer timers[MAX_NUM_TIMERS_OK];
@@ -42,33 +46,44 @@ static void timer_handle_error(int code, const char* msg) {
 
 static void timer_init(struct timer *t, uint64_t nsec, int count);
 static void timer_set_current_time(struct timer *t);
-static void* timer_thread_start(void* timer);
+static void* timer_thread_loop(void* timer);
 static void timer_bang(struct timer *t);
-static void timer_reset(struct timer* t) { t->cur = 0; }
+static void timer_sleep(struct timer *t);
+static void timer_reset(struct timer* t, int stage);
+static void timer_cancel(struct timer *t);
 
 //------------------------
 //---- extern definitions
-
- void timers_init(void) {
-   for(int i=0; i<MAX_NUM_TIMERS_OK; i++) {
-	 timers[i].state = STOPPED;
-   }
+void timers_init(void) {
+  for(int i=0; i<MAX_NUM_TIMERS_OK; i++) {
+	timers[i].status = TIMER_STATUS_STOPPED;
+	timers[i].seconds = 1.0;
+  }
 }
 
-void timer_start(int idx, double seconds, int count) {
-  uint64_t nsec = (uint64_t) (seconds * 1000000000.0);
+void timer_start(int idx, double seconds, int count, int stage) {
+  //  int status;
+  uint64_t nsec;
+  struct timer* t = &timers[idx];
   
   if(idx >= 0 && idx < MAX_NUM_TIMERS_OK) {
-	if(timers[idx].state == STOPPED) {
-	  //	  printf("timer_add(): OK: index %d, period %d nsec, count %d \r\n",
-	  //			 idx, nsec, count);  fflush(stdout);
-	  timers[idx].idx = idx;
-	  timer_init(&timers[idx], nsec, count);
-	  timer_reset(&timers[idx]);
-	} else {
-	  // printf("timer_add(): aborting; timer is already running \n");
-	  // fflush(stdout);
+
+	pthread_mutex_lock(&t->status_lock);
+	if(t->status == TIMER_STATUS_RUNNING) {
+	  timer_cancel(t);
+	}	
+	pthread_mutex_unlock(&t->status_lock);
+	
+	if(seconds > 0.0) { 
+	  timers[idx].seconds = seconds;
 	}
+	nsec = (uint64_t)(timers[idx].seconds * 1000000000.0);
+	timers[idx].idx = idx;
+	
+	timer_reset(&timers[idx], stage);
+	timer_init(&timers[idx], nsec, count);
+
+	
   } else {
 	printf("invalid timer index, not added. max count of timers is %d\n",
 		   MAX_NUM_TIMERS_OK);  fflush(stdout);
@@ -77,6 +92,12 @@ void timer_start(int idx, double seconds, int count) {
 			   
 //------------------------
 //---- static definitions
+static void timer_reset(struct timer* t, int stage) {
+  pthread_mutex_lock(&(t->stage_lock));
+  if(stage > 0) { t->stage = stage; }
+  else { t->stage = 0; }
+  pthread_mutex_unlock(&(t->stage_lock));
+}
 
 void timer_init(struct timer *t, uint64_t nsec, int count) {
   int res;
@@ -92,7 +113,7 @@ void timer_init(struct timer *t, uint64_t nsec, int count) {
   t->delta = nsec;
   t->count = count;
   
-  res = pthread_create(&(t->tid), &attr, &timer_thread_start, (void*)t);
+  res = pthread_create(&(t->tid), &attr, &timer_thread_loop, (void*)t);
   if(res !=0) {
 	timer_handle_error(res, "pthread_create");
 	return;
@@ -106,24 +127,30 @@ void timer_init(struct timer *t, uint64_t nsec, int count) {
 	  timer_handle_error(res, "pthread_setschedparam");
 	  return;
 	}
-	t->state = RUNNING;
+	t->status = TIMER_STATUS_RUNNING;
   }
   
 }
 
-void* timer_thread_start(void* timer) {
+void* timer_thread_loop(void* timer) {
   struct timer *t = (struct timer*) timer;
+  int stop = 0;
 
   timer_set_current_time(t);
-  
-  if(t->count < 0) {
-	while(1) {
-	  timer_bang(t);
-	}
-  } else {
-	while(t->cur < (t->count)) {
-	  timer_bang(t);
-	}
+
+  while(!stop) {
+	pthread_mutex_lock(&(t->stage_lock));
+	if(t->stage >= t->count && t->count > 0) {
+	  stop = 1;
+	} 
+	pthread_mutex_unlock(&(t->stage_lock));
+	if(stop) { break; }
+	pthread_testcancel(); // important!
+	pthread_mutex_lock(&(t->stage_lock));
+	timer_bang(t);
+	t->stage += 1;
+	pthread_mutex_unlock(&(t->stage_lock));
+	timer_sleep(t);
   }
 }
 
@@ -134,11 +161,15 @@ void timer_set_current_time(struct timer *t) {
 }
 
 void timer_bang(struct timer *t) {
-  t->cur += 1;
-  event_post(EVENT_TIMER, &(t->idx), &(t->cur));
+  int* pidx = (int*)malloc(sizeof(void*));
+  int* pstage = (int*)malloc(sizeof(void*));
+  *pidx = t->idx;
+  *pstage = t->stage;
+  event_post(EVENT_TIMER, pidx, pstage);
+  // event handler should free the data
+}
 
-  // with nanosleep(), thread can be preempted while sleeping.
-  // so for accuracy, tell system clock to wake us at absolute time:
+void timer_sleep(struct timer* t) {
   struct timespec ts;
   t->time += t->delta;
   ts.tv_sec = (time_t) t->time / 1000000000;
@@ -151,24 +182,55 @@ void timer_wait(int idx) {
 }
 
 void timer_stop(int idx) {
-  if( timers[idx].state == STOPPED) {
-	//	printf("timer_stop(): nothing to do (timer is stopped)\n");
-	fflush(stdout);
-	return;
+  if(idx >=0 && idx < MAX_NUM_TIMERS_OK) {
+	
+	pthread_mutex_lock(&(timers[idx].status_lock));
+	if( timers[idx].status == TIMER_STATUS_STOPPED) {
+	  ;; // nothing to do
+	} else {
+	  timer_cancel(&timers[idx]);
+	}
+	pthread_mutex_unlock(&(timers[idx].status_lock));
+	
+  } else {
+	printf("timer_stop(): invalid timer index, max count of timers is %d\n",
+		   MAX_NUM_TIMERS_OK );  fflush(stdout);
   }
-  if(idx >=0 && idx < MAX_NUM_TIMERS_OK) { 
-	int ret = pthread_cancel(timers[idx].tid);
+}
+
+void timer_cancel(struct timer *t) {
+  int ret = pthread_cancel(t->tid);
 	if(ret) { 
 	  printf("timer_stop(): pthread_cancel() failed; error: 0x%08x\r\n", ret);
 	  fflush(stdout);
 	} else {
-	  timers[idx].state = STOPPED;
+	  t->status = TIMER_STATUS_STOPPED;
 	  //	  printf("timer_stop(): OK (timer %d)\n", idx); fflush(stdout);
 	}
-  } else {
-	printf("invalid timer index, not stopped. max count of timers is %d\n",
-		   MAX_NUM_TIMERS_OK );  fflush(stdout);
+}
+
+/*
+void timer_restart(int idx, double seconds, int count, int stage) {
+  int status;
+  printf("timer_restart(%d, %f, %d, %d)\n", idx, seconds, count, stage);
+  fflush(stdout);
+  if(idx >= 0 && idx < MAX_NUM_TIMERS_OK) {
+	
+	pthread_mutex_lock(&(timers[idx].status_lock));
+	status = timers[idx].status;
+	pthread_mutex_unlock(&(timers[idx].status_lock));
+	
+	if(status == TIMER_STATUS_RUNNING) {
+	  printf("timer_restart(): stopping\n"); fflush(stdout);
+	  timer_stop(idx);
+	}
+	
+	if(seconds > 0.0) { timers[idx].seconds = seconds; }
+	timers[idx].count = count;
+	timer_start(idx, timers[idx].seconds, timers[idx].count, stage);
   }
 }
+*/
+
 
 #undef MAX_NUM_TIMERS_OK

--- a/matron/src/timers.h
+++ b/matron/src/timers.h
@@ -10,14 +10,15 @@ extern const int MAX_NUM_TIMERS;
 extern void timers_init(void);
 
 // create a timer at the specified index
-extern void timer_start(int idx, double seconds, int count);
+// seconds < 0 == use previous period
+extern void timer_start(int idx, double seconds, int count, int stage);
+
 // wait for a timer to finish
-extern void timer_wait(int idx);
+// extern void timer_wait(int idx);
+
 // cancel all scheduled iterations
 extern void timer_stop(int idx);
 
-// TODO
-// restart counter immediately (at an arbitrary position?)
-// extern void timer_reset(int idx, int count);
-// extern void timer_set_period(int idx, double seconds);
-// extern void timer_set_callback(int idx, timer_cb cb);
+// restart timer immediately
+
+// extern void timer_restart(int idx, double seconds, int count, int stage);

--- a/matron/src/weaver.h
+++ b/matron/src/weaver.h
@@ -36,4 +36,4 @@ extern void w_handle_command_report(const struct engine_command* arr,
 									const int num);
 
 //--- timer bang handler
-extern void w_handle_timer(const int idx, const int count);
+extern void w_handle_timer(const int idx, const int stage);


### PR DESCRIPTION
timer_start() now restarts instead of bailing if the timer isn't stopped so it's easier to use for sequencing (see `lua/test128.lua` for grid+timer sequencing test)

this meant adding some thread synchronization mechanics (maybe too much.) which means it's easier to add dynamic stage numbers/loop points if desired.

also fixed inconsistencies with 0-base/1-base indexing