### PR TITLE
migrate `try` to use an `xpcall` for more context on errors

### DIFF
--- a/lua/norns.lua
+++ b/lua/norns.lua
@@ -156,7 +156,8 @@ norns.enc = norns.encoders.process
 
 --- Error handling
 norns.try = function(f,msg)
-  local status, err = pcall(f)
+  local handler = function (err) return err .. "\n" .. debug.traceback() end
+  local status, err = xpcall(f, handler)
   if not status then
     norns.scripterror(msg)
     print(err)


### PR DESCRIPTION
the error from `pcall` in `norns.try` is not super useful when the error is in a nested call.

![image](https://user-images.githubusercontent.com/67586/41008248-d3fd82d4-68de-11e8-83dc-5fa7d42a7899.png)

notice in particular, that it's not clear what line _in user code_ caused the error.

`xpcall` w/ a `dbug.traceback()` hander gives us a bunch more context.

![image](https://user-images.githubusercontent.com/67586/41008295-1e2d8f3e-68df-11e8-8922-26056c7315d3.png)

/cc @tehn @catfact 



