### PR TITLE
use context and doneCallback in CroneEngine

### DIFF
--- a/sc/Engine_PolyPerc.sc
+++ b/sc/Engine_PolyPerc.sc
@@ -8,12 +8,12 @@ Engine_PolyPerc : CroneEngine {
     var gain=2;
 
 	*new { arg context, doneCallback;
-		^super.new.init(context, doneCallback).init_PolyPerc(context, doneCallback);
+		^super.new(context, doneCallback).init_PolyPerc;
 	}
 
-	init_PolyPerc{ arg ctx, callback;
+	init_PolyPerc{
         SynthDef("PolyPerc", {
-			arg out = ctx.out_b, freq = 440, pw=pw, amp=amp, cutoff=cutoff, gain=gain, release=release;
+			arg out = context.out_b, freq = 440, pw=pw, amp=amp, cutoff=cutoff, gain=gain, release=release;
 			var snd = LFPulse.ar(freq, 0, pw);
 			var filt = MoogFF.ar(snd,cutoff,gain);
 			var env = Env.perc(level: amp, releaseTime: release).kr(2);
@@ -42,6 +42,6 @@ Engine_PolyPerc : CroneEngine {
 			gain = msg[1];
 		});
 
-		callback.value(this);
+		doneCallback.value(this);
 	}
 }

--- a/sc/Engine_PolySub.sc
+++ b/sc/Engine_PolySub.sc
@@ -5,7 +5,6 @@ Engine_PolySub : CroneEngine {
 	classvar polyDef, compVerbDef;
 	classvar paramDefaults;
 
-	var <ctx; // audio context
 	var <ctlBus; // collection of control busses
 	var <mixBus; // audio bus for mixing synth voices
 	var <gr; // parent group for voice nodes
@@ -123,13 +122,11 @@ Engine_PolySub : CroneEngine {
 	} // initClass
 
 	*new { arg context, callback;
-		^super.new.init(context, callback).init_PolySub(context, callback); }
+		^super.new(context, callback).init_PolySub;
+	}
 
 	init_PolySub {
-		arg context, callback;
-		context.postln;
-		ctx = context;
-		gr = Group.new(ctx.xg);
+		gr = Group.new(context.xg);
 
 		voices = Dictionary.new;
 		ctlBus = Dictionary.new;
@@ -137,7 +134,7 @@ Engine_PolySub : CroneEngine {
 			var name = ctl.name;
 			postln("control name: " ++ name);
 			if((name != \gate) && (name != \hz) && (name != \out), {
-				ctlBus.add(name -> Bus.control(ctx.server));
+				ctlBus.add(name -> Bus.control(context.server));
 				ctlBus[name].set(paramDefaults[name]);
 			});
 		});
@@ -147,10 +144,10 @@ Engine_PolySub : CroneEngine {
 		ctlBus[\level].setSynchronous( 0.2 );
 
 		// mix bus for all synth outputs
-		mixBus =  Bus.audio(ctx.server, 2);
+		mixBus =  Bus.audio(context.server, 2);
 
 		// throw a little crummy comp and reverb on there, send to the context output
-		compVerbSyn = Synth.new(\compVerb, [\in, mixBus.index, \out, ctx.out_b.index], gr, \addAfter);
+		compVerbSyn = Synth.new(\compVerb, [\in, mixBus.index, \out, context.out_b.index], gr, \addAfter);
 
 
 		//--------------
@@ -193,7 +190,7 @@ Engine_PolySub : CroneEngine {
 
 
 		postln("polysub: performing init callback");
-		callback.value(this);
+		doneCallback.value(this);
 
 	} // init
 

--- a/sc/Engine_SoftCut.sc
+++ b/sc/Engine_SoftCut.sc
@@ -5,7 +5,6 @@ Engine_SoftCut : CroneEngine {
 
 	classvar commands;
 
-	var <ctx; // audio context
 	var <bus; // busses
 	var <buf; // buffers
 	var <syn; // synths
@@ -17,7 +16,7 @@ Engine_SoftCut : CroneEngine {
 	// @param: audio context
 	// @param: callback when done initializing resourcess
 	*new { arg context, doneCallback;
-		^super.new.init(context, doneCallback).init_SoftCut(context, doneCallback);
+		^super.new(context, doneCallback).init_SoftCut;
 	}
 
 	free {
@@ -46,10 +45,10 @@ Engine_SoftCut : CroneEngine {
 	// destructive trim
 	trimBuf { arg i, start, end;
 		var startsamp, endsamp, samps, newbuf;
-		startsamp = start * ctx.server.sampleRate;
-		endsamp = end * ctx.server.sampleRate;
+		startsamp = start * context.server.sampleRate;
+		endsamp = end * context.server.sampleRate;
 		samps = endsamp - startsamp;
-		newbuf = Buffer.alloc(ctx.server, samps);
+		newbuf = Buffer.alloc(context.server, samps);
 		buf[i].copyData(newbuf, 0, startsamp, samps);
 		// any voices using this buffer need to be reassigned
 		voices.do({ arg v;
@@ -80,24 +79,20 @@ Engine_SoftCut : CroneEngine {
 	playDacLevel { |srcId, dstId, level| pm.pb_dac.level_(srcId, dstId, level); }
 
 	init_SoftCut {
-		arg context, callback;
-
 		var com;
 		var bus_pb_idx; // tmp collection of playback bus indices
 		var bus_rec_idx;
 		var bufcon;
 
-		ctx = context;
-
 		Routine {
-			var s = ctx.server;
+			var s = context.server;
 
 			postln("SoftCut: init routine");
 
 			//--- groups
 			gr = Event.new;
-			gr.pb = Group.new(ctx.xg);
-			gr.rec = Group.after(ctx.ig);
+			gr.pb = Group.new(context.xg);
+			gr.rec = Group.after(context.ig);
 			// phase bus per voice (output)
 			bus = Event.new;
 
@@ -114,18 +109,18 @@ Engine_SoftCut : CroneEngine {
 			s.sync;
 
 			//--- busses
-			bus.adc = ctx.in_b;
+			bus.adc = context.in_b;
 			// FIXME? not sure about the peculiar arrangement of dual mono in / stereo out.
 			// FIXME: oh! actually just use array of panners, instead of output patch matrix.
 			// here we convert  output bus to a mono array
-			bus.dac = Array.with( Bus.newFrom(ctx.out_b, 0), Bus.newFrom(ctx.out_b, 1));
+			bus.dac = Array.with( Bus.newFrom(context.out_b, 0), Bus.newFrom(context.out_b, 1));
 			bus.rec = Array.fill(nvoices, { Bus.audio(s, 1); });
 			bus.pb = Array.fill(nvoices, { Bus.audio(s, 1); });
 
 			//-- voices
 			voices = Array.fill(nvoices, { |i|
 				// 	arg server, target, buf, in, out;
-				SoftCutVoice.new(s, ctx.xg, buf[i], bus.rec[i].index, bus.pb[i].index);
+				SoftCutVoice.new(s, context.xg, buf[i], bus.rec[i].index, bus.pb[i].index);
 			});
 
 			//--- patch matrices
@@ -174,7 +169,7 @@ Engine_SoftCut : CroneEngine {
 
 
 			s.sync;
-			callback.value(this);
+			doneCallback.value(this);
 
 		}.play;
 

--- a/sc/Engine_TestSine.sc
+++ b/sc/Engine_TestSine.sc
@@ -4,17 +4,17 @@ Engine_TestSine : CroneEngine {
 	var <synth;
 
 	*new { arg context, doneCallback;
-		^super.new.init(context, doneCallback).init_TestSine(context, doneCallback);
+		^super.new(context, doneCallback).init_TestSine;
 	}
 
-	init_TestSine { arg ctx, callback;
+	init_TestSine {
 		synth = {
 			arg out=context.out_b, hz=220, amp=0.5, amplag=0.02, hzlag=0.01;
 			var amp_, hz_;
 			amp_ = Lag.ar(K2A.ar(amp), amplag);
 			hz_ = Lag.ar(K2A.ar(hz), hzlag);
 			Out.ar(out, (SinOsc.ar(hz_) * amp_).dup);
-		}.play(ctx.xg);
+		}.play(context.xg);
 
 		this.addCommand("hz", "f", { arg msg;
 			synth.set(\hz, msg[1]);
@@ -24,7 +24,7 @@ Engine_TestSine : CroneEngine {
 			synth.set(\amp, msg[1]);
 		});
 
-		callback.value(this);
+		doneCallback.value(this);
 	}
 
 	free {

--- a/sc/core/CroneEngine.sc
+++ b/sc/core/CroneEngine.sc
@@ -2,6 +2,8 @@
 // maintains some DSP processing and provides control over parameters and analysis results
 // new engines should inherit from this
 CroneEngine {
+	var <doneCallback;
+
 	// an AudioContext
 	var <context;
 
@@ -16,10 +18,13 @@ CroneEngine {
 		^super.new.init(context, doneCallback);
 	}
 
-	init { arg ctx, doneCallback;
+	init { arg argContext, argDoneCallback;
 		commands = List.new;
 		commandNames = Dictionary.new;
 		pollNames = Set.new;
+		context = argContext;
+		context.postln;
+		doneCallback = argDoneCallback;
 	}
 
 	addPoll { arg name, func;


### PR DESCRIPTION
Cleanup: no need to pass context and doneCallback twice