### PR TITLE
report errors in script init

### DIFF
--- a/lua/script.lua
+++ b/lua/script.lua
@@ -38,8 +38,9 @@ end
 Script.init = function()
   print("# script init")
   params.name = norns.state.name
-  if not pcall(init) then norns.scripterror() end
-  norns.menu.init()
+  if norns.try(init, "init") then
+    norns.menu.init()
+  end
 end
 
 --- load a script from the /scripts folder


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/67586/40895593-398d97fe-6765-11e8-87e8-19289a002960.png)


fixes: #358

(there's another `pcall` in `cleanup()` that could maybe get similar treatment, but since there's a `norns.try` right after maybe that's intended?)

/cc @tehn @catfact