### PR TITLE
fix paramset file load for type FILE

### DIFF
--- a/lua/paramset.lua
+++ b/lua/paramset.lua
@@ -124,7 +124,11 @@ function ParamSet:read(filename)
     for line in io.lines(data_dir .. filename) do
       --print(line)
       k,v = line:match("([^,]+),([^,]+)")
-      self.params[tonumber(k)]:set(tonumber(v))
+      if tonumber(v) ~= nil then
+        self.params[tonumber(k)]:set(tonumber(v))
+      else
+        self.params[tonumber(k)]:set(v)
+      end
     end 
   end 
 end


### PR DESCRIPTION
minor but makes param file save/load work correctly.

@antonhornquist you can now use the param menu to specify .wav files for the sample player etc

still need to add slotted file saving (right now it's just one default file per script)