### PR TITLE
Send synthdefs in alloc

### DIFF
--- a/sc/Engine_Knaster.sc
+++ b/sc/Engine_Knaster.sc
@@ -37,7 +37,7 @@ Engine_Knaster : CroneEngine {
 	*new { |context, callback| ^super.new(context, callback) }
 
 	alloc {
-		this.knasterSynthDef.add;
+		this.class.knasterSynthDef.add;
 
 		context.server.sync;
 


### PR DESCRIPTION
fixes #180 . all engines reviewed, knaster changed (SoftCutVoice sends defs the *initClass way but i didn't change anything since they appear to be generic CroneDefs). this is a minor thing anyway (sending defs in `alloc` to avoid engines overwriting synthdefs having the same name, which confused me alot until i understood what was going on).