### PR TITLE
Util.lua additions and fixes

### DIFF
--- a/lua/util.lua
+++ b/lua/util.lua
@@ -130,7 +130,7 @@ function util.expexp(slo, shi, dlo, dhi, f)
   elseif f >= shi then
     return dhi
   else
-    return math.pow(dhi/dlo, math.log(f/slo)) / (math.log(shi/slo)) * dlo
+    return math.pow(dhi/dlo, math.log(f/slo) / math.log(shi/slo)) * dlo
   end
 end
 

--- a/lua/util.lua
+++ b/lua/util.lua
@@ -59,6 +59,12 @@ end
 -- linlin, linexp, explin, expexp ripped from SC source code
 -- https://github.com/supercollider/supercollider/blob/cca12ff02a774a9ea212e8883551d3565bb24a6f/lang/LangSource/MiscInlineMath.h 
 
+--- convert a linear range to an exponential range
+-- @param slo lower limit of input range
+-- @param shi upper limit of input range
+-- @param dlo lower limit of output range (must be non-zero and of the same sign as dhi)
+-- @param dhi upper limit of output range (must be non-zero and of the same sign as dlo)
+-- @param f input to convert
 function util.linexp(slo, shi, dlo, dhi, f)
   if f <= slo then
     return dlo
@@ -69,6 +75,12 @@ function util.linexp(slo, shi, dlo, dhi, f)
   end
 end
 
+--- map a linear range to another linear range
+-- @param slo lower limit of input range
+-- @param shi upper limit of input range
+-- @param dlo lower limit of output range
+-- @param dhi upper limit of output range
+-- @param f input to convert
 function util.linlin(slo, shi, dlo, dhi, f)
   if f <= slo then
     return dlo
@@ -79,6 +91,12 @@ function util.linlin(slo, shi, dlo, dhi, f)
   end
 end
 
+--- convert an exponential range to a linear range
+-- @param slo lower limit of input range (must be non-zero and of the same sign as shi)
+-- @param shi upper limit of input range (must be non-zero and of the same sign as slo)
+-- @param dlo lower limit of output range
+-- @param dhi upper limit of output range
+-- @param f input to convert
 function util.explin(slo, shi, dlo, dhi, f)
   if f <= slo then
     return dlo
@@ -89,6 +107,12 @@ function util.explin(slo, shi, dlo, dhi, f)
   end
 end
 
+--- map an exponential range to another exponential range
+-- @param slo lower limit of input range (must be non-zero and of the same sign as shi)
+-- @param shi upper limit of input range (must be non-zero and of the same sign as slo)
+-- @param dlo lower limit of output range (must be non-zero and of the same sign as dhi)
+-- @param dhi upper limit of output range (must be non-zero and of the same sign as dlo)
+-- @param f input to convert
 function util.expexp(slo, shi, dlo, dhi, f)
   if f <= slo then
     return dlo
@@ -99,6 +123,9 @@ function util.expexp(slo, shi, dlo, dhi, f)
   end
 end
 
+--- round to a multiple of a number
+-- @param number number to round
+-- @param quant precision to round to
 function util.round(number, quant)
   if quant == 0 then
     return number
@@ -107,6 +134,9 @@ function util.round(number, quant)
   end
 end
 
+--- round up to a multiple of a number
+-- @param number number to round
+-- @param quant precision to round to
 function util.round_up(number, quant)
   if quant == 0 then
     return number

--- a/lua/util.lua
+++ b/lua/util.lua
@@ -47,6 +47,17 @@ util.string_starts = function(s,start)
   return string.sub(s,1,string.len(start))==start
 end
 
+--- convert midi note number to name
+-- @param note_num midi note number (0-127)
+-- @param include_octave optional, include octave number in return string if set to true
+-- @return name string (eg, C#3)
+function util.midi_note_to_name(note_num, include_octave)
+  local NAMES = {'C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B'}
+  local name = NAMES[note_num % 12 + 1]
+  if include_octave then name = name .. math.floor(note_num / 12 - 1) end
+  return name
+end
+
 --- clamp values to min max
 -- @param n value
 -- @param min minimum

--- a/lua/util.lua
+++ b/lua/util.lua
@@ -1,4 +1,4 @@
---- Utility module;
+--- Utility module
 -- @module util
 
 util = {}
@@ -45,17 +45,6 @@ end
 -- @return true or false
 util.string_starts = function(s,start)
   return string.sub(s,1,string.len(start))==start
-end
-
---- convert midi note number to name
--- @param note_num midi note number (0-127)
--- @param include_octave optional, include octave number in return string if set to true
--- @return name string (eg, C#3)
-function util.midi_note_to_name(note_num, include_octave)
-  local NAMES = {'C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B'}
-  local name = NAMES[note_num % 12 + 1]
-  if include_octave then name = name .. math.floor(note_num / 12 - 1) end
-  return name
 end
 
 --- clamp values to min max


### PR DESCRIPTION
Three commits in here:

- The first adds some comments for documentation for the undocumented methods in `util.lua`. I wasn't sure how the docs were generated so this is just the lua file.

- The second commit is a suggestion to add a method to `util.lua` for generating note name strings from MIDI note numbers. Let me know if this should go elsewhere.

- The third requires a little more explaining...

It seemed that the existing `util.expexp()` method was returning invalid values outside of range. This method was pulled directly from [this snippet](https://github.com/supercollider/supercollider/blob/cca12ff02a774a9ea212e8883551d3565bb24a6f/lang/LangSource/MiscInlineMath.h#L49) of SC and matches. However, looking at [this other snippet](https://github.com/supercollider/supercollider/blob/a51dad9cb479503a6f031d425d8aa4d484474b34/SCClassLibrary/Common/Math/SimpleNumber.sc#L439) from SC there is a difference in the brackets. My third commit replaces that line of code with the line from SC's `SimpleNumber.sc`. I assume this is a SC bug that got pasted across but please check I'm not crazy here :) 
