### PR TITLE
first shot at parameters

### DIFF
--- a/sc/Engine_Knaster.sc
+++ b/sc/Engine_Knaster.sc
@@ -1,0 +1,75 @@
+Engine_Knaster : CroneEngine {
+	classvar defName = \knaster;
+	classvar <specs;
+	var <group;
+	var synth;
+
+	*initClass {
+		Class.initClassTree(ControlSpec);
+		specs = IdentityDictionary[
+			\db -> \db.asSpec
+		];
+		StartUp.add {
+			var synthDef = SynthDef.new(defName, {
+				arg out, gate=1, meh, db;
+				var sig;
+				var panmod, delaymod, delaytime;
+				var hpfCutoff = meh;
+				var freq = meh;
+				var delaySpec = \delay.asSpec.copy.maxval_(4);
+				var rhpfFreqSpec = ControlSpec(1, 6000, 'exp', 0, 440, " Hz");
+				var dustFreqSpec = ControlSpec(1.5, 100, 'exp', 0, 6, " Hz");
+
+				panmod = LFNoise1.ar(1.8);
+				delaymod = LFNoise1.ar(2.2).range(0.01, 1);
+				sig = Dust2.ar(dustFreqSpec.map(freq));
+				sig = HPF.ar(sig, rhpfFreqSpec.map(hpfCutoff));
+				sig = Pan2.ar(sig, panmod);
+				sig = FreeVerb2.ar(sig[0], sig[1], room:1, damp: 0.3);
+
+				delaytime = delaySpec.map(delaymod);
+				sig = sig + CombC.ar(sig, maxdelaytime: delaySpec.maxval, delaytime: delaytime, decaytime: 1);
+				sig = sig * \db.asSpec.unmap(In.kr(db));
+				sig = sig * Env.cutoff(0.01).ar(2, gate);
+				Out.ar(out, sig);
+			});
+
+			CroneDefs.add(synthDef);
+		}
+	}
+
+	*new { arg context; ^super.new.init(context).initEngine_Knaster; }
+
+	initEngine_Knaster {
+		context.postln;
+		group = Group.new(context.xg);
+
+		this.addCommand(\start, "", { arg msg;
+			if (synth == nil) {
+				synth = Synth.new(
+					defName,
+					[
+						\out, context.out_b.index,
+						\db, parameterControlBusses[\db],
+						\meh, 0.333
+					],
+					group
+				);
+			};
+		});
+
+		this.addCommand(\stop, "", { arg msg;
+			if (synth.notNil) {
+				synth.release;
+				synth = nil;
+			}
+		});
+
+		this.addParameter(\db, specs[\db]);
+	}
+
+	free {
+		group.free;
+		super.free;
+	}
+}

--- a/sc/core/Crone.sc
+++ b/sc/core/Crone.sc
@@ -126,6 +126,18 @@ Crone {
 		remoteAddr.sendMsg('/report/commands/end');
 	}
 
+	*reportParameters {
+		var parameters = engine !? _.parameters;
+		postln("parameters: " ++ parameters);
+		remoteAddr.sendMsg('/report/parameters/start', parameters.size);
+		parameters.do({ arg parameter, i;
+			var spec = parameter.spec;
+			postln('command entry: ' ++ [i, parameter.name, spec.minval, spec.maxval, spec.warp, spec.step, spec.default, spec.units]);
+			remoteAddr.sendMsg('/report/parameters/entry', i, parameter.name, spec.minval, spec.maxval, spec.warp, spec.step, spec.default, spec.units);
+		});
+		remoteAddr.sendMsg('/report/parameters/end');
+	}
+
 	*reportPolls {
 		var num = CronePollRegistry.getNumPolls;
 		remoteAddr.sendMsg('/report/polls/start', num);
@@ -181,6 +193,13 @@ Crone {
 				arg msg, time, addr, recvPort;
 				this.reportCommands;
 			}, '/report/commands'),
+
+			/// begin OSC command report sequence
+			// @function /report/parameters
+			'/report/parameters':OSCFunc.new({
+				arg msg, time, addr, recvPort;
+				this.reportParameters;
+			}, '/report/parameters'),
 
 			/// begin OSC poll report sequence
 			// @function /report/polls

--- a/sc/tests/Knaster-test.scd
+++ b/sc/tests/Knaster-test.scd
@@ -1,0 +1,22 @@
+Mamock.croneReportEngines;
+Mamock.croneLoadEngine("Knaster").
+Mamock.croneReportParameters.
+Mamock.croneReportCommands.
+Mamock.croneCommand("start");
+
+(
+// UI
+var dbspec = \db.asSpec;
+
+a=Window.new;
+c=Slider.new(a, Rect(0, 0, 40, 200));
+c.value = dbspec.unmap(dbspec.default).debug;
+c.action = { |slider|
+	Mamock.croneParameter("db", \db.asSpec.map(slider.value));
+};
+a.front;
+)
+
+Mamock.croneParameter("db", -20);
+Mamock.croneParameter("db", -10);
+Mamock.croneCommand("stop");

--- a/sc/tests/Mamock.sc
+++ b/sc/tests/Mamock.sc
@@ -1,0 +1,120 @@
+Mamock {
+	classvar
+		<>trace = true,
+		matronRecvPort = 8888,
+		<croneAddr,
+		default
+	;
+
+	var <oscFuncs;
+
+	*initClass {
+	}
+
+	*default {
+		^if (default.notNil) {
+			default
+		} {
+			default = this.new
+		}
+	}
+
+	*croneLoadEngine { |name|
+		this.default.croneLoadEngine(name);
+	}
+
+	*croneReportEngines {
+		this.default.croneReportEngines;
+	}
+
+	*croneReportCommands {
+		this.default.croneReportCommands;
+	}
+
+	*croneReportParameters {
+		this.default.croneReportParameters;
+	}
+
+	*croneReportPolls {
+		this.default.croneReportPolls;
+	}
+
+	*croneCommand { |cmd ... args|
+		this.default.croneCommand(cmd, *args);
+	}
+
+	*croneParameter { |parameter ... args|
+		this.default.croneParameter(parameter, *args);
+	}
+
+	*croneMsg { |...args|
+		this.default.croneMsg(*args);
+	}
+
+	*new { ^super.new.initmmmmmmm }
+
+	initmmmmmmm {
+		croneAddr = NetAddr.localAddr;
+
+		thisProcess.openUDPPort(matronRecvPort); // enable matron sc port
+
+		["engines", "commands", "parameters", "polls"].do { |type|
+			["start", "entry", "end"].do { |suffix|
+				var path = "/report/" ++ type ++ "/" ++ suffix;
+				oscFuncs = oscFuncs.add(
+					OSCFunc(
+						{
+							|msg, time, addr, recvPort|
+							this.traceComm(\mmock_received, [msg, time, addr, recvPort]);
+						},
+						path,
+						recvPort: matronRecvPort
+					)
+				);
+			};
+		}
+
+	}
+
+	croneLoadEngine { |name|
+		this.croneMsg("/engine/load/name", name);
+	}
+
+	croneReportEngines {
+		this.croneMsg("/report/engines");
+	}
+
+	croneReportCommands {
+		this.croneMsg("/report/commands");
+	}
+
+	croneReportPolls {
+		this.croneMsg("/report/polls");
+	}
+
+	croneReportParameters {
+		this.croneMsg("/report/parameters");
+	}
+
+	croneCommand { |cmd ... args|
+		var msg = ["/command/" ++ cmd.asString].addAll(args);
+		this.traceComm(\mmock_sent, msg);
+		this.croneMsg(*msg);
+	}
+
+	croneParameter { |cmd ... args|
+		var msg = ["/parameter/" ++ cmd.asString].addAll(args);
+		this.traceComm(\mmock_sent, msg);
+		this.croneMsg(*msg);
+	}
+
+	croneMsg { |...args|
+		croneAddr.sendMsg(*args);
+	}
+
+	traceComm { |...msg|
+		if (trace) {
+			msg.debug(\mmock_sent);
+		}
+	}
+}


### PR DESCRIPTION
Something like this, perhaps.

Test engine Knaster included having db parameter mapped to standard \db spec. This hasn't been tested with anything other than my matron mock class (included, should not cause any trouble) on my laptop.

As you see in last addParameter argument I kinda like adding the spec itself, rather than its parts.