### PR TITLE
Crone adjustments

### DIFF
--- a/sc/core/Crone.sc
+++ b/sc/core/Crone.sc
@@ -85,7 +85,7 @@ Crone {
 	}
 
 	// start a thread to continuously send a named report with a given interval
-	*startPoll { arg idx, intervalMs =100;
+	*startPoll { arg idx;
 		var poll = CronePollRegistry.getPollFromIdx(idx);
 		if(poll.notNil, {
 			poll.start(remoteAddr);


### PR DESCRIPTION
to leverage all subclasses to (that is, not only those directly below) CroneEngine means it's possible to build class hierarchy (example soon)

also: removed unused intervalMs from startPoll