### PR TITLE
Polysub save cpu

### DIFF
--- a/sc/Engine_PolySub.sc
+++ b/sc/Engine_PolySub.sc
@@ -12,7 +12,7 @@ Engine_PolySub : CroneEngine {
 	var <voices; // collection of voice nodes
 
 	*initClass {
-		maxNumVoices = 12;
+		maxNumVoices = 10;
 		StartUp.add {
 			// a decently versatile subtractive synth voice
 			polyDef = SynthDef.new(\polySub, {


### PR DESCRIPTION
polysub, manage CPU:

synth changes:
- remove compressor + reverb
- remove per-voice delay ugens and parameters 

voice management changes:
- there is now a hardcoded maximum voice count. requesting a new voice past the maximum simply does nothing.
- requesting a new voice at an existing voice ID now simply re-opens the gate for the existing voice.

**caveats**

- there isn't any way for matron to know when a "new voice" command isn't honored because the voice count has been reached. could add new async polls for when voices are created / freed / retriggered / ignored...

- when a voice is retriggered, control-bus mapping isn't reset. so the `solo` mode doesn't work properly for a retriggered voice.