### PR TITLE
Make wifi.sh more reliable & resilient

### DIFF
--- a/wifi.sh
+++ b/wifi.sh
@@ -21,10 +21,10 @@ function all_off {
     sudo service hostapd stop &> /dev/null
     sudo service dnsmasq stop &> /dev/null
     sudo killall wpa_supplicant &> /dev/null
-    while [ "`ps aux |grep wpa_supplicant |grep -v grep`" ] 
+    while [ "`ps aux |grep wpa_supplicant |grep -v grep`" ]
     do
-	    echo waiting for wpa_supplicant to die
-	    sleep 0.1
+	echo waiting for wpa_supplicant to die
+	sleep 0.1
     done
     sudo killall dhcpcd &> /dev/null
     sudo ip addr flush dev $WIFI_INTERFACE


### PR DESCRIPTION
There are a couple of weird edge-cases & race conditions I managed to unearth by testing the snot out of this thing.  The gotchas are:

- block until after wpa_supplicant starts or dies after instantiating or killing it
- kill all other existing wifi.sh instances when you call wifi.sh off
- diagnose credential fail after failing to connect for 5s

Important to understand these cases whether we end up porting this script into lua or not!