### PR TITLE
always free + load engine in Crone.setEngine

### DIFF
--- a/sc/core/Crone.sc
+++ b/sc/core/Crone.sc
@@ -66,36 +66,29 @@ Crone {
 	*setEngine { arg name;
 		var class;
 		class = CroneEngine.allSubclasses.detect({ arg n; n.asString == name.asString });
-		if(engine.class != class, {
-			if(class.notNil, {
-				fork {
-					if(engine.notNil, {
-						var cond = Condition.new(false);
-						postln("free engine: " ++ engine);
-						engine.deinit({ cond.test = true; cond.signal; });
-						cond.wait;
+		if(class.notNil, {
+			fork {
+				if(engine.notNil, {
+					var cond = Condition.new(false);
+					postln("free engine: " ++ engine);
+					engine.deinit({ cond.test = true; cond.signal; });
+					cond.wait;
 
-					});
-					class.new(ctx, {
-						arg theEngine;
-						postln("-----------------------");
-						postln("-- crone: done loading engine, starting reports");
-						postln("--------");
+				});
+				class.new(ctx, {
+					arg theEngine;
+					postln("-----------------------");
+					postln("-- crone: done loading engine, starting reports");
+					postln("--------");
 
-						this.engine = theEngine;
-						postln("engine: " ++ this.engine);
+					this.engine = theEngine;
+					postln("engine: " ++ this.engine);
 
-						this.reportCommands;
-						this.reportPolls;
-					});
-				}
-			});
-		}, {
-			// if we didn't change engines, just resend the reports
-			this.reportCommands;
-			this.reportPolls;
+					this.reportCommands;
+					this.reportPolls;
+				});
+			}
 		});
-
 	}
 
 	// start a thread to continuously send a named report with a given interval


### PR DESCRIPTION
fixes issues with scripts reusing the same engine expecting the engine to be loaded from scratch (ie. `r` engines `3oscs`, `gong`, `rymd`)

kinda related to #187

`engine.load([the current engine])` == `engine.reset()` 

so should be noted that with this, engines are _always_ recreated from scratch upon loading new scripts.