### PR TITLE
new method for allocating server resources

### DIFF
--- a/sc/Engine_PolyPerc.sc
+++ b/sc/Engine_PolyPerc.sc
@@ -8,10 +8,10 @@ Engine_PolyPerc : CroneEngine {
     var gain=2;
 
 	*new { arg context, doneCallback;
-		^super.new(context, doneCallback).init_PolyPerc;
+		^super.new(context, doneCallback);
 	}
 
-	init_PolyPerc{
+	alloc {
         SynthDef("PolyPerc", {
 			arg out = context.out_b, freq = 440, pw=pw, amp=amp, cutoff=cutoff, gain=gain, release=release;
 			var snd = LFPulse.ar(freq, 0, pw);
@@ -41,7 +41,5 @@ Engine_PolyPerc : CroneEngine {
 		this.addCommand("gain", "f", { arg msg;
 			gain = msg[1];
 		});
-
-		doneCallback.value(this);
 	}
 }

--- a/sc/Engine_PolySub.sc
+++ b/sc/Engine_PolySub.sc
@@ -122,10 +122,10 @@ Engine_PolySub : CroneEngine {
 	} // initClass
 
 	*new { arg context, callback;
-		^super.new(context, callback).init_PolySub;
+		^super.new(context, callback);
 	}
 
-	init_PolySub {
+	alloc {
 		gr = Group.new(context.xg);
 
 		voices = Dictionary.new;
@@ -188,12 +188,8 @@ Engine_PolySub : CroneEngine {
 			this.addCommand(name, "f", { arg msg; compVerbSyn.set(name, msg[1]); });
 		});
 
-
 		postln("polysub: performing init callback");
-		doneCallback.value(this);
-
-	} // init
-
+	}
 
 	addVoice { arg id, hz, map=true;
 		var params = List.with(\out, mixBus.index, \hz, hz);

--- a/sc/Engine_SoftCut.sc
+++ b/sc/Engine_SoftCut.sc
@@ -16,7 +16,7 @@ Engine_SoftCut : CroneEngine {
 	// @param: audio context
 	// @param: callback when done initializing resourcess
 	*new { arg context, doneCallback;
-		^super.new(context, doneCallback).init_SoftCut;
+		^super.new(context, doneCallback);
 	}
 
 	free {
@@ -78,103 +78,96 @@ Engine_SoftCut : CroneEngine {
 	adcRecLevel { |srcId, dstId, level| pm.adc_rec.level_(srcId, dstId, level); }
 	playDacLevel { |srcId, dstId, level| pm.pb_dac.level_(srcId, dstId, level); }
 
-	init_SoftCut {
+	alloc {
 		var com;
 		var bus_pb_idx; // tmp collection of playback bus indices
 		var bus_rec_idx;
 		var bufcon;
+		var s = context.server;
 
-		Routine {
-			var s = context.server;
+		postln("SoftCut: init routine");
 
-			postln("SoftCut: init routine");
+		//--- groups
+		gr = Event.new;
+		gr.pb = Group.new(context.xg);
+		gr.rec = Group.after(context.ig);
+		// phase bus per voice (output)
+		bus = Event.new;
 
-			//--- groups
-			gr = Event.new;
-			gr.pb = Group.new(context.xg);
-			gr.rec = Group.after(context.ig);
-			// phase bus per voice (output)
-			bus = Event.new;
+		s.sync;
 
-			s.sync;
+		//--- buffers
 
-			//--- buffers
+		postln("SoftCut: allocating buffers");
+		buf = Array.fill(nvoices, { arg i;
+			Buffer.alloc(s, s.sampleRate * bufdur, completionMessage: {
+			})
+		});
 
-			postln("SoftCut: allocating buffers");
-			buf = Array.fill(nvoices, { arg i;
-				Buffer.alloc(s, s.sampleRate * bufdur, completionMessage: {
-				})
+		s.sync;
+
+		//--- busses
+		bus.adc = context.in_b;
+		// FIXME? not sure about the peculiar arrangement of dual mono in / stereo out.
+		// FIXME: oh! actually just use array of panners, instead of output patch matrix.
+		// here we convert  output bus to a mono array
+		bus.dac = Array.with( Bus.newFrom(context.out_b, 0), Bus.newFrom(context.out_b, 1));
+		bus.rec = Array.fill(nvoices, { Bus.audio(s, 1); });
+		bus.pb = Array.fill(nvoices, { Bus.audio(s, 1); });
+
+		//-- voices
+		voices = Array.fill(nvoices, { |i|
+			// 	arg server, target, buf, in, out;
+			SoftCutVoice.new(s, context.xg, buf[i], bus.rec[i].index, bus.pb[i].index);
+		});
+
+		//--- patch matrices
+		bus_pb_idx = bus.pb.collect({ |b| b.index });
+		bus_rec_idx = bus.rec.collect({ |b| b.index });
+		pm = Event.new;
+
+		postln("softcut: in->rec patchmatrix");
+		// input -> record
+		pm.adc_rec = PatchMatrix.new(
+			server:s, target:gr.rec, action:\addToTail,
+			in: bus.adc.collect({ |b| b.index }),
+			out: bus_rec_idx,
+			feedback:true
+		);
+		postln("softcut: pb->out patchmatrix");
+		// playback -> output
+		pm.pb_dac = PatchMatrix.new(
+			server:s, target:gr.pb, action:\addAfter,
+			in: bus_pb_idx,
+			out: bus.dac.collect({ |b| b.index }),
+			feedback:true
+		);
+
+		// playback -> record
+		postln("softcut: pb->rec patchmatrix");
+		pm.pb_rec = PatchMatrix.new(
+			server:s, target:gr.pb, action:\addAfter,
+			in: bus_pb_idx,
+			out: bus_rec_idx,
+			feedback:true
+		);
+
+		this.addCommands;
+
+		nvoices.do({ arg i;
+			this.addPoll(("phase_" ++ (i+1)).asSymbol, {
+				var val = voices[i].phase_b.getSynchronous;
+				postln("phase: " ++ val);
+				val
 			});
-
-			s.sync;
-
-			//--- busses
-			bus.adc = context.in_b;
-			// FIXME? not sure about the peculiar arrangement of dual mono in / stereo out.
-			// FIXME: oh! actually just use array of panners, instead of output patch matrix.
-			// here we convert  output bus to a mono array
-			bus.dac = Array.with( Bus.newFrom(context.out_b, 0), Bus.newFrom(context.out_b, 1));
-			bus.rec = Array.fill(nvoices, { Bus.audio(s, 1); });
-			bus.pb = Array.fill(nvoices, { Bus.audio(s, 1); });
-
-			//-- voices
-			voices = Array.fill(nvoices, { |i|
-				// 	arg server, target, buf, in, out;
-				SoftCutVoice.new(s, context.xg, buf[i], bus.rec[i].index, bus.pb[i].index);
+			this.addPoll(("phase_norm_" ++ (i+1)).asSymbol, {
+				voices[i].phase_b.getSynchronous / voices[i].buf.duration
 			});
-
-			//--- patch matrices
-			bus_pb_idx = bus.pb.collect({ |b| b.index });
-			bus_rec_idx = bus.rec.collect({ |b| b.index });
-			pm = Event.new;
-
-			postln("softcut: in->rec patchmatrix");
-			// input -> record
-			pm.adc_rec = PatchMatrix.new(
-				server:s, target:gr.rec, action:\addToTail,
-				in: bus.adc.collect({ |b| b.index }),
-				out: bus_rec_idx,
-				feedback:true
-			);
-			postln("softcut: pb->out patchmatrix");
-			// playback -> output
-			pm.pb_dac = PatchMatrix.new(
-				server:s, target:gr.pb, action:\addAfter,
-				in: bus_pb_idx,
-				out: bus.dac.collect({ |b| b.index }),
-				feedback:true
-			);
-
-			// playback -> record
-			postln("softcut: pb->rec patchmatrix");
-			pm.pb_rec = PatchMatrix.new(
-				server:s, target:gr.pb, action:\addAfter,
-				in: bus_pb_idx,
-				out: bus_rec_idx,
-				feedback:true
-			);
-
-			this.addCommands;
-
-			nvoices.do({ arg i;
-				this.addPoll(("phase_" ++ (i+1)).asSymbol, {
-					var val = voices[i].phase_b.getSynchronous;
-					postln("phase: " ++ val);
-					val
-				});
-				this.addPoll(("phase_norm_" ++ (i+1)).asSymbol, {
-					voices[i].phase_b.getSynchronous / voices[i].buf.duration
-				});
-			});
+		});
 
 
-			s.sync;
-			doneCallback.value(this);
-
-		}.play;
-
-
-	} // init_SoftCut
+		s.sync;
+	}
 
 	addCommands {
 

--- a/sc/Engine_TestSine.sc
+++ b/sc/Engine_TestSine.sc
@@ -4,10 +4,10 @@ Engine_TestSine : CroneEngine {
 	var <synth;
 
 	*new { arg context, doneCallback;
-		^super.new(context, doneCallback).init_TestSine;
+		^super.new(context, doneCallback);
 	}
 
-	init_TestSine {
+	alloc {
 		synth = {
 			arg out=context.out_b, hz=220, amp=0.5, amplag=0.02, hzlag=0.01;
 			var amp_, hz_;
@@ -23,8 +23,6 @@ Engine_TestSine : CroneEngine {
 		this.addCommand("amp", "f", { arg msg;
 			synth.set(\amp, msg[1]);
 		});
-
-		doneCallback.value(this);
 	}
 
 	free {

--- a/sc/core/CroneEngine.sc
+++ b/sc/core/CroneEngine.sc
@@ -18,13 +18,20 @@ CroneEngine {
 		^super.new.init(context, doneCallback);
 	}
 
-	init { arg argContext, argDoneCallback;
+	init { arg argContext, doneCallback;
 		commands = List.new;
 		commandNames = Dictionary.new;
 		pollNames = Set.new;
 		context = argContext;
 		context.postln;
-		doneCallback = argDoneCallback;
+		fork {
+			this.alloc;
+			doneCallback.value(this);
+		};
+	}
+
+	alloc {
+		// subclass responsibility to allocate server resources, this method is called in a Routine so it's okay to s.sync
 	}
 
 	addPoll { arg name, func;


### PR DESCRIPTION
i suggest to allocate server resources in other method than `init` - namely `alloc` (not sure about naming) which is called in a `Routine` ending with `doneCallback` invocation in `CroneEngine.init` function . so, no longer need for subclasses to explicitly call doneCallback.

this should work but i haven't tested it in SoftCut.