### PR TITLE
Polysub

### DIFF
--- a/sc/Engine_PolySub.sc
+++ b/sc/Engine_PolySub.sc
@@ -62,7 +62,7 @@ Engine_PolySub : CroneEngine {
 				fenv = EnvGen.ar(Env.adsr(cutAtk, cutDec, cutSus, cutRel), gate);
 
 				cut = SelectX.kr(cutEnvAmt, [cut, cut * fenv]);
-				cut = cut * hz;
+				cut = cut * hz.min(SampleRate.ir * 0.5);
 
 				snd = SelectX.ar(noise, [snd, [PinkNoise.ar, PinkNoise.ar]]);
 				snd = MoogFF.ar(snd, cut, fgain) * aenv;


### PR DESCRIPTION
some incremental fixes to polysub:

- note creation logic is fixed, so envelope parameters are read correctly
- there is a "solo" command in addition to "start" command. "solo" doesn't map the control busses, just reads their current values on note creation. so you can have different voices with different parameter settings.
- delay feedback works now
- delay uses linear interp, so it's not quite so totally insane on the cpu
- cutoff is limited to nyquist, so it doesn't explode the filter

still needs work:
- the "sub" parameter is missing command glue, or just missing in the script, or something
- sadly, delay per voice is just too ridiculous i think. too easy to have voices that take forever to free with delay feedback. even if this is a good idea, it should use `BufDelay` and a pool of buffers (but clean buffer allocation kinda requires issue #106)
- on the other hand, a very tiny delay (<1 period) or phase offset argument for each of the oscillators would open up some more timbral space pretty easily
- dunno if i like the way filter envelope works

(general)
- need to fix ServerOptions to allocate more memory
- really need issue #111 so that we can use a NodeWatcher to send messages back to matron when nodes self-free,  allowing a proper voice allocator to be built in lua