### PR TITLE
add math lib to matron link script

### DIFF
--- a/matron/wscript
+++ b/matron/wscript
@@ -45,5 +45,5 @@ def build(bld):
             'SNDFILE',
             'AVAHI-COMPAT-LIBDNS_SD',
         ], lib=[
-            'pthread',
+            'pthread', 'm'
         ], cflags=['-O3', '-Wall'])


### PR DESCRIPTION
i needed to do this to build matron on desktop, since the addition of `hello.c`