### PR TITLE
Metro min stack detached

### DIFF
--- a/matron/src/metro.c
+++ b/matron/src/metro.c
@@ -13,6 +13,7 @@
 // posix / linux
 #include <assert.h>
 #include <errno.h>
+#include <limits.h>
 #include <pthread.h>
 #include <time.h>
 
@@ -140,7 +141,11 @@ void metro_init(struct metro *t, uint64_t nsec, int count) {
     }
 
     // set other thread attributes here...
-
+    res = pthread_attr_setstacksize(&attr, PTHREAD_STACK_MIN );
+    if(res != 0) { metro_handle_error(res, "pthread_attr_init"); return; }
+    res |= pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED); 
+    if(res != 0) { metro_handle_error(res, "pthread_attr_init"); return; }
+    
     t->delta = nsec;
     t->count = count;
     res = pthread_create(&(t->tid), &attr, &metro_thread_loop, (void *)t);


### PR DESCRIPTION
this is a bandaid for issue #250 part 3.

setting stack size to minimum for new metro threads.
new metro threads are detached.

i think without setting detached state on creation, some system resource like sockets weren't being cleaned up under the hood. (some quirk of pthread ARM implementation i guess.) it is running ok so far (just a few minutes with the stress test, but that is way longer than ever before.

will try other cases (current test doesn't have 1shot or other non-infinite timers) and keep an eye on continuous uptime under load