### PR TITLE
add start.sh back in

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,3 @@
+./crone.sh > /dev/null &
+sleep 6
+./matron.sh > /dev/null &


### PR DESCRIPTION
I was using this to boot straight into the main norns app (see https://github.com/tehn/norns-image/pull/12)