### PR TITLE
get controlspec.step to work again

### DIFF
--- a/lua/control.lua
+++ b/lua/control.lua
@@ -44,7 +44,7 @@ end
 --- set
 -- accepts a mapped value
 function Control:set(value)
-  self:set_raw(util.round(self.controlspec:unmap(value),controlspec.step))
+  self:set_raw(util.round(self.controlspec:unmap(value),self.controlspec.step))
 end
 
 --- set_raw

--- a/lua/controlspec.lua
+++ b/lua/controlspec.lua
@@ -19,7 +19,7 @@ function ControlSpec.new(minval, maxval, warp, step, default, units)
   else
     s.warp = WARP_LIN
   end
-  s.step = step
+  s.step = step or 0
   s.default = default or minval -- TODO: test to ensure minval fallback works
   s.units = units or ""
   return s


### PR DESCRIPTION
my previous util.round() fix broke control:set(). should be fixed by this pr.

changes:
controlspec.step now defaults to 0 (no step) rather than nil (nil would round to integers with revised util.round())
fixed bug in control:set where controlspec member was not referred correctly.
