### PR TITLE
allow matron to run without a screen

### DIFF
--- a/matron/Makefile
+++ b/matron/Makefile
@@ -46,6 +46,7 @@ OBJ = $(patsubst %,$(OBJ_DIR)/%,$(_OBJ))
 
 $(OBJ_DIR)/%.o : $(SRC_DIR)/%.c
 	@ mkdir -p $(OBJ_DIR)/device
+	@ mkdir -p $(OBJ_DIR)/hardware
 	$(CC) -c $(CFLAGS) $(INC) $< -o $@  
 
 $(TARGET): $(OBJ) $(STATIC)


### PR DESCRIPTION
changed how screen driver handles missing framebuffer, so that it doesn't exit matron immediately. needed continue to use and test norns away from the hardware.

this means pretty much every function in screen.c checks for null pointer to cairo instance. this is done in a macro so it can be easily removed

also fixes a warning/error in pointer/int comparison