### PR TITLE
ensure Midi.add callback is defined before calling

### DIFF
--- a/lua/midi.lua
+++ b/lua/midi.lua
@@ -41,7 +41,7 @@ end
 -- when scripts are restarted
 function Midi.reconnect()
   for id,dev in pairs(Midi.devices) do
-    Midi.add(dev)
+    if Midi.add ~= nil then Midi.add(dev) end
   end
 end
 


### PR DESCRIPTION
the low level event hooks check to see if an `add` callback is defined before it is called but the highlevel reconnect logic wasn't doing the same (and I tripped over that when writing a script which cleaned up its callbacks).