### PR TITLE
band-aid for reverse audio taper bounds

### DIFF
--- a/sc/abstractions/AudioTaper.sc
+++ b/sc/abstractions/AudioTaper.sc
@@ -52,7 +52,7 @@ ReverseAudioTaper {
 		if(amp < breaklin, {
 			^(amp / breaklin * (breakn-1)).floor.asInteger;
 		}, {
-			^linlogarr[((amp - breaklin) / lininc).floor].asInteger;
+			^linlogarr[((amp - breaklin) / lininc).floor.min(nlininc-1)].asInteger;
 		})
 	}
 }


### PR DESCRIPTION
something is a little off with the lin-log reverse lookup range... just clamping right now so it doesn't crash the VU thread