### PR TITLE
round/round_up fix

### DIFF
--- a/lua/util.lua
+++ b/lua/util.lua
@@ -92,18 +92,18 @@ function util.expexp(slo, shi, dlo, dhi, f)
 end
 
 function util.round(number, quant)
-  if not quant or quant == 0 then
+  if quant == 0 then
     return number
   else
-    return math.floor(number/quant + 0.5) * quant
+    return math.floor(number/(quant or 1) + 0.5) * (quant or 1)
   end
 end
 
 function util.round_up(number, quant)
-  if not quant or quant == 0 then
+  if quant == 0 then
     return number
   else
-    return math.ceil(number/quant + 0.5) * quant
+    return math.ceil(number/(quant or 1) + 0.5) * (quant or 1)
   end
 end
 


### PR DESCRIPTION
i suggest round() and round_up() should round to integer if no quant is supplied. this is how it worked before moved to norns core (the quant argument is a bit weird, value is rounded to the nearest multiple of quant, so quant = 0 does not round at all. quant = 1 rounds to nearest integer)