### PR TITLE
fix engine load: send reports even if engine didn't change

### DIFF
--- a/sc/core/Crone.sc
+++ b/sc/core/Crone.sc
@@ -78,6 +78,10 @@ Crone {
 					this.reportPolls;
 				});
 			});
+		}, {
+		    // if we didn't change engines, just resend the reports
+                        this.reportCommands;
+                        this.reportPolls;
 		});
 
 	}


### PR DESCRIPTION
simple hotfix

with new engine-load sequence, re-running a script didn't switch engines, didn't send command/report polls, and didn't run the init script. this fixes that.

it might be better to actually free and restart the engine, but that needs a little more thought - i tihink this is ok for now