### PR TITLE
ensure Script.init is called before *.reconnect

### DIFF
--- a/lua/script.lua
+++ b/lua/script.lua
@@ -75,17 +75,21 @@ end
 
 --- load engine, execute script-specified init (if present)
 Script.run = function()
+  local bootstrap = function()
+    Script.init()
+    print("reconnecting grid...")
+    grid.reconnect()
+    print("reconnecting midi...")
+    midi.reconnect()
+  end
+
   print("# script run")
   if engine.name ~= nil then
-     print("loading engine; name: " .. engine.name)
-     engine.load(engine.name, Script.init) 
+    print("loading engine; name: " .. engine.name)
+    engine.load(engine.name, bootstrap)
   else
-     Script.init()
+    bootstrap()
   end
-  print("reconnecting grid...")
-  grid.reconnect()
-  print("reconnecting midi...")
-  midi.reconnect()
 end
 
 --- load script metadata


### PR DESCRIPTION
while working on a high level midi framework i noticed that the execution order of `Script.init`, `grid.reconnect`, and `midi.reconnect` changed depending on whether the user script defined `engine.name`.

if `engine.name` was not defined `Script.run` would call `Script.init` before `*.reconnect`. if `engine.name` *was* defined then `*.reconnect` were called immediately but `Script.init` invocation was deferred until the `norns.report.did_engine_load` callback was invoked.

this patch ensures that if the script is using an engine all three functions are deferred.

the variable order was preventing consistent results when registering device add/remove callbacks in a script's `init` function.
  