### PR TITLE
rewrite event queue

### DIFF
--- a/lua/monome.lua
+++ b/lua/monome.lua
@@ -54,7 +54,7 @@ monome.add = function(id, serial, name, dev)
 end
 
 monome.remove = function(id)
-   print('>> removing device')
+   print('>> removing device ' .. id)
    monome.grids[id]:print()
    monome.grids[id] = nil
 end
@@ -74,6 +74,8 @@ monome.key = function(id, x, y, val)
 		 m:led(x, y, 0x0)
 	  end
 	  m:refresh()
+   else
+	  print('>> error: no entry for grid ' .. id)
    end
 end
 

--- a/matron/Makefile
+++ b/matron/Makefile
@@ -9,7 +9,7 @@ CFLAGS = -g -std=gnu11
 # CFLAGS += -fstack-protector-all
 
 LDFLAGS = 
-LIB = -llo -llua -lpthread -lSDL2 -lmonome -ludev -levdev
+LIB = -llo -llua -lpthread -lmonome -ludev -levdev
 
 OBJ_DIR = obj
 SRC_DIR = src

--- a/matron/src/event_types.c
+++ b/matron/src/event_types.c
@@ -1,0 +1,1 @@
+#include "event_types.h"

--- a/matron/src/event_types.h
+++ b/matron/src/event_types.h
@@ -1,0 +1,67 @@
+#pragma once
+
+#include <stdint.h>
+
+typedef enum {
+  // unused (do not remove)
+  EVENT_FIRST_EVENT = 0,
+  // code to be executed by luavm
+  EVENT_EXEC_CODE_LINE = 0x100,
+    // timer has fired
+  EVENT_TIMER = 0x200,
+  // libmonome device added
+  EVENT_MONOME_ADD = 0x500,
+  // libmonome device removed
+  EVENT_MONOME_REMOVE = 0x600,
+  // monome grid press/lift
+  EVENT_GRID_KEY = 0x700,
+  // finished receiving audio engine list
+  EVENT_ENGINE_REPORT = 0x300,
+  // finished receiving command list
+  EVENT_COMMAND_REPORT = 0x400,
+  // quit the event loop
+  EVENT_QUIT = 0x800
+} event_t;
+
+struct event_common {
+  uint32_t type;
+  // could put timestamp here if we want
+}; // +4
+
+struct event_exec_code_line {
+  struct event_common common;
+  char* line;
+}; // +4
+
+struct event_monome_add {
+  struct event_common common;
+  void* dev;
+}; // +4
+
+struct event_monome_remove {
+  struct event_common common;
+  uint32_t id;
+}; // +4
+
+struct event_grid_key {
+  struct event_common common;
+  uint8_t id;
+  uint8_t x;
+  uint8_t y;
+  uint8_t state;
+}; // +4
+
+struct event_timer {
+  struct event_common common;
+  uint32_t id;
+  uint32_t stage;
+}; // +4
+
+union event_data {
+  uint32_t type;
+  struct event_exec_code_line exec_code_line ;
+  struct event_monome_add monome_add ;
+  struct event_monome_remove monome_remove ;
+  struct event_grid_key grid_key ;
+  struct event_timer timer ;
+};

--- a/matron/src/events.h
+++ b/matron/src/events.h
@@ -1,28 +1,8 @@
 #pragma once
 
-typedef enum {
-  // code to be executed by luavm
-  EVENT_EXEC_CODE_LINE,
-  // monome grid press
-  EVENT_GRID_PRESS,
-  // monome grid lift
-  EVENT_GRID_LIFT,
-  // timer has fired
-  EVENT_TIMER,
-  // finished receiving audio engine list
-  EVENT_ENGINE_REPORT,
-  // finished receiving command list
-  EVENT_COMMAND_REPORT,
-  // libmonome device added
-  EVENT_MONOME_ADD,
-  // libmonome device removed
-  EVENT_MONOME_REMOVE,
-  // quit the event loop
-  EVENT_QUIT
-} event_t;
+#include "event_types.h"
 
 extern void events_init(void);
 extern void event_loop(void);
-extern void event_post(event_t evcode, void* data1, void* data2);
-// FIXME: this shouldn't really have to be a separate thing
-extern void event_post_grid_event(event_t evcode, void* md, int x, int y);
+extern union event_data* event_data_new(event_t evcode);
+extern void event_post(union event_data* ev);

--- a/matron/src/input.c
+++ b/matron/src/input.c
@@ -20,9 +20,7 @@ static void* input_run(void* p) {
   	len = strlen(rxbuf);
   	if(len == 2) {
   	  if(rxbuf[0] == 'q') {
-  		// tell main event loop to quit
-  		event_t ev = EVENT_QUIT;
-  		event_post(ev, NULL, NULL);
+		event_post(event_data_new(EVENT_QUIT));
   		fflush(stdout);
   		quit = 1;
   		continue;
@@ -33,7 +31,9 @@ static void* input_run(void* p) {
   	  line = malloc((len+1) * sizeof(char));
   	  strncpy(line, rxbuf, len);
   	  line[len] = '\0';
-  	  event_post(EVENT_EXEC_CODE_LINE, line, NULL);
+	  union event_data *ev = event_data_new(EVENT_EXEC_CODE_LINE);
+	  ev->exec_code_line.line = line;
+	  event_post(ev);
   	}
   }
   free(rxbuf);

--- a/matron/src/oracle.c
+++ b/matron/src/oracle.c
@@ -141,7 +141,6 @@ const struct engine_command* o_get_commands(void) {
 
 //-- mutex access
 void o_lock_descriptors() {
-  //  printf("o_lock_descriptors() \n");
   int res = pthread_mutex_lock(&desc_lock);
   if(res) {
 	printf("o_lock_descriptors failed with code %d \b", res); fflush(stdout);
@@ -149,7 +148,6 @@ void o_lock_descriptors() {
 }
 
 void o_unlock_descriptors() {
-  //  printf("o_unlock_descriptors() \n");
   int res = pthread_mutex_unlock(&desc_lock);
   if(res)  {
 	printf("o_unlock_descriptors failed with code %d \b", res); fflush(stdout);
@@ -295,7 +293,7 @@ int engine_report_end(const char *path, const char *types, lo_arg ** argv,
   // or (better?) we could simply use binary blobs from Crone,
   // replacing the whole response sequence with a single message
   // (downside: nasty blob-construction code in supercollider)
-  event_post(EVENT_ENGINE_REPORT, NULL, NULL);
+  event_post(event_data_new(EVENT_ENGINE_REPORT));
 }
 
 //---------------------
@@ -303,7 +301,6 @@ int engine_report_end(const char *path, const char *types, lo_arg ** argv,
 
 int command_report_start(const char *path, const char *types, lo_arg ** argv,
 						 int argc, void *data, void *user_data) {
-  //  printf("command_report_start(): %d\n", argv[0]->i);
   o_clear_commands();
   o_set_num_desc(&num_commands, argv[0]->i);
 }
@@ -315,7 +312,7 @@ int command_report_entry(const char *path, const char *types, lo_arg ** argv,
 
 int command_report_end(const char *path, const char *types, lo_arg ** argv,
 					   int argc, void *data, void *user_data) {
-   event_post(EVENT_COMMAND_REPORT, NULL, NULL);
+  event_post(event_data_new(EVENT_COMMAND_REPORT));
 }
 
 void lo_error_handler(int num, const char *m, const char *path) {

--- a/matron/src/weaver.h
+++ b/matron/src/weaver.h
@@ -22,8 +22,7 @@ extern void w_handle_line(char* line);
 //---- c -> lua glue
 
 //--- hardware input
-extern void w_handle_grid_press(int id, int x, int y);
-extern void w_handle_grid_lift(int id, int x, int y);
+extern void w_handle_grid_key(int id, int x, int y, int state);
 extern void w_handle_monome_add(void* mdev);
 extern void w_handle_monome_remove(int id);
 


### PR DESCRIPTION
this commit adds our own event queue implementation, removing the dependency on SDL and making event data structures more tidy / suitable.

one optimization in SDL is the use of object pools for event data. we are just allocating and freeing each event. in practice i don't think this is likely to behave differently - these are small allocations and malloc/calloc should be re-using memory already wired to our process - but i will run a cachegrind comparison to be sure.

also fixed a probable bug in monome device queue management.