### PR TITLE
don't rely on audio context being initialized in engine alloc method

### DIFF
--- a/sc/Engine_PolyPerc.sc
+++ b/sc/Engine_PolyPerc.sc
@@ -13,16 +13,17 @@ Engine_PolyPerc : CroneEngine {
 
 	alloc {
         SynthDef("PolyPerc", {
-			arg out = context.out_b, freq = 440, pw=pw, amp=amp, cutoff=cutoff, gain=gain, release=release;
+			arg out, freq = 440, pw=pw, amp=amp, cutoff=cutoff, gain=gain, release=release;
 			var snd = LFPulse.ar(freq, 0, pw);
 			var filt = MoogFF.ar(snd,cutoff,gain);
 			var env = Env.perc(level: amp, releaseTime: release).kr(2);
+			//			out.poll;
 			Out.ar(out, (filt*env).dup);
 		}).add;
 
 		this.addCommand("hz", "f", { arg msg;
 			var val = msg[1];
-            Synth("PolyPerc", [\freq,val,\pw,pw,\amp,amp,\cutoff,cutoff,\gain,gain,\release,release]);
+            Synth("PolyPerc", [\out, context.out_b, \freq,val,\pw,pw,\amp,amp,\cutoff,cutoff,\gain,gain,\release,release], target:context.xg);
 		});
 
 		this.addCommand("amp", "f", { arg msg;


### PR DESCRIPTION
@antonhornquist  this is to work around an oddity introduced by CroneEngine.alloc (i think)
- the output bus for polyperc synthdef has a default value that is set to `context.out_b`
- the synthdef is created in `.alloc` and the default value is set there
- i'm not sure where alloc is called r/n, but seems like maybe context isn't initialized yet or something, context.out_b doesn't exist and defaults to zero
- so, the synths get patched to output bus 0, which is hardware, bypassing context patch synth that controls level