### PR TITLE
[WIP / don't merge] fix crone/matron start scripts to use ws-wrapper

### DIFF
--- a/crone.sh
+++ b/crone.sh
@@ -3,6 +3,7 @@
 # do not try reserving device (disable dbus)
 export JACK_NO_AUDIO_RESERVATION=1
 
-# ipc wrapper requires full path 
+# socket wrapper requires full path 
 SCLANG=$(which sclang)
-./ipc-wrapper/ipc-wrapper $SCLANG ipc:///tmp/crone_in.ipc ipc:///tmp/crone_out.ipc
+
+./ws-wrapper/ws-wrapper $SCLANG ws://*:5556

--- a/matron.sh
+++ b/matron.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-./ipc-wrapper/ipc-wrapper ./matron/matron ipc:///tmp/matron_in.ipc ipc:///tmp/matron_out.ipc
+./ws-wrapper/ws-wrapper ./matron/matron ws://*:5555

--- a/ws-matron.sh
+++ b/ws-matron.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-./ws-wrapper/ws-wrapper ./matron/matron ws://*:5555


### PR DESCRIPTION
ipc-wrapper has been nuked, ws-wrapper is the future

inferred sclang port from @ngwese  maiden project