### PR TITLE
engines shouldn't call super.free anymore. this can kill scsynth

### DIFF
--- a/sc/Engine_PolySub.sc
+++ b/sc/Engine_PolySub.sc
@@ -192,7 +192,6 @@ Engine_PolySub : CroneEngine {
 	free {
 		gr.free;
 		ctlBus.do({ arg bus, i; bus.free; });
-		super.free;
 	}
 
 } // class

--- a/sc/Engine_SoftCut.sc
+++ b/sc/Engine_SoftCut.sc
@@ -156,7 +156,6 @@ Engine_SoftCut : CroneEngine {
 		buf.free;
 		bus.do({ arg bs; bs.do({ arg b; b.free; }); });
 		pm.do({ arg p; p.free; });
-		super.free;
 	}
 
 	//---  buffer and routing methods


### PR DESCRIPTION
... when switching scripts / engines. or even when re-running a script since we always free and relaunch the engine now.