### PR TITLE
fix CronePoll value setter issue

### DIFF
--- a/sc/core/CronePoll.sc
+++ b/sc/core/CronePoll.sc
@@ -11,7 +11,7 @@ CronePoll {
 	var <>oscAddr; 	// NetAddr; address to send to.
 	var <callback; 	// Function; full (private) callback function
 	var <periodic; // Boolean; is this a scheduled/repeating poll or not
-	var <value;   // last value
+	var <>value;   // last value
 
 	// create and define a new poll.
 	// function argument should return value or data


### PR DESCRIPTION
fixed `ERROR: Message 'value_' not understood.` when starting polls