### PR TITLE
retry gateway check on fail

### DIFF
--- a/wifi.sh
+++ b/wifi.sh
@@ -95,7 +95,16 @@ elif [ $1 = "on" ]; then
 
     wait_associating;
     sudo dhcpcd
+    
     gw=$(ip route |grep default |awk '{print $3}')
+    n=0
+    until [ -n "$gw" ] || [ $n -ge 5 ] ; do # retry
+	    echo retrying gateway check...
+	    sleep 1s
+	    gw=$(ip route |grep default |awk '{print $3}')
+	    n=$[$n+1]
+    done
+    
     if [ -d $gw ]; then
 	    echo failed > $HOME/status.wifi
     else


### PR DESCRIPTION
adds a retry on the gateway check.  5 retries was arbitrary.  (mine seems to often take about 3.)

_(i'm by no means a shell hacker so feel free to refine)_

fixes: #375 

/cc @catfact @tehn @simonvanderveldt @ranch-verdin 