### PR TITLE
carriage return terminates line

### DIFF
--- a/matron/src/hid.c
+++ b/matron/src/hid.c
@@ -28,7 +28,7 @@ static void *hid_run(void *p) {
             if(nb < RX_BUF_LEN) {
                 read(STDIN_FILENO, &b, 1);
                 if(b == '\0') { continue; }
-                if(b == '\n') { newline = true; }
+                if(b == '\n' || b == '\r') { newline = true; }
                 rxbuf[nb++] = b;
             }
         }


### PR DESCRIPTION
this patch changes `hid_run()` to treat carriage return the same as line feed - terminating the line and denoting a command.