### PR TITLE
renaming

### DIFF
--- a/lua/control.lua
+++ b/lua/control.lua
@@ -1,19 +1,19 @@
---- Param class
+--- Control class
 -- @module paramset
 
 local ControlSpec = require 'controlspec'
 
-local Param = {}
-Param.__index = Param
+local Control = {}
+Control.__index = Control
 
-local tPARAM = 3
+local tCONTROL = 3
 
 --- constructor
 -- @param name of param
 -- @param controlspec
 -- @param formatter
-function Param.new(name, controlspec, formatter)
-  local p = setmetatable({}, Param)
+function Control.new(name, controlspec, formatter)
+  local p = setmetatable({}, Control)
   p.t = tPARAM
   if not controlspec then controlspec = ControlSpec.unipolar() end
   p.name = name
@@ -31,25 +31,25 @@ end
 
 --- get
 -- returns mapped value
-function Param:get()
+function Control:get()
   return self.controlspec:map(self.raw)
 end
 
 --- get_raw
 -- get 0-1
-function Param:get_raw()
+function Control:get_raw()
   return self.raw
 end
 
 --- set
 -- accepts a mapped value
-function Param:set(value)
+function Control:set(value)
   self:set_raw(util.round(self.controlspec:unmap(value),controlspec.step))
 end
 
 --- set_raw
 -- set 0-1
-function Param:set_raw(value)
+function Control:set_raw(value)
   clamped_value = util.clamp(value, 0, 1)
   if self.raw ~= clamped_value then
     self.raw = clamped_value
@@ -60,23 +60,23 @@ end
 --- delta
 -- add delta to current value. checks controlspec for mapped vs not
 -- default division of delta for 100 steps range
-function Param:delta(d)
+function Control:delta(d)
   self:set_raw(self.raw + d/100)
 end
 
 --- set_default
-function Param:set_default()
+function Control:set_default()
   self:set(self.controlspec.default)
 end
 
 --- bang
-function Param:bang()
+function Control:bang()
   self.action(self:get())
 end
 
 --- string
 -- @return formatted string
-function Param:string()
+function Control:string()
   if self.formatter then
     return self.formatter(self)
   else
@@ -85,4 +85,4 @@ function Param:string()
   end
 end
 
-return Param
+return Control

--- a/lua/menu.lua
+++ b/lua/menu.lua
@@ -413,25 +413,25 @@ end
 m.enc[pPARAMS] = function(n,d)
   if n==2 then
     local prev = m.params.pos
-    m.params.pos = util.clamp(m.params.pos + d, 0, p.count - 1)
+    m.params.pos = util.clamp(m.params.pos + d, 0, params.count - 1)
     if m.params.pos ~= prev then menu.redraw() end
-  elseif n==3 and p.count > 0 then
-    p:delta(m.params.pos+1,d)
+  elseif n==3 and params.count > 0 then
+    params:delta(m.params.pos+1,d)
     menu.redraw()
   end
 end
 
 m.redraw[pPARAMS] = function()
   s_clear()
-  if(p.count > 0) then 
+  if(params.count > 0) then 
     local i
     for i=1,6 do
-      if (i > 2 - m.params.pos) and (i < p.count - m.params.pos + 3) then
+      if (i > 2 - m.params.pos) and (i < params.count - m.params.pos + 3) then
         if i==3 then s_level(15) else s_level(4) end
         s_move(0,10*i)
-        s_text(p:get_name(i+m.params.pos-2))
+        s_text(params:get_name(i+m.params.pos-2))
         s_move(127,10*i)
-        s_text_right(p:string(i+m.params.pos-2))
+        s_text_right(params:string(i+m.params.pos-2))
       end 
     end
   else

--- a/lua/paramset.lua
+++ b/lua/paramset.lua
@@ -1,17 +1,17 @@
---- Paramset class
+--- ParamSet class
 -- @module paramset
 
-local Paramset = {}
-Paramset.__index = Paramset
+local ParamSet = {}
+ParamSet.__index = ParamSet
 
 local tNUMBER = 1
 local tOPTION = 2
-local tPARAM = 3
+local tCONTROL = 3
 
 --- constructor
 -- @param name
-function Paramset.new(name)
-  local ps = setmetatable({}, Paramset)
+function ParamSet.new(name)
+  local ps = setmetatable({}, ParamSet)
   ps.name = name or ""
   ps.params = {}
   ps.count = 0
@@ -20,28 +20,28 @@ function Paramset.new(name)
 end
 
 --- add number
-function Paramset:add_number(name, min, max, default)
+function ParamSet:add_number(name, min, max, default)
   table.insert(self.params, number.new(name, min, max, default))
   self.count = self.count + 1
   self.lookup[name] = self.count
 end
 
 --- add option
-function Paramset:add_option(name, options, default)
+function ParamSet:add_option(name, options, default)
   table.insert(self.params, option.new(name, options, default))
   self.count = self.count + 1
   self.lookup[name] = self.count
 end
 
---- add param
-function Paramset:add_param(name, controlspec, formatter)
-  table.insert(self.params, param.new(name, controlspec, formatter))
+--- add control
+function ParamSet:add_control(name, controlspec, formatter)
+  table.insert(self.params, control.new(name, controlspec, formatter))
   self.count = self.count + 1
   self.lookup[name] = self.count
 end
 
 --- print
-function Paramset:print()
+function ParamSet:print()
   print("paramset ["..self.name.."]")
   for k,v in pairs(self.params) do
     print(k.." "..v.name.." = "..v:string())
@@ -49,36 +49,36 @@ function Paramset:print()
 end
 
 --- name
-function Paramset:get_name(index)
+function ParamSet:get_name(index)
   return self.params[index].name
 end
 
 --- string
-function Paramset:string(index)
+function ParamSet:string(index)
   if type(index) == "string" then index = self.lookup[index] end
   return self.params[index]:string()
 end
 
 --- set
-function Paramset:set(index, v)
+function ParamSet:set(index, v)
   if type(index) == "string" then index = self.lookup[index] end
   self.params[index]:set(v)
 end
 
 --- get
-function Paramset:get(index)
+function ParamSet:get(index)
   if type(index) == "string" then index = self.lookup[index] end
   return self.params[index]:get()
 end
 
 --- delta
-function Paramset:delta(index, d)
+function ParamSet:delta(index, d)
   if type(index) == "string" then index = self.lookup[index] end
   self.params[index]:delta(d)
 end
 
 --- set action
-function Paramset:set_action(index, func)
+function ParamSet:set_action(index, func)
   if type(index) == "string" then index = self.lookup[index] end
   self.params[index].action = func
 end
@@ -87,7 +87,7 @@ end
  
 --- write to disk
 -- @param filename relative to data_dir
-function Paramset:write(filename) 
+function ParamSet:write(filename) 
   local fd=io.open(data_dir .. filename,"w+")
   io.output(fd)
   for k,v in pairs(self.params) do
@@ -99,7 +99,7 @@ end
 
 --- read from disk
 -- @param filename relative to data_dir
-function Paramset:read(filename)
+function ParamSet:read(filename)
   local fd=io.open(data_dir .. filename,"r")
   if fd then
     io.close(fd)
@@ -112,17 +112,17 @@ function Paramset:read(filename)
 end
 
 --- bang all params
-function Paramset:bang()
+function ParamSet:bang()
   for k,v in pairs(self.params) do
     v:bang()
   end
 end 
 
 --- clear
-function Paramset:clear()
+function ParamSet:clear()
   self.name = ""
   self.params = {}
   self.count = 0
 end
 
-return Paramset
+return ParamSet

--- a/lua/screen.lua
+++ b/lua/screen.lua
@@ -172,8 +172,8 @@ end
 
 --- disable screen functions (menu only controls screen)
 s_disable = function()
-  for k, v in pairs(s) do
-    s[k] = norns.none
+  for k, v in pairs(screen) do
+    screen[k] = norns.none
   end
 end
 

--- a/lua/script.lua
+++ b/lua/script.lua
@@ -21,17 +21,17 @@ Script.clear = function()
   -- clear polls
   poll.report = norns.none
   -- clear engine
-  engine = nil
+  engine.name = nil
   -- clear init
   init = norns.none
   -- clear last run
   norns.state.script = ''
   -- clear params
-  p:clear()
+  params:clear()
 end
 
 Script.init = function()
-  p.name = norns.state.script
+  params.name = norns.state.script
   init()
   norns.menu.init()
 end
@@ -59,8 +59,8 @@ end
 
 --- load engine, execute script-specified init (if present)
 Script.run = function()
-  if engine ~= nil then
-    e.load(engine, Script.init)
+  if engine.name ~= nil then
+    engine.load(engine.name, Script.init)
   else
     Script.init()
   end

--- a/lua/startup.lua
+++ b/lua/startup.lua
@@ -1,33 +1,26 @@
--- STARTUP
-
-require 'math'
-
-require 'engine'
-require 'grid'
-require 'hid'
-require 'midi'
-require 'poll'
-require 'metro'
+-- STARTUP 
 require 'menu'
 
--- more random
-math.randomseed(os.time())
+require 'math' 
+math.randomseed(os.time()) -- more random
 
 -- globals
-s = require 'screen'
+screen = require 'screen'
 grid = require 'grid'
+hid = require 'hid'
 metro = require 'metro'
+midi = require 'midi'
 poll = require 'poll'
-e = require 'engine'
+engine = require 'engine'
 wifi = require 'wifi'
 
 number = require 'number'
 option = require 'option'
-param = require 'param'
+control = require 'control'
 controlspec = require 'controlspec'
-paramset = require 'paramset'
+paramset = require 'paramset' 
 
-p = paramset.new()
+params = paramset.new()
 
 tab = require 'tabutil'
 util = require 'util'


### PR DESCRIPTION
numerous changes, so user scripts need updating:

`e` is now `engine`
`s` is now `screen`
`param` is now `control`
`p` is now `params` (the default/menu paramset, but you can make additional paramsets with `paramset.new()`

now that `engine` is the base name for engine manipulation, the user variable "engine" (which previously selected the engine to be loaded, before executing `init` ) is now `engine.name` instead. `engine.load` now uses `engine.name`.

dust scripts updated as examples.