### PR TITLE
fix typo, correctly clamping cutoff to nyquist

### DIFF
--- a/sc/Engine_PolySub.sc
+++ b/sc/Engine_PolySub.sc
@@ -59,7 +59,7 @@ Engine_PolySub : CroneEngine {
 				fenv = EnvGen.ar(Env.adsr(cutAtk, cutDec, cutSus, cutRel), gate);
 
 				cut = SelectX.kr(cutEnvAmt, [cut, cut * fenv]);
-				cut = cut * hz.min(SampleRate.ir * 0.5);
+				cut = (cut * hz).min(SampleRate.ir * 0.5);
 
 				snd = SelectX.ar(noise, [snd, [PinkNoise.ar, PinkNoise.ar]]);
 				snd = MoogFF.ar(snd, cut, fgain) * aenv;


### PR DESCRIPTION
stupid parens bug. this is why cutoff env "wasn't working" when cutoff was some high ratio