### PR TITLE
Refactor crone startup

### DIFF
--- a/lua/audio.lua
+++ b/lua/audio.lua
@@ -58,7 +58,9 @@ Audio.pitch_off = function()
 end
 
 --- restart the audio engine (recompile sclang)
-Audio.restart = function() restart_audio() end
+Audio.restart = function()
+   restart_audio()
+end
 
 --- global functions
 -- @section globals

--- a/lua/menu.lua
+++ b/lua/menu.lua
@@ -190,8 +190,6 @@ mix:set_action("comp makeup gain",
   function(x) fx.insert_fx_param("makeup_gain",x) end) 
 
 
-
-
 local pending = false
 -- metro for key hold detection
 local metro = require 'metro'

--- a/lua/norns.lua
+++ b/lua/norns.lua
@@ -117,6 +117,9 @@ norns.report.did_engine_load = function()
    -- engine module should assign callback
 end
 
+--- startup callbacks
+-- @section startup
+norns.
 
 --- poll callback; used by C interface
 -- @param id identfier
@@ -142,6 +145,7 @@ norns.audio = require 'audio'
 
 --- Management
 -- @section management
+---- ... whaaat?? why are all of these made global here?
 norns.script = require 'script'
 norns.state = require 'state'
 norns.log = require 'log'

--- a/lua/norns.lua
+++ b/lua/norns.lua
@@ -21,11 +21,6 @@ local engine = require 'engine'
 local poll = require 'poll'
 local tab = require 'tabutil'
 
---- startup function will be run after I/O subsystems are initialized,
--- but before I/O event loop starts ticking (see readme-script.md)
-startup = function()
-  require('startup')
-end
 
 --- Global Functions
 -- @section global_functions
@@ -119,7 +114,11 @@ end
 
 --- startup callbacks
 -- @section startup
-norns.
+
+--- startup handlers
+norns.startup_status = {}
+norns.startup_status.ok = function() print("startup ok") end
+norns.startup_status.timeout = function() print("startup timeout") end
 
 --- poll callback; used by C interface
 -- @param id identfier
@@ -173,4 +172,11 @@ norns.none = function() end
 norns.blank = function()
   s_clear()
   s_update()
+end
+
+
+--- startup function will be run after I/O subsystems are initialized,
+-- but before I/O event loop starts ticking (see readme-script.md)
+startup = function()
+  require('startup')
 end

--- a/lua/norns.lua
+++ b/lua/norns.lua
@@ -6,6 +6,8 @@ norns = {}
 norns.version = {}
 norns.version.norns = "1.0.0"
 
+print("norns.lua")
+
 -- import update version number
 local fd = io.open(os.getenv("HOME").."/version.txt","r")
 if fd then
@@ -20,7 +22,6 @@ end
 local engine = require 'engine'
 local poll = require 'poll'
 local tab = require 'tabutil'
-
 
 --- Global Functions
 -- @section global_functions
@@ -178,5 +179,6 @@ end
 --- startup function will be run after I/O subsystems are initialized,
 -- but before I/O event loop starts ticking (see readme-script.md)
 startup = function()
+   print("norns.lua:startup()")
   require('startup')
 end

--- a/lua/startup.lua
+++ b/lua/startup.lua
@@ -58,19 +58,10 @@ norns.startup_status.ok = function()
 end
 
 norns.startup_status.timeout = function()
-   print("norns.startup_status.timeout")
-   screen.clear()
-   screen.aa(1)
-   screen.line_width(1)
-   screen.level(10)
-   screen.move(10, 10)
-   screen.text("error: audio timed out")
-   screen.update()
-   --- FIXME: should probably do something different here,
-   --- but menu breaks if we don't try to load a script :/
-   norns.state.resume()
+  print("norns.startup_status.timeout")
+  norns.script.clear()
+  norns.scripterror("AUDIO ENGINE")
 end
-
 
 print("start_audio(): ")
 -- start the process of syncing with crone boot

--- a/lua/startup.lua
+++ b/lua/startup.lua
@@ -47,7 +47,16 @@ end
 
 grid.remove = function(device) g = nil end
 
+norns.startup_status.ok = function()
 -- resume last loaded script
-norns.script.clear()
-norns.log.post("norns started")
-norns.state.resume()
+   norns.script.clear()
+   norns.log.post("norns started")
+   norns.state.resume()
+end
+
+norns.startup_status.timeout = function()
+   -- FIXME: show something on the screen or whatever
+end
+
+-- start the process of syncing with crone boot
+start_audio()

--- a/lua/startup.lua
+++ b/lua/startup.lua
@@ -58,8 +58,17 @@ norns.startup_status.ok = function()
 end
 
 norns.startup_status.timeout = function()
-      print("norns.startup_status.timeout")
-   -- FIXME: show something on the screen or whatever
+   print("norns.startup_status.timeout")
+   screen.clear()
+   screen.aa(1)
+   screen.line_width(1)
+   screen.level(10)
+   screen.move(10, 10)
+   screen.text("error: audio timed out")
+   screen.update()
+   --- FIXME: should probably do something different here,
+   --- but menu breaks if we don't try to load a script :/
+   norns.state.resume()
 end
 
 

--- a/lua/startup.lua
+++ b/lua/startup.lua
@@ -47,7 +47,10 @@ end
 
 grid.remove = function(device) g = nil end
 
+print("setting startup_status callbacks...")
+
 norns.startup_status.ok = function()
+   print("norns.startup_status.ok")
 -- resume last loaded script
    norns.script.clear()
    norns.log.post("norns started")
@@ -55,8 +58,11 @@ norns.startup_status.ok = function()
 end
 
 norns.startup_status.timeout = function()
+      print("norns.startup_status.timeout")
    -- FIXME: show something on the screen or whatever
 end
 
+
+print("start_audio(): ")
 -- start the process of syncing with crone boot
 start_audio()

--- a/matron/src/event_types.h
+++ b/matron/src/event_types.h
@@ -41,10 +41,6 @@ typedef enum {
     EVENT_OSC,
     // finished receiving audio engine list
     EVENT_ENGINE_REPORT,
-    /* // finished receiving commands list */
-    /* EVENT_COMMAND_REPORT, */
-    /* // finished receiving polls list */
-    /* EVENT_POLL_REPORT, */
     // finished loading engine
     EVENT_ENGINE_LOADED,
     // polled value from crone
@@ -55,6 +51,10 @@ typedef enum {
     EVENT_POLL_WAVE,
     // polled i/o VU levels from crone
     EVENT_POLL_IO_LEVELS,
+    // crone startup ack event
+    EVENT_STARTUP_READY_ACK,
+    // crone startup timeout event
+    EVENT_STARTUP_READY_TIMEOUT,
     // quit the event loop
     EVENT_QUIT,
 } event_t;
@@ -196,6 +196,14 @@ struct event_poll_wave {
     uint8_t *data;
 }; // + 8
 
+struct event_startup_ready_ack {
+    struct event_common common;
+}; // + 0
+
+struct event_startup_ready_timeout {
+    struct event_common common;  
+}; // + 0
+
 union event_data {
     uint32_t type;
     struct event_exec_code_line exec_code_line;
@@ -218,4 +226,6 @@ union event_data {
     struct event_poll_data poll_data;
     struct event_poll_io_levels poll_io_levels;
     struct event_poll_wave poll_wave;
+    struct event_startup_ready_ack startup_ready_ack;
+    struct event_startup_ready_timeout startup_ready_timeout;
 };

--- a/matron/src/event_types.h
+++ b/matron/src/event_types.h
@@ -52,14 +52,14 @@ typedef enum {
     // polled i/o VU levels from crone
     EVENT_POLL_IO_LEVELS,
     // crone startup ack event
-    EVENT_STARTUP_READY_ACK,
+    EVENT_STARTUP_READY_OK,
     // crone startup timeout event
     EVENT_STARTUP_READY_TIMEOUT,
     // quit the event loop
     EVENT_QUIT,
 } event_t;
 
-// a packed data structure for four volume levels
+// a poked data structure for four volume levels
 // each channel is represented by unsigned byte with audio taper:
 // 255 == 0db
 // each step represents 0.25db, down to -60db
@@ -196,7 +196,7 @@ struct event_poll_wave {
     uint8_t *data;
 }; // + 8
 
-struct event_startup_ready_ack {
+struct event_startup_ready_ok {
     struct event_common common;
 }; // + 0
 
@@ -226,6 +226,6 @@ union event_data {
     struct event_poll_data poll_data;
     struct event_poll_io_levels poll_io_levels;
     struct event_poll_wave poll_wave;
-    struct event_startup_ready_ack startup_ready_ack;
+    struct event_startup_ready_ok startup_ready_ok;
     struct event_startup_ready_timeout startup_ready_timeout;
 };

--- a/matron/src/events.c
+++ b/matron/src/events.c
@@ -246,6 +246,12 @@ static void handle_event(union event_data *ev) {
     case EVENT_POLL_IO_LEVELS:
         w_handle_poll_io_levels(ev->poll_io_levels.value.bytes);
         break;
+    case EVENT_STARTUP_READY_ACK:
+        w_handle_startup_ready_ack();
+        break;
+    case EVENT_STARTUP_READY_TIMEOUT:
+        w_handle_startup_ready_timeout();
+        break;
     case EVENT_QUIT:
         quit = true;
         break;
@@ -266,22 +272,3 @@ void handle_engine_report(void) {
     o_unlock_descriptors();
 }
 
-/*
-void handle_command_report(void) {
-    o_lock_descriptors();
-    const struct engine_command *p = o_get_commands();
-    const int n = o_get_num_commands();
-    printf("handling command report with %d commands \n", n);
-    w_handle_command_report(p, n);
-    o_unlock_descriptors();
-}
-
-void handle_poll_report(void) {
-    o_lock_descriptors();
-    const struct engine_poll *p = o_get_polls();
-    const int n = o_get_num_polls();
-    w_handle_poll_report(p, n);
-    o_unlock_descriptors();
-};
-
-*/

--- a/matron/src/events.c
+++ b/matron/src/events.c
@@ -246,8 +246,8 @@ static void handle_event(union event_data *ev) {
     case EVENT_POLL_IO_LEVELS:
         w_handle_poll_io_levels(ev->poll_io_levels.value.bytes);
         break;
-    case EVENT_STARTUP_READY_ACK:
-        w_handle_startup_ready_ack();
+    case EVENT_STARTUP_READY_OK:
+        w_handle_startup_ready_ok();
         break;
     case EVENT_STARTUP_READY_TIMEOUT:
         w_handle_startup_ready_timeout();

--- a/matron/src/hello.c
+++ b/matron/src/hello.c
@@ -22,24 +22,24 @@ static const int tick_us = 5000;
 static const int timeout_ticks = 1600; // 8 seconds?
 
 struct {
-    double x;
-    double y;
-    double dx;
-    double dy;
-    int range;
-    int life;
+  double x;
+  double y;
+  double dx;
+  double dy;
+  int range;
+  int life;
 } light[LIGHTS];
 
 struct {
-    double x;
-    double y;
-    double dx;
-    double dy;
+  double x;
+  double y;
+  double dx;
+  double dy;
 } center;
 
 struct {
-    int x;
-    int y;
+  int x;
+  int y;
 } black;
 
 static int count = 0;
@@ -47,28 +47,39 @@ static int start = 1;
 
 static int status = 0;
 static int timeout = 0;
+static int ok = 0;
 
 
 static int norns_hello();
 static void* hello_loop(void*);
 static void start_thread();
 
- void* hello_loop(void * p) {
-   (void)p;
-  while(norns_hello(status)) {
-    if((count & 4095) == 0) {
-      o_query_startup();
-      fprintf(stderr, "query audio startup");
-    }
+void* hello_loop(void * p) {
+  (void)p;
+
+  fprintf(stderr, "hello_loop()\n");
+
+  while(!ok && !timeout) { 
+
+    norns_hello(1);
+    o_query_startup();
 
     if(count > timeout_ticks) {
       fprintf(stderr, "audio startup timeout \n");
       timeout = 1;
       status = 0;
-      usleep(tick_us);
     }
+    
+    usleep(tick_us);
+    count++;
+    // fprintf(stderr, "%d\n", count);
   }
 
+  // fadeout
+  while(norns_hello(0)) {
+    usleep(tick_us);
+  }  
+  
   if(timeout) {
     event_post( event_data_new(EVENT_STARTUP_READY_TIMEOUT) );
   } else {
@@ -78,88 +89,89 @@ static void start_thread();
   return NULL;
 }
 
- void start_thread() {
-      // start thread
-    int res;
-    pthread_attr_t attr;
+void start_thread() {
+  // start thread
+  int res;
+  pthread_attr_t attr;
 
-    res = pthread_attr_init(&attr);
-    if(res != 0) {
-      // oops
-      return;
-    }
-    res = pthread_create(&tid, &attr, &hello_loop, NULL);
-    if(res != 0) {
-      // oops
-    }
+  res = pthread_attr_init(&attr);
+  if(res != 0) {
+    fprintf(stderr, "error creating pthread attributes\n");
+    return;
+  }
+  res = pthread_create(&tid, &attr, &hello_loop, NULL);
+  if(res != 0) {
+    fprintf(stderr, "error creating pthread\n");
+  }
 }
 
 void norns_hello_start() {
-    srand(time(NULL));
-    screen_aa(0);
-    for(int i=0;i<LIGHTS;i++)
-        light[i].range = 1;
-    black.x = 60 + rand()%8;
-    black.y = 28 + rand()%8;
-    center.x = 60 + rand()%8;
-    center.y = 28 + rand()%8;
-    center.dx = 0;
-    center.dy = 0;
-    count = 0;
-    status = 1;
-    start_thread();    
- }
+    fprintf(stderr, "norns_hello_start()\n");
+    
+  srand(time(NULL));
+  screen_aa(0);
+
+  for(int i=0;i<LIGHTS;i++) {
+    light[i].range = 1;
+  }
+  
+  black.x = 60 + rand()%8;
+  black.y = 28 + rand()%8;
+  center.x = 60 + rand()%8;
+  center.y = 28 + rand()%8;
+  center.dx = 0;
+  center.dy = 0;
+  count = 0;
+
+  timeout = 0;
+  status = 1;
+
+  start_thread();
+}
 
 void norns_hello_stop() {
   status =0;
 }
 
 int norns_hello(int live) {
-    count++;
 
-    if((count & 255) == 0) {
-        black.x = 60 + rand()%8;
-        black.y = 28 + rand()%8;
-    }
+  if((count & 255) == 0) {
+    black.x = 60 + rand()%8;
+    black.y = 28 + rand()%8;
+  }
 
-    screen_clear();
-    //screen_line_width(1.0); // FIXME: for some reason setting this disables drawing
+  screen_clear();
+  //screen_line_width(1.0); // FIXME: for some reason setting this disables drawing
     
-    center.dx = center.dx + (black.x - center.x)/GRAVITY;
-    center.dy = center.dy + (black.y - center.y)/GRAVITY;
-    center.x = center.x + center.dx;
-    center.y = center.y + center.dy;
+  center.dx = center.dx + (black.x - center.x)/GRAVITY;
+  center.dy = center.dy + (black.y - center.y)/GRAVITY;
+  center.x = center.x + center.dx;
+  center.y = center.y + center.dy;
+  int alive = 0;
 
-    //screen_move(center.x,center.y);
-    //screen_line_rel(1,0);
-    //screen_level(15);
-    //screen_stroke();
-    
-    int alive = 0;
+  for(int i=0;i<LIGHTS;i++) {
+    if(light[i].range == 2) {
+      if(start<64) start++; 
+      light[i].range--;
+    } else if(light[i].range > 2) {
+      light[i].range--;
+      light[i].x += light[i].dx;
+      light[i].y += light[i].dy; 
+      alive++;
+      screen_move(light[i].x,light[i].y);
+      screen_line_rel(1,0);
+      screen_level(ceil(15*light[i].range/light[i].life)*(start/64.0));
+      screen_stroke();
+    } else if(live) { 
+      light[i].life = 64 + rand()%64;
+      light[i].range = light[i].life;
+      light[i].x = center.x;
+      light[i].y = center.y;
+      light[i].dx = (rand()%32-16)/96.0;
+      light[i].dy = (rand()%32-16)/96.0;
+    } 
+  }
+  screen_update();
 
-    for(int i=0;i<LIGHTS;i++) {
-        if(light[i].range == 2) {
-            if(start<64) start++; 
-            light[i].range--;
-        } else if(light[i].range > 2) {
-            light[i].range--;
-            light[i].x += light[i].dx;
-            light[i].y += light[i].dy; 
-            alive++;
-            screen_move(light[i].x,light[i].y);
-            screen_line_rel(1,0);
-            screen_level(ceil(15*light[i].range/light[i].life)*(start/64.0));
-            screen_stroke();
-        } else if(live) { 
-            light[i].life = 64 + rand()%64;
-            light[i].range = light[i].life;
-            light[i].x = center.x;
-            light[i].y = center.y;
-            light[i].dx = (rand()%32-16)/96.0;
-            light[i].dy = (rand()%32-16)/96.0;
-        } 
-    }
-    screen_update();
-
-    return alive;
+  return alive;
 }

--- a/matron/src/hello.c
+++ b/matron/src/hello.c
@@ -23,24 +23,24 @@ static const int timeout_ticks = 2400; // ~12 seconds?
 
 
 struct {
-  double x;
-  double y;
-  double dx;
-  double dy;
-  int range;
-  int life;
+    double x;
+    double y;
+    double dx;
+    double dy;
+    int range;
+    int life;
 } light[LIGHTS];
 
 struct {
-  double x;
-  double y;
-  double dx;
-  double dy;
+    double x;
+    double y;
+    double dx;
+    double dy;
 } center;
 
 struct {
-  int x;
-  int y;
+    int x;
+    int y;
 } black;
 
 static int count = 0;
@@ -56,120 +56,122 @@ static void* hello_loop(void*);
 static void start_thread();
 
 void* hello_loop(void * p) {
-  (void)p;
+    (void)p;
 
-  thread_running = true;
+    thread_running = true;
 
-  while(!ok && !timeout) { 
+    while(!ok && !timeout) {
 
-    norns_hello(1);
-    o_query_startup();
+        norns_hello(1);
+        o_query_startup();
 
-    if(count > timeout_ticks) {
-      timeout = 1;
+        if(count > timeout_ticks) {
+            timeout = 1;
+        }
+
+        usleep(tick_us);
+        count++;
+        // fprintf(stderr, "%d\n", count);
     }
-    
-    usleep(tick_us);
-    count++;
-    // fprintf(stderr, "%d\n", count);
-  }
 
-  // fadeout
-  while(norns_hello(0)) {
-    usleep(tick_us);
-  }  
-  
-  if(timeout) {
-    event_post( event_data_new(EVENT_STARTUP_READY_TIMEOUT) );
-  } else {
-    event_post( event_data_new(EVENT_STARTUP_READY_OK) );
-  }
+    // fadeout
+    while(norns_hello(0)) {
+        usleep(tick_us);
+    }
 
-  thread_running = false;
-  return NULL;
+    if(timeout) {
+        event_post( event_data_new(EVENT_STARTUP_READY_TIMEOUT) );
+    } else {
+        event_post( event_data_new(EVENT_STARTUP_READY_OK) );
+    }
+
+    thread_running = false;
+    return NULL;
 }
 
 void start_thread() {
-  // start thread
-  int res;
-  pthread_attr_t attr;
+    // start thread
+    int res;
+    pthread_attr_t attr;
 
-  res = pthread_attr_init(&attr);
-  if(res != 0) {
-    fprintf(stderr, "error creating pthread attributes\n");
-    return;
-  }
-  res = pthread_create(&tid, &attr, &hello_loop, NULL);
-  if(res != 0) {
-    fprintf(stderr, "error creating pthread\n");
-  }
+    res = pthread_attr_init(&attr);
+    if(res != 0) {
+        fprintf(stderr, "error creating pthread attributes\n");
+        return;
+    }
+    res = pthread_create(&tid, &attr, &hello_loop, NULL);
+    if(res != 0) {
+        fprintf(stderr, "error creating pthread\n");
+    }
 }
 
 void norns_hello_start() {
-  if(thread_running) { return; }
-    
-  srand(time(NULL));
-  screen_aa(0);
+    if(thread_running) { return; }
 
-  for(int i=0;i<LIGHTS;i++) {
-    light[i].range = 1;
-  }
-  
-  black.x = 60 + rand()%8;
-  black.y = 28 + rand()%8;
-  center.x = 60 + rand()%8;
-  center.y = 28 + rand()%8;
-  center.dx = 0;
-  center.dy = 0;
-  count = 0;
+    srand(time(NULL));
+    screen_aa(0);
 
-  timeout = 0;
-  ok = 0;
+    for(int i=0; i<LIGHTS; i++) {
+        light[i].range = 1;
+    }
 
-  start_thread();
+    black.x = 60 + rand()%8;
+    black.y = 28 + rand()%8;
+    center.x = 60 + rand()%8;
+    center.y = 28 + rand()%8;
+    center.dx = 0;
+    center.dy = 0;
+    count = 0;
+
+    timeout = 0;
+    ok = 0;
+
+    start_thread();
 }
 
-void norns_hello_ok() { ok = 1; } 
+void norns_hello_ok() {
+    ok = 1;
+}
 
 int norns_hello(int live) {
 
-  if((count & 255) == 0) {
-    black.x = 60 + rand()%8;
-    black.y = 28 + rand()%8;
-  }
+    if((count & 255) == 0) {
+        black.x = 60 + rand()%8;
+        black.y = 28 + rand()%8;
+    }
 
-  screen_clear();
-  //screen_line_width(1.0); // FIXME: for some reason setting this disables drawing
-    
-  center.dx = center.dx + (black.x - center.x)/GRAVITY;
-  center.dy = center.dy + (black.y - center.y)/GRAVITY;
-  center.x = center.x + center.dx;
-  center.y = center.y + center.dy;
-  int alive = 0;
+    screen_clear();
+    //screen_line_width(1.0); // FIXME: for some reason setting this disables drawing
 
-  for(int i=0;i<LIGHTS;i++) {
-    if(light[i].range == 2) {
-      if(start<64) start++; 
-      light[i].range--;
-    } else if(light[i].range > 2) {
-      light[i].range--;
-      light[i].x += light[i].dx;
-      light[i].y += light[i].dy; 
-      alive++;
-      screen_move(light[i].x,light[i].y);
-      screen_line_rel(1,0);
-      screen_level(ceil(15*light[i].range/light[i].life)*(start/64.0));
-      screen_stroke();
-    } else if(live) { 
-      light[i].life = 64 + rand()%64;
-      light[i].range = light[i].life;
-      light[i].x = center.x;
-      light[i].y = center.y;
-      light[i].dx = (rand()%32-16)/96.0;
-      light[i].dy = (rand()%32-16)/96.0;
-    } 
-  }
-  screen_update();
+    center.dx = center.dx + (black.x - center.x)/GRAVITY;
+    center.dy = center.dy + (black.y - center.y)/GRAVITY;
+    center.x = center.x + center.dx;
+    center.y = center.y + center.dy;
+    int alive = 0;
 
-  return alive;
+    for(int i=0; i<LIGHTS; i++) {
+        if(light[i].range == 2) {
+            if(start<64) start++;
+            light[i].range--;
+        } else if(light[i].range > 2) {
+            light[i].range--;
+            light[i].x += light[i].dx;
+            light[i].y += light[i].dy;
+            alive++;
+            screen_move(light[i].x,light[i].y);
+            screen_line_rel(1,0);
+            screen_level(ceil(15*light[i].range/light[i].life)*(start/64.0));
+            screen_stroke();
+        } else if(live) {
+            light[i].life = 64 + rand()%64;
+            light[i].range = light[i].life;
+            light[i].x = center.x;
+            light[i].y = center.y;
+            light[i].dx = (rand()%32-16)/96.0;
+            light[i].dy = (rand()%32-16)/96.0;
+        }
+    }
+    screen_update();
+
+    return alive;
 }

--- a/matron/src/hello.h
+++ b/matron/src/hello.h
@@ -1,4 +1,5 @@
 #pragma once
 
-void norns_hello_init(void);
+void norns_hello_start(void);
+void norns_hello_stop(void);
 int norns_hello(int);

--- a/matron/src/hello.h
+++ b/matron/src/hello.h
@@ -1,5 +1,6 @@
 #pragma once
 
 void norns_hello_start(void);
-void norns_hello_stop(void);
+void norns_hello_ok(void);
+
 int norns_hello(int);

--- a/matron/src/main.c
+++ b/matron/src/main.c
@@ -54,8 +54,10 @@ int main(int argc, char **argv) {
     battery_init();
     i2c_init();
     osc_init();
+    
     o_init(); // oracle (audio)
 
+    /*
     norns_hello_init();
 
     // wait here for a signal from the audio server...
@@ -69,6 +71,7 @@ int main(int argc, char **argv) {
     while(norns_hello(0)) {
         usleep(5000);
     }
+    */
 
     w_init(); // weaver (scripting)
     dev_list_init();

--- a/matron/src/main.c
+++ b/matron/src/main.c
@@ -73,6 +73,7 @@ int main(int argc, char **argv) {
     w_init(); // weaver (scripting)
     dev_list_init();
     dev_monitor_init();
+    
     // now is a good time to set our cleanup
     atexit(cleanup);
     // start reading input to interpreter

--- a/matron/src/oracle.c
+++ b/matron/src/oracle.c
@@ -563,6 +563,7 @@ int handle_crone_ready(const char *path,
     (void)argv;
     (void)data;
     (void)user_data;
+    /// FIXME
     ready = 1;
     return 0;
 }

--- a/matron/src/oracle.c
+++ b/matron/src/oracle.c
@@ -19,6 +19,7 @@
 
 #include "args.h"
 #include "events.h"
+#include "hello.h"
 #include "oracle.h"
 
 static lo_address remote_addr;
@@ -562,9 +563,7 @@ int handle_crone_ready(const char *path,
     (void)argv;
     (void)data;
     (void)user_data;
-    /// FIXME
-    ///
-    
+    norns_hello_ok();
     return 0;
 }
 

--- a/matron/src/oracle.c
+++ b/matron/src/oracle.c
@@ -135,10 +135,9 @@ static void test_engine_load_done();
 //-----------------------------------
 //---- extern function definitions
 
-int o_ready(void) {
+void o_query_startup(void) {
     // fprintf(stderr, "sending /ready: %d", rem_port);
     lo_send(remote_addr, "/ready","");
-    return ready;
 }
 
 //--- init
@@ -564,7 +563,8 @@ int handle_crone_ready(const char *path,
     (void)data;
     (void)user_data;
     /// FIXME
-    ready = 1;
+    ///
+    
     return 0;
 }
 

--- a/matron/src/oracle.h
+++ b/matron/src/oracle.h
@@ -38,12 +38,14 @@ struct engine_param {
 };
 
 
-// check for audio engine boot completion
-extern int o_ready();
+
 // initialize
 extern void o_init();
 // shutdown
 extern void o_deinit();
+
+// send query for audio engine boot completion
+extern void o_query_startup();
 
 //----------------------
 //--- access param and buffer descriptors

--- a/matron/src/weaver.c
+++ b/matron/src/weaver.c
@@ -149,7 +149,9 @@ static int _set_insert_fx_off(lua_State *l);
 static int _set_insert_fx_mix(lua_State *l);
 static int _set_insert_fx_param(lua_State *l);
 
-// restart audio completely (recompile sclang)
+// start audio (sync with sclang startup)
+static int _start_audio(lua_State *l);
+// restart audio (recompile sclang)
 static int _restart_audio(lua_State *l);
 
 // soundfile inspection
@@ -279,10 +281,11 @@ void w_init(void) {
   lua_register(lvm, "set_insert_fx_mix", &_set_insert_fx_mix);
   lua_register(lvm, "set_insert_fx_param", &_set_insert_fx_param);
 
-
-  // completely restart the audio process (recompile sclang)
+  // start audio (query for sclang readiness)
+  lua_register(lvm, "start_audio", &_start_audio);
+  // restart the audio process (recompile sclang)
   lua_register(lvm, "restart_audio", &_restart_audio);
-
+ 
   // returns channels, frames, samplerate
   lua_register(lvm, "sound_file_inspect", &_sound_file_inspect);
 
@@ -1351,6 +1354,16 @@ void w_handle_engine_report(const char **arr, const int n) {
   l_report(lvm, l_docall(lvm, 2, 0));
 }
 
+void w_handle_startup_ready_ack() {
+  _push_norns_func("startup", "ready");
+  l_report(lvm, l_docall(lvm, 0, 0));
+}
+
+void w_handle_startup_ready_timeout() {
+  _push_norns_func("startup", "timeout");
+  l_report(lvm, l_docall(lvm, 0, 0));
+}
+
 // helper: push table of commands
 // each entry is a subtatble: {name, format}
 static void _push_commands() {
@@ -1777,6 +1790,10 @@ int _set_insert_fx_param(lua_State *l) {
   return 0;
 }
 
+int _start_audio(lua_State *l) {
+  (void)l;
+  return 0;
+}
 
 int _restart_audio(lua_State *l) {
   (void)l;
@@ -1796,3 +1813,4 @@ int _sound_file_inspect(lua_State *l) {
   lua_pushinteger(l, desc.samplerate);
   return 3;
 }
+

--- a/matron/src/weaver.c
+++ b/matron/src/weaver.c
@@ -26,6 +26,7 @@
 #include "device_monome.h"
 #include "device_midi.h"
 #include "events.h"
+#include "hello.h"
 #include "lua_eval.h"
 #include "metro.h"
 #include "screen.h"
@@ -1354,13 +1355,13 @@ void w_handle_engine_report(const char **arr, const int n) {
   l_report(lvm, l_docall(lvm, 2, 0));
 }
 
-void w_handle_startup_ready_ack() {
-  _push_norns_func("startup", "ready");
+void w_handle_startup_ready_ok() {
+  _push_norns_func("startup_status", "ready");
   l_report(lvm, l_docall(lvm, 0, 0));
 }
 
 void w_handle_startup_ready_timeout() {
-  _push_norns_func("startup", "timeout");
+  _push_norns_func("startup_status", "timeout");
   l_report(lvm, l_docall(lvm, 0, 0));
 }
 
@@ -1792,11 +1793,14 @@ int _set_insert_fx_param(lua_State *l) {
 
 int _start_audio(lua_State *l) {
   (void)l;
+  norns_hello_start();
+  o_query_startup();
   return 0;
 }
 
 int _restart_audio(lua_State *l) {
   (void)l;
+  norns_hello_start();
   o_restart_audio();
   return 0;
 }

--- a/matron/src/weaver.c
+++ b/matron/src/weaver.c
@@ -1794,14 +1794,13 @@ int _set_insert_fx_param(lua_State *l) {
 int _start_audio(lua_State *l) {
   (void)l;  
   norns_hello_start();
-  o_query_startup();
   return 0;
 }
 
 int _restart_audio(lua_State *l) {
   (void)l;
-  norns_hello_start();
   o_restart_audio();
+  norns_hello_start();
   return 0;
 }
 

--- a/matron/src/weaver.c
+++ b/matron/src/weaver.c
@@ -1356,13 +1356,11 @@ void w_handle_engine_report(const char **arr, const int n) {
 }
 
 void w_handle_startup_ready_ok() {
-  fprintf(stderr, "w_handle_startup_ready_ok()\n");
   _push_norns_func("startup_status", "ok");
   l_report(lvm, l_docall(lvm, 0, 0));
 }
 
 void w_handle_startup_ready_timeout() {
-  fprintf(stderr, "w_handle_startup_ready_timeout()\n");
   _push_norns_func("startup_status", "timeout");
   l_report(lvm, l_docall(lvm, 0, 0));
 }

--- a/matron/src/weaver.c
+++ b/matron/src/weaver.c
@@ -1356,11 +1356,13 @@ void w_handle_engine_report(const char **arr, const int n) {
 }
 
 void w_handle_startup_ready_ok() {
-  _push_norns_func("startup_status", "ready");
+  fprintf(stderr, "w_handle_startup_ready_ok()\n");
+  _push_norns_func("startup_status", "ok");
   l_report(lvm, l_docall(lvm, 0, 0));
 }
 
 void w_handle_startup_ready_timeout() {
+  fprintf(stderr, "w_handle_startup_ready_timeout()\n");
   _push_norns_func("startup_status", "timeout");
   l_report(lvm, l_docall(lvm, 0, 0));
 }
@@ -1792,7 +1794,7 @@ int _set_insert_fx_param(lua_State *l) {
 }
 
 int _start_audio(lua_State *l) {
-  (void)l;
+  (void)l;  
   norns_hello_start();
   o_query_startup();
   return 0;

--- a/matron/src/weaver.h
+++ b/matron/src/weaver.h
@@ -71,5 +71,5 @@ extern void w_handle_poll_io_levels(uint8_t *levels);
 extern void w_handle_engine_loaded();
 
 // callbacks for ACK and timeout of sclang startup
-extern void w_handle_startup_ready_ack();
+extern void w_handle_startup_ready_ok();
 extern void w_handle_startup_ready_timeout();

--- a/matron/src/weaver.h
+++ b/matron/src/weaver.h
@@ -69,3 +69,7 @@ extern void w_handle_poll_wave(int idx, uint8_t *data);
 extern void w_handle_poll_io_levels(uint8_t *levels);
 
 extern void w_handle_engine_loaded();
+
+// callbacks for ACK and timeout of sclang startup
+extern void w_handle_startup_ready_ack();
+extern void w_handle_startup_ready_timeout();


### PR DESCRIPTION
implemented changes described in https://github.com/monome/norns/issues/381

this makes `audio.restart()` lua method more functional, as a first step for editing SC classes. (`audio.restart()` should now re-trigger the main startup sequence, including resuming last script and sending audio I/O and effect parameters.)

it also means that if SC fails to boot, you get a timeout message but can continue to use the menu to turn on wifi. 