### PR TITLE
Fix libevdev include

### DIFF
--- a/matron/Makefile
+++ b/matron/Makefile
@@ -12,7 +12,7 @@ CFLAGS += -Wall -Wextra -Werror
 CFLAGS += -g
 
 INC =  -Isrc -Isrc/device -Ilua -Isrc/hardware
-INC += -I/usr/include/libevdev-1.0/libevdev
+INC += -I/usr/include/libevdev-1.0
 INC += -I/usr/include/cairo -I/usr/include/freetype2
 
 LDFLAGS =
@@ -47,13 +47,13 @@ OBJ = $(patsubst %,$(OBJ_DIR)/%,$(_OBJ))
 $(OBJ_DIR)/%.o : $(SRC_DIR)/%.c
 	@ mkdir -p $(OBJ_DIR)/device
 	@ mkdir -p $(OBJ_DIR)/hardware
-	$(CC) -c $(CFLAGS) $(INC) $< -o $@  
+	$(CC) -c $(CFLAGS) $(INC) $< -o $@
 
 $(TARGET): $(OBJ) $(STATIC)
 	$(LD) $(LDFLAGS) $(OBJ) -o $@ $(STATIC) $(LIB)
 
 lua/liblua.a:
-	cd lua && make 
+	cd lua && make
 
 clean:
 	rm $(TARGET)

--- a/matron/src/device/device_hid.h
+++ b/matron/src/device/device_hid.h
@@ -3,7 +3,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 
-#include <libevdev.h>
+#include <libevdev/libevdev.h>
 #include "device_common.h"
 
 typedef uint8_t dev_vid_t;


### PR DESCRIPTION
Small change to fix the libevdev include, this changes it to the way most projects handle it (don't know if there's a default way to do so, but this seems to be it) that's also supported by all build tools :)

Also: Some free whitespace fixes! :tada: 