### PR TITLE
menu: update method, multiple paramset slots

### DIFF
--- a/lua/menu.lua
+++ b/lua/menu.lua
@@ -639,6 +639,7 @@ m.sel.pos = 0
 m.sel.list = util.scandir(script_dir)
 m.sel.len = tab.count(m.sel.list)
 m.sel.depth = 0
+m.sel.folderpos = {}
 m.sel.folders = {}
 m.sel.path = ""
 m.sel.file = ""
@@ -673,7 +674,7 @@ m.key[pSELECT] = function(n,z)
       -- FIXME return to folder position
       m.sel.list = util.scandir(m.sel.dir())
       m.sel.len = tab.count(m.sel.list)
-      m.sel.pos = 0
+      m.sel.pos = m.sel.folderpos[m.sel.depth] or 0
       menu.redraw()
     else
       menu.set_page(pHOME)
@@ -683,6 +684,7 @@ m.key[pSELECT] = function(n,z)
     m.sel.file = m.sel.list[m.sel.pos+1]
     if string.find(m.sel.file,'/') then
       print("folder")
+      m.sel.folderpos[m.sel.depth] = m.sel.pos
       m.sel.depth = m.sel.depth + 1
       m.sel.folders[m.sel.depth] = m.sel.file
       m.sel.list = util.scandir(m.sel.dir())

--- a/lua/norns.lua
+++ b/lua/norns.lua
@@ -150,6 +150,7 @@ norns.script = require 'script'
 norns.state = require 'state'
 norns.log = require 'log'
 norns.encoders = require 'encoders'
+norns.update = require 'update'
 
 norns.enc = norns.encoders.process
 

--- a/lua/paramset.lua
+++ b/lua/paramset.lua
@@ -127,6 +127,18 @@ end
 --- write to disk
 -- @param filename relative to data_dir
 function ParamSet:write(filename)
+  -- check for subfolder in filename, create subfolder if it doesn't exist
+  local subfolder, found = string.gsub(filename,"/(.*)","")
+  if found==1 then
+    local fd = io.open(data_dir..subfolder,"r")
+    if fd then
+      io.close(fd) 
+    else
+      print("creating subfolder")
+      os.execute("mkdir "..data_dir..subfolder) 
+    end
+  end
+  -- write file
   local fd = io.open(data_dir..filename, "w+")
   io.output(fd)
   for k,param in pairs(self.params) do

--- a/lua/script.lua
+++ b/lua/script.lua
@@ -63,8 +63,8 @@ Script.load = function(filename)
     if status == true then
       norns.log.post("loaded " .. filename) -- post to log
       norns.state.script = filename -- store script name
-      norns.state.name = string.gsub(filename,'.lua','') -- store name
-      norns.state.name = norns.state.name:match("[^/]*$") -- strip path from name
+      norns.state.folder_name = string.gsub(filename,'.lua','') -- store name
+      norns.state.name = norns.state.folder_name:match("[^/]*$") -- strip path from name
       norns.state.save() -- remember this script for next launch
       norns.script.redraw = redraw -- store redraw function for context switching
       redraw = norns.none -- block redraw until Script.init

--- a/lua/startup.lua
+++ b/lua/startup.lua
@@ -1,4 +1,5 @@
 -- STARTUP 
+
 require 'menu'
 
 require 'math' 
@@ -62,6 +63,10 @@ norns.startup_status.timeout = function()
   norns.script.clear()
   norns.scripterror("AUDIO ENGINE")
 end
+
+
+-- check for pending updates
+norns.update.run()
 
 print("start_audio(): ")
 -- start the process of syncing with crone boot

--- a/lua/update.lua
+++ b/lua/update.lua
@@ -1,0 +1,70 @@
+--- system update functions
+local Update = {}
+
+function Update.check()
+  local found = false
+  local i, t, popen = 0, {}, io.popen
+  -- CHECK FOR UPDATE FOLDER
+  local test = util.os_capture("ls $HOME | grep update")
+  if test ~= "update" then os.execute("mkdir $HOME/update") end
+  -- COPY FROM USB
+  local disk = util.os_capture("lsblk -o mountpoint | grep media")
+  local pfile = popen("ls -p "..disk.."/norns*.tgz")
+  for filename in pfile:lines() do
+    os.execute("cp "..filename.." $HOME/update/")
+  end 
+  -- PREPARE
+  pfile = popen('ls -p $HOME/update/norns*.tgz')
+  for filename in pfile:lines() do
+    print(filename)
+    -- extract
+    os.execute("tar -xzvC $HOME/update -f "..filename)
+    -- check md5
+    local md5 = util.os_capture("cd $HOME/update; md5sum -c *.md5")
+    print(">> "..md5)
+    if string.find(md5,"OK") then
+      found = true
+      norns.log.post("new update found")
+      -- unpack
+      local file = string.sub(md5,1,-5)
+      os.execute("tar -xzvC $HOME/update -f $HOME/update/"..file)
+    else norns.log.post("bad update file") end
+    -- delete
+    os.execute("rm $HOME/update/*.tgz; rm $HOME/update/*.md5")
+  end
+  pfile:close()
+
+  return found 
+end
+
+function Update.run() 
+  local pfile = io.popen('ls -tp $HOME/update') 
+  local l = {}
+  local newest = 0
+  for file in pfile:lines() do
+    local s = string.sub(file,0,-2)
+    local n = tonumber(s)
+    if n then 
+      print("update found: "..n)
+      if n > newest then newest = n end
+    end
+  end
+  if newest > tonumber(norns.version.update) then
+    print("updating with: "..newest)
+    screen.clear()
+    screen.move(64,32)
+    screen.level(10)
+    screen.text_center("running update: "..newest)
+    screen.update()
+    os.execute("$HOME/update/"..newest.."/update.sh")
+    screen.clear()
+    screen.move(64,32)
+    screen.level(10)
+    screen.text_center("complete. shutting down.")
+    screen.update()
+    os.execute("rm -rf $HOME/update/*")
+    os.execute("sleep 0.5; sudo shutdown now") 
+  end 
+end
+
+return Update


### PR DESCRIPTION
## update method

- SYSTEM > UPDATE now simply primes an update. grabs file from USB disk, extracts it to ~/update
- on boot, ~/update is checked for any updates and then executes them if available. shut down upon completion

## parameter set slots

- BREAKING CHANGE: parameter sets moved to subfolders ie tehn/awake.pset
- hold KEY1 in PARAMETER menu to bring up load/save.
- ENC3 scrolls slot (default is 0)
- then use KEY2/KEY3 to save/load to slot positions.
- "slot" files saved with -nn extension ie awake-02.pset
- save/load status/fade shown, load dimmed for nonexistent files

- NEEDED: dust updates for default .pset files and loading within `init` of any script doing `params:read()`

## select nav behavior

- when navigating into ie `/tehn` and then backing out, the select position will resume from `/tehn`
