### PR TITLE
quickest hack to allow norns compilation via buildroot

### DIFF
--- a/wifi.sh
+++ b/wifi.sh
@@ -4,11 +4,10 @@ WIFI_INTERFACE=$(ip addr|grep 2: | awk '{print $2}'|sed -e s/:$//)
 function wpa_boot {
     WPA_PS=$(ps aux | grep wpa_supplicant |grep -v grep | awk '{print $2}')
     if [ -z $WPA_PS ]; then
-	echo "starting wpa_supplicant..."
 	WPA_FILE=$HOME/wpa_supplicant.conf
 	echo ctrl_interface=/run/wpa_supplicant > $WPA_FILE
 	echo update_config=1 >> $WPA_FILE
-	sudo wpa_supplicant -B -i$WIFI_INTERFACE -c$WPA_FILE
+	sudo wpa_supplicant -B -i$WIFI_INTERFACE -c$WPA_FILE > /dev/null
     fi
 }
 


### PR DESCRIPTION
This jerry-rig should let me pass a different compiler than gcc via the CC environment variable.

This is desirable for cross-compiling with buildroot...