### PR TITLE
arc support

### DIFF
--- a/doc/index.html
+++ b/doc/index.html
@@ -38,6 +38,7 @@
   <li><a href="modules/engine.html">engine</a></li>
   <li><a href="modules/number.html">number</a></li>
   <li><a href="modules/grid.html">grid</a></li>
+  <li><a href="modules/arc.html">arc</a></li>
   <li><a href="modules/hid.html">hid</a></li>
   <li><a href="modules/log.html">log</a></li>
   <li><a href="modules/metro.html">metro</a></li>
@@ -91,6 +92,10 @@
 	<tr>
 		<td class="name"  nowrap><a href="modules/grid.html">grid</a></td>
 		<td class="summary">Grid class</td>
+	</tr>
+	<tr>
+		<td class="name"  nowrap><a href="modules/arc.html">arc</a></td>
+		<td class="summary">Arc class</td>
 	</tr>
 	<tr>
 		<td class="name"  nowrap><a href="modules/hid.html">hid</a></td>

--- a/doc/modules/Log.html
+++ b/doc/modules/Log.html
@@ -41,6 +41,7 @@
   <li><a href="../modules/audio.html">audio</a></li>
   <li><a href="../modules/engine.html">engine</a></li>
   <li><a href="../modules/grid.html">grid</a></li>
+  <li><a href="../modules/arc.html">arc</a></li>
   <li><a href="../modules/hid.html">hid</a></li>
   <li><strong>log</strong></li>
   <li><a href="../modules/metro.html">metro</a></li>

--- a/doc/modules/arc.html
+++ b/doc/modules/arc.html
@@ -45,11 +45,11 @@
   <li><a href="../modules/engine.html">engine</a></li>
   <li><a href="../modules/number.html">number</a></li>
   <li><a href="../modules/grid.html">grid</a></li>
-  <li><a href="../modules/arc.html">arc</a></li>
+  <li><strong>arc</strong></li>
   <li><a href="../modules/hid.html">hid</a></li>
   <li><a href="../modules/log.html">log</a></li>
   <li><a href="../modules/metro.html">metro</a></li>
-  <li><strong>midi</strong></li>
+  <li><a href="../modules/midi.html">midi</a></li>
   <li><a href="../modules/norns.html">norns</a></li>
   <li><a href="../modules/number.html">number</a></li>
   <li><a href="../modules/option.html">option</a></li>
@@ -68,42 +68,50 @@
 
 <div id="content">
 
-<h1>Module <code>midi</code></h1>
-<p>midi devices</p>
+<h1>Module <code>arc</code></h1>
+<p>Arc class</p>
 <p></p>
 
 
 <h2><a href="#Functions">Functions</a></h2>
 <table class="function_list">
 	<tr>
-	<td class="name" nowrap><a href="#new">new (id, name, dev)</a></td>
+	<td class="name" nowrap><a href="#new">new (id, serial, name, dev)</a></td>
 	<td class="summary">constructor</td>
 	</tr>
 	<tr>
 	<td class="name" nowrap><a href="#add">add (dev)</a></td>
-	<td class="summary">static callback when any midi device is added;
+	<td class="summary">static callback when any arc device is added;
  user scripts can redefine</td>
+	</tr>
+	<tr>
+	<td class="name" nowrap><a href="#reconnect">reconnect ()</a></td>
+	<td class="summary">scan device list and grab one, redefined later</td>
 	</tr>
 	<tr>
 	<td class="name" nowrap><a href="#remove">remove (dev)</a></td>
-	<td class="summary">static callback when any midi device is removed;
+	<td class="summary">static callback when any arc device is removed;
  user scripts can redefine</td>
 	</tr>
 	<tr>
-	<td class="name" nowrap><a href="#send">send (array)</a></td>
-	<td class="summary">send midi event to device</td>
+	<td class="name" nowrap><a href="#led">led (enc, led, val)</a></td>
+	<td class="summary">set state of single LED on this arc device</td>
 	</tr>
 	<tr>
-	<td class="name" nowrap><a href="#norns.midi.add">norns.midi.add (id, name, dev)</a></td>
-	<td class="summary">add a device</td>
+	<td class="name" nowrap><a href="#all">all (val)</a></td>
+	<td class="summary">set state of all LEDs on this arc device</td>
 	</tr>
 	<tr>
-	<td class="name" nowrap><a href="#norns.midi.remove">norns.midi.remove (id)</a></td>
-	<td class="summary">remove a device</td>
+	<td class="name" nowrap><a href="#refresh">refresh ()</a></td>
+	<td class="summary">update any dirty encoders on this arc device</td>
 	</tr>
 	<tr>
-	<td class="name" nowrap><a href="#norns.midi.event">norns.midi.event (id, data)</a></td>
-	<td class="summary">handle a midi event</td>
+	<td class="name" nowrap><a href="#print">print ()</a></td>
+	<td class="summary">print a description of this arc device</td>
+	</tr>
+	<tr>
+	<td class="name" nowrap><a href="#norns.arc.enc">norns.arc.enc (id, n, delta)</a></td>
+	<td class="summary">redefine global arc encoder input handler</td>
 	</tr>
 </table>
 
@@ -116,7 +124,7 @@
     <dl class="function">
     <dt>
     <a name = "new"></a>
-    <strong>new (id, name, dev)</strong>
+    <strong>new (id, serial, name, dev)</strong>
     </dt>
     <dd>
     constructor
@@ -127,6 +135,10 @@
         <li><span class="parameter">id</span>
             <span class="types"><span class="type">integer</span></span>
          : arbitrary numeric identifier
+        </li>
+        <li><span class="parameter">serial</span>
+            <span class="types"><a class="type" href="https://www.lua.org/manual/5.1/manual.html#5.4">string</a></span>
+         : serial
         </li>
         <li><span class="parameter">name</span>
             <span class="types"><a class="type" href="https://www.lua.org/manual/5.1/manual.html#5.4">string</a></span>
@@ -148,16 +160,30 @@
     <strong>add (dev)</strong>
     </dt>
     <dd>
-    static callback when any midi device is added;
+    static callback when any arc device is added;
  user scripts can redefine
 
 
     <h3>Parameters:</h3>
     <ul>
         <li><span class="parameter">dev</span>
-         : a Midi table
+         : a Arc table
         </li>
     </ul>
+
+
+
+
+
+</dd>
+    <dt>
+    <a name = "reconnect"></a>
+    <strong>reconnect ()</strong>
+    </dt>
+    <dd>
+    scan device list and grab one, redefined later
+
+
 
 
 
@@ -169,14 +195,14 @@
     <strong>remove (dev)</strong>
     </dt>
     <dd>
-    static callback when any midi device is removed;
+    static callback when any arc device is removed;
  user scripts can redefine
 
 
     <h3>Parameters:</h3>
     <ul>
         <li><span class="parameter">dev</span>
-         : a Midi table
+         : a Arc table
         </li>
     </ul>
 
@@ -186,17 +212,26 @@
 
 </dd>
     <dt>
-    <a name = "send"></a>
-    <strong>send (array)</strong>
+    <a name = "led"></a>
+    <strong>led (enc, led, val)</strong>
     </dt>
     <dd>
-    send midi event to device
+    set state of single LED on this arc device
 
 
     <h3>Parameters:</h3>
     <ul>
-        <li><span class="parameter">array</span>
-
+        <li><span class="parameter">enc</span>
+            <span class="types"><span class="type">integer</span></span>
+         : encoder index (1-based!)
+        </li>
+        <li><span class="parameter">led</span>
+            <span class="types"><span class="type">integer</span></span>
+         : LED index (1-based!)
+        </li>
+        <li><span class="parameter">val</span>
+            <span class="types"><span class="type">integer</span></span>
+         : LED brightness in [1, 16]
         </li>
     </ul>
 
@@ -206,11 +241,60 @@
 
 </dd>
     <dt>
-    <a name = "norns.midi.add"></a>
-    <strong>norns.midi.add (id, name, dev)</strong>
+    <a name = "all"></a>
+    <strong>all (val)</strong>
     </dt>
     <dd>
-    add a device
+    set state of all LEDs on this arc device
+
+
+    <h3>Parameters:</h3>
+    <ul>
+        <li><span class="parameter">val</span>
+            <span class="types"><span class="type">integer</span></span>
+         : LED brightness in [1, 16]
+        </li>
+    </ul>
+
+
+
+
+
+</dd>
+    <dt>
+    <a name = "refresh"></a>
+    <strong>refresh ()</strong>
+    </dt>
+    <dd>
+    update any dirty encoders on this arc device
+
+
+
+
+
+
+
+</dd>
+    <dt>
+    <a name = "print"></a>
+    <strong>print ()</strong>
+    </dt>
+    <dd>
+    print a description of this arc device
+
+
+
+
+
+
+
+</dd>
+    <dt>
+    <a name = "norns.arc.enc"></a>
+    <strong>norns.arc.enc (id, n, delta)</strong>
+    </dt>
+    <dd>
+    redefine global arc encoder input handler
 
 
     <h3>Parameters:</h3>
@@ -218,53 +302,10 @@
         <li><span class="parameter">id</span>
 
         </li>
-        <li><span class="parameter">name</span>
+        <li><span class="parameter">n</span>
 
         </li>
-        <li><span class="parameter">dev</span>
-
-        </li>
-    </ul>
-
-
-
-
-
-</dd>
-    <dt>
-    <a name = "norns.midi.remove"></a>
-    <strong>norns.midi.remove (id)</strong>
-    </dt>
-    <dd>
-    remove a device
-
-
-    <h3>Parameters:</h3>
-    <ul>
-        <li><span class="parameter">id</span>
-
-        </li>
-    </ul>
-
-
-
-
-
-</dd>
-    <dt>
-    <a name = "norns.midi.event"></a>
-    <strong>norns.midi.event (id, data)</strong>
-    </dt>
-    <dd>
-    handle a midi event
-
-
-    <h3>Parameters:</h3>
-    <ul>
-        <li><span class="parameter">id</span>
-
-        </li>
-        <li><span class="parameter">data</span>
+        <li><span class="parameter">delta</span>
 
         </li>
     </ul>

--- a/doc/modules/audio.html
+++ b/doc/modules/audio.html
@@ -47,6 +47,7 @@
   <li><a href="../modules/engine.html">engine</a></li>
   <li><a href="../modules/number.html">number</a></li>
   <li><a href="../modules/grid.html">grid</a></li>
+  <li><a href="../modules/arc.html">arc</a></li>
   <li><a href="../modules/hid.html">hid</a></li>
   <li><a href="../modules/log.html">log</a></li>
   <li><a href="../modules/metro.html">metro</a></li>

--- a/doc/modules/controlspec.html
+++ b/doc/modules/controlspec.html
@@ -41,6 +41,7 @@
   <li><a href="../modules/engine.html">engine</a></li>
   <li><a href="../modules/number.html">number</a></li>
   <li><a href="../modules/grid.html">grid</a></li>
+  <li><a href="../modules/arc.html">arc</a></li>
   <li><a href="../modules/hid.html">hid</a></li>
   <li><a href="../modules/log.html">log</a></li>
   <li><a href="../modules/metro.html">metro</a></li>

--- a/doc/modules/encoders.html
+++ b/doc/modules/encoders.html
@@ -41,6 +41,7 @@
   <li><a href="../modules/engine.html">engine</a></li>
   <li><a href="../modules/number.html">number</a></li>
   <li><a href="../modules/grid.html">grid</a></li>
+  <li><a href="../modules/arc.html">arc</a></li>
   <li><a href="../modules/hid.html">hid</a></li>
   <li><a href="../modules/log.html">log</a></li>
   <li><a href="../modules/metro.html">metro</a></li>

--- a/doc/modules/engine.html
+++ b/doc/modules/engine.html
@@ -45,6 +45,7 @@
   <li><strong>engine</strong></li>
   <li><a href="../modules/number.html">number</a></li>
   <li><a href="../modules/grid.html">grid</a></li>
+  <li><a href="../modules/arc.html">arc</a></li>
   <li><a href="../modules/hid.html">hid</a></li>
   <li><a href="../modules/log.html">log</a></li>
   <li><a href="../modules/metro.html">metro</a></li>

--- a/doc/modules/grid.html
+++ b/doc/modules/grid.html
@@ -45,6 +45,7 @@
   <li><a href="../modules/engine.html">engine</a></li>
   <li><a href="../modules/number.html">number</a></li>
   <li><strong>grid</strong></li>
+  <li><a href="../modules/arc.html">arc</a></li>
   <li><a href="../modules/hid.html">hid</a></li>
   <li><a href="../modules/log.html">log</a></li>
   <li><a href="../modules/metro.html">metro</a></li>

--- a/doc/modules/hid.html
+++ b/doc/modules/hid.html
@@ -45,6 +45,7 @@
   <li><a href="../modules/engine.html">engine</a></li>
   <li><a href="../modules/number.html">number</a></li>
   <li><a href="../modules/grid.html">grid</a></li>
+  <li><a href="../modules/arc.html">arc</a></li>
   <li><strong>hid</strong></li>
   <li><a href="../modules/log.html">log</a></li>
   <li><a href="../modules/metro.html">metro</a></li>

--- a/doc/modules/metro.html
+++ b/doc/modules/metro.html
@@ -46,6 +46,7 @@
   <li><a href="../modules/engine.html">engine</a></li>
   <li><a href="../modules/number.html">number</a></li>
   <li><a href="../modules/grid.html">grid</a></li>
+  <li><a href="../modules/arc.html">arc</a></li>
   <li><a href="../modules/hid.html">hid</a></li>
   <li><a href="../modules/log.html">log</a></li>
   <li><strong>metro</strong></li>

--- a/doc/modules/norns.html
+++ b/doc/modules/norns.html
@@ -49,6 +49,7 @@
   <li><a href="../modules/engine.html">engine</a></li>
   <li><a href="../modules/number.html">number</a></li>
   <li><a href="../modules/grid.html">grid</a></li>
+  <li><a href="../modules/arc.html">arc</a></li>
   <li><a href="../modules/hid.html">hid</a></li>
   <li><a href="../modules/log.html">log</a></li>
   <li><a href="../modules/metro.html">metro</a></li>
@@ -115,6 +116,10 @@
 	<tr>
 	<td class="name" nowrap><a href="#norns.grid.key">norns.grid.key (id, x, y, val)</a></td>
 	<td class="summary">grid key event</td>
+	</tr>
+	<tr>
+	<td class="name" nowrap><a href="#norns.arc.enc">norns.arc.enc (id, n, delta)</a></td>
+	<td class="summary">arc encoder event</td>
 	</tr>
 	<tr>
 	<td class="name" nowrap><a href="#norns.hid.add">norns.hid.add (id, serial, name, types, codes)</a></td>
@@ -341,6 +346,32 @@
         </li>
         <li><span class="parameter">val</span>
         print("norns.grid.key ", id,x,y,val)
+        </li>
+    </ul>
+
+
+
+
+
+</dd>
+    <dt>
+    <a name = "norns.arc.enc"></a>
+    <strong>norns.arc.enc (id, n, delta)</strong>
+    </dt>
+    <dd>
+    arc encoder event
+
+
+    <h3>Parameters:</h3>
+    <ul>
+        <li><span class="parameter">id</span>
+
+        </li>
+        <li><span class="parameter">n</span>
+
+        </li>
+        <li><span class="parameter">delta</span>
+        print("norns.arc.enc ", id,n,delta)
         </li>
     </ul>
 

--- a/doc/modules/number.html
+++ b/doc/modules/number.html
@@ -41,6 +41,7 @@
   <li><a href="../modules/engine.html">engine</a></li>
   <li><strong>number</strong></li>
   <li><a href="../modules/grid.html">grid</a></li>
+  <li><a href="../modules/arc.html">arc</a></li>
   <li><a href="../modules/hid.html">hid</a></li>
   <li><a href="../modules/log.html">log</a></li>
   <li><a href="../modules/metro.html">metro</a></li>

--- a/doc/modules/option.html
+++ b/doc/modules/option.html
@@ -41,6 +41,7 @@
   <li><a href="../modules/engine.html">engine</a></li>
   <li><a href="../modules/number.html">number</a></li>
   <li><a href="../modules/grid.html">grid</a></li>
+  <li><a href="../modules/arc.html">arc</a></li>
   <li><a href="../modules/hid.html">hid</a></li>
   <li><a href="../modules/log.html">log</a></li>
   <li><a href="../modules/metro.html">metro</a></li>

--- a/doc/modules/osc.html
+++ b/doc/modules/osc.html
@@ -45,6 +45,7 @@
   <li><a href="../modules/engine.html">engine</a></li>
   <li><a href="../modules/number.html">number</a></li>
   <li><a href="../modules/grid.html">grid</a></li>
+  <li><a href="../modules/arc.html">arc</a></li>
   <li><a href="../modules/hid.html">hid</a></li>
   <li><a href="../modules/log.html">log</a></li>
   <li><a href="../modules/metro.html">metro</a></li>

--- a/doc/modules/paramset.html
+++ b/doc/modules/paramset.html
@@ -45,6 +45,7 @@
   <li><a href="../modules/engine.html">engine</a></li>
   <li><a href="../modules/number.html">number</a></li>
   <li><a href="../modules/grid.html">grid</a></li>
+  <li><a href="../modules/arc.html">arc</a></li>
   <li><a href="../modules/hid.html">hid</a></li>
   <li><a href="../modules/log.html">log</a></li>
   <li><a href="../modules/metro.html">metro</a></li>

--- a/doc/modules/poll.html
+++ b/doc/modules/poll.html
@@ -47,6 +47,7 @@
   <li><a href="../modules/engine.html">engine</a></li>
   <li><a href="../modules/number.html">number</a></li>
   <li><a href="../modules/grid.html">grid</a></li>
+  <li><a href="../modules/arc.html">arc</a></li>
   <li><a href="../modules/hid.html">hid</a></li>
   <li><a href="../modules/log.html">log</a></li>
   <li><a href="../modules/metro.html">metro</a></li>

--- a/doc/modules/screen.html
+++ b/doc/modules/screen.html
@@ -45,6 +45,7 @@
   <li><a href="../modules/engine.html">engine</a></li>
   <li><a href="../modules/number.html">number</a></li>
   <li><a href="../modules/grid.html">grid</a></li>
+  <li><a href="../modules/arc.html">arc</a></li>
   <li><a href="../modules/hid.html">hid</a></li>
   <li><a href="../modules/log.html">log</a></li>
   <li><a href="../modules/metro.html">metro</a></li>

--- a/doc/modules/script.html
+++ b/doc/modules/script.html
@@ -45,6 +45,7 @@
   <li><a href="../modules/engine.html">engine</a></li>
   <li><a href="../modules/number.html">number</a></li>
   <li><a href="../modules/grid.html">grid</a></li>
+  <li><a href="../modules/arc.html">arc</a></li>
   <li><a href="../modules/hid.html">hid</a></li>
   <li><a href="../modules/log.html">log</a></li>
   <li><a href="../modules/metro.html">metro</a></li>

--- a/doc/modules/state.html
+++ b/doc/modules/state.html
@@ -45,6 +45,7 @@
   <li><a href="../modules/engine.html">engine</a></li>
   <li><a href="../modules/number.html">number</a></li>
   <li><a href="../modules/grid.html">grid</a></li>
+  <li><a href="../modules/arc.html">arc</a></li>
   <li><a href="../modules/hid.html">hid</a></li>
   <li><a href="../modules/log.html">log</a></li>
   <li><a href="../modules/metro.html">metro</a></li>

--- a/doc/modules/tabutil.html
+++ b/doc/modules/tabutil.html
@@ -45,6 +45,7 @@
   <li><a href="../modules/engine.html">engine</a></li>
   <li><a href="../modules/number.html">number</a></li>
   <li><a href="../modules/grid.html">grid</a></li>
+  <li><a href="../modules/arc.html">arc</a></li>
   <li><a href="../modules/hid.html">hid</a></li>
   <li><a href="../modules/log.html">log</a></li>
   <li><a href="../modules/metro.html">metro</a></li>

--- a/doc/modules/textentry.html
+++ b/doc/modules/textentry.html
@@ -41,6 +41,7 @@
   <li><a href="../modules/engine.html">engine</a></li>
   <li><a href="../modules/number.html">number</a></li>
   <li><a href="../modules/grid.html">grid</a></li>
+  <li><a href="../modules/arc.html">arc</a></li>
   <li><a href="../modules/hid.html">hid</a></li>
   <li><a href="../modules/log.html">log</a></li>
   <li><a href="../modules/metro.html">metro</a></li>

--- a/doc/modules/util.html
+++ b/doc/modules/util.html
@@ -45,6 +45,7 @@
   <li><a href="../modules/engine.html">engine</a></li>
   <li><a href="../modules/number.html">number</a></li>
   <li><a href="../modules/grid.html">grid</a></li>
+  <li><a href="../modules/arc.html">arc</a></li>
   <li><a href="../modules/hid.html">hid</a></li>
   <li><a href="../modules/log.html">log</a></li>
   <li><a href="../modules/metro.html">metro</a></li>

--- a/lua/arc.lua
+++ b/lua/arc.lua
@@ -1,0 +1,105 @@
+--- Arc class
+-- @module arc
+-- @alias Arc
+require 'norns'
+norns.version.arc = '0.0.2'
+
+
+---------------------------------
+-- Arc device class
+
+local Arc = {}
+Arc.devices = {}
+Arc.__index = Arc
+
+--- constructor
+-- @tparam integer id : arbitrary numeric identifier
+-- @tparam string serial : serial
+-- @tparam string name : name
+-- @tparam userdata dev : opaque pointer to device
+function Arc.new(id, serial, name, dev)
+  local a = setmetatable({}, Arc)
+  a.id = id
+  a.serial = serial
+  a.name = name
+  a.dev = dev -- opaque pointer
+  a.enc = nil -- encoder event callback
+  a.remove = nil -- device unplug callback
+  a.encs = arc_encs(dev)
+  return a
+end
+
+--- static callback when any arc device is added;
+-- user scripts can redefine
+-- @param dev : an Arc table
+function Arc.add(dev)
+  print("arc added", dev.id, dev.name)
+end
+
+--- scan device list and grab one, redefined later
+function Arc.reconnect()
+end
+
+--- static callback when any arc device is removed;
+-- user scripts can redefine
+-- @param dev : an Arc table
+function Arc.remove(dev)
+  -- print("Arc.remove")
+  -- dev:print()
+end
+
+--- set state of single LED on this arc device
+-- @tparam integer enc : encoder index (1-based!)
+-- @tparam integer led : led index (1-based!)
+-- @tparam integer val : LED brightness in [1, 16]
+function Arc:led(enc, led, val)
+  arc_set_led(self.dev, enc, led, val)
+end
+
+--- set state of all LEDs on this arc device
+-- @tparam integer val : LED brightness in [1, 16]
+function Arc:all(val)
+  arc_all_led(self.dev, val)
+end
+
+--- update any dirty quads on this arc device
+function Arc:refresh()
+  arc_refresh(self.dev)
+end
+
+--- print a description of this arc device
+function Arc:print()
+  for k,v in pairs(self) do
+    print('>> ', k,v)
+  end
+end
+
+-- arc devices
+norns.arc.add = function(id, serial, name, dev)
+  local a = Arc.new(id,serial,name,dev)
+  Arc.devices[id] = a
+  if Arc.add ~= nil then Arc.add(a) end
+end
+
+norns.arc.remove = function(id)
+  if Arc.devices[id] then
+    if Arc.remove ~= nil then
+      Arc.remove(Arc.devices[id])
+    end
+  end
+  Arc.devices[id] = nil
+end
+
+--- redefine global arc encoder input handler
+norns.arc.enc = function(id, n, delta)
+  local a = Arc.devices[id]
+  if a ~= nil then
+    if a.enc ~= nil then
+      a.enc(n, delta)
+    end
+  else
+    print('>> error: no entry for arc ')
+  end
+end
+
+return Arc

--- a/lua/grid.lua
+++ b/lua/grid.lua
@@ -75,26 +75,6 @@ function Grid:print()
   end
 end
 
--- -------------------------------
--- monome device manager
-
--- @fixme shouldn'e be in this module, shouldn't assume all monomes are grids
-
-norns.monome = {}
-
-norns.monome.add = function(id, serial, name, dev)
-  -- TODO: distinguish between grids and arcs
-  -- for now, assume its a grid
-  norns.grid.add(id,serial,name,dev)
-end
-
-
-norns.monome.remove = function(id)
-  -- TODO: distinguish between grids and arcs
-  -- for now, assume its a grid
-  norns.grid.remove(id)
-end
-
 -- grid devices
 norns.grid.add = function(id, serial, name, dev)
   local g = Grid.new(id,serial,name,dev)

--- a/lua/monome.lua
+++ b/lua/monome.lua
@@ -1,0 +1,23 @@
+-- monome device manager
+
+norns.monome = {}
+
+
+norns.monome.add = function(id, serial, name, dev)
+  -- TODO is there a better way to determine?
+  if (string.find(name, "arc") == nil) then
+    -- print("grid detected")
+    norns.grid.add(id,serial,name,dev)
+  else
+    -- print("arc detected")
+    norns.arc.add(id,serial,name,dev)
+  end
+end
+
+
+norns.monome.remove = function(id)
+  -- call both since we don't know if it's a grid or an arc
+  -- grid/arc functions will check for existence
+  norns.grid.remove(id)
+  norns.arc.remove(id)
+end

--- a/lua/norns.lua
+++ b/lua/norns.lua
@@ -72,6 +72,13 @@ norns.grid.key = function(id, x, y, val)
    -- print("norns.grid.key ", id,x,y,val)
 end
 
+-- arc device callbacks
+norns.arc = {}
+--- arc enc event
+norns.arc.enc = function(id, n, delta)
+   -- print("norns.arc.enc ", id,n,delta)
+end
+
 -- hid callbacks
 norns.hid = {}
 --- HID or other input device added

--- a/lua/script.lua
+++ b/lua/script.lua
@@ -14,13 +14,19 @@ Script.clear = function()
   -- redirect inputs to nowhere
   key = norns.none
   enc = norns.none
-  -- clear, redirect, and reset grid
+  -- clear, redirect, and reset grid/arc
   if g then 
     g:all(0)
     g:refresh()
     g.key = norns.none
   end
   g = nil
+  if arc then 
+    arc:all(0)
+    arc:refresh()
+    arc.enc = norns.none
+  end
+  arc = nil
   -- stop all timers
   metro.free_all()
   -- stop all polls and clear callbacks
@@ -81,6 +87,8 @@ Script.run = function()
     Script.init()
     print("reconnecting grid...")
     grid.reconnect()
+    print("reconnecting arc...")
+    arc.reconnect()
     print("reconnecting midi...")
     midi.reconnect()
   end

--- a/lua/script.lua
+++ b/lua/script.lua
@@ -88,7 +88,7 @@ Script.run = function()
     print("reconnecting grid...")
     grid.reconnect()
     print("reconnecting arc...")
-    arc.reconnect()
+    _arc.reconnect()
     print("reconnecting midi...")
     midi.reconnect()
   end

--- a/lua/startup.lua
+++ b/lua/startup.lua
@@ -1,6 +1,7 @@
 -- STARTUP 
 
 require 'menu'
+require 'monome'
 
 require 'math' 
 math.randomseed(os.time()) -- more random
@@ -8,6 +9,7 @@ math.randomseed(os.time()) -- more random
 -- globals
 screen = require 'screen'
 grid = require 'grid'
+_arc = require 'arc'
 hid = require 'hid'
 metro = require 'metro'
 midi = require 'midi'
@@ -47,6 +49,27 @@ grid.reconnect = function()
 end
 
 grid.remove = function(device) g = nil end
+
+-- management of arcs
+arc = nil
+
+_arc.add = function(device)
+  print("attaching arc ")
+  arc = device
+  arc.enc = arcenc
+  arc:print()
+  norns.log.post("connected: arc")
+end
+
+_arc.reconnect = function()
+   print("arc.reconnect (default)")
+  _, arc = next(_arc.devices) -- hacky way to get basically random item in a table
+  if arc then
+     _arc.add(arc)
+  end
+end
+
+_arc.remove = function(device) arc = nil end
 
 print("setting startup_status callbacks...")
 

--- a/matron/src/device/device_monome.h
+++ b/matron/src/device/device_monome.h
@@ -13,20 +13,26 @@ struct dev_monome {
     monome_t *m;
     uint8_t data[4][64]; // led data by quad
     bool dirty[4];       // quad-dirty flags
+    bool arc;
 };
 
 // set a single led
 extern void dev_monome_set_led(struct dev_monome *md,
                                uint8_t x, uint8_t y, uint8_t val);
+extern void dev_arc_set_led(struct dev_monome *md,
+                            uint8_t enc, uint8_t led, uint8_t val);
 // set all led
 extern void dev_monome_all_led(struct dev_monome *md, uint8_t val);
+extern void dev_arc_all_led(struct dev_monome *md, uint8_t val);
 // set all data for a quad
 extern void dev_monome_set_quad(struct dev_monome *md,
                                 uint8_t quad, uint8_t *data);
 // transmit data for all dirty quads
 extern void dev_monome_refresh(struct dev_monome *md);
+
 extern int dev_monome_grid_rows(struct dev_monome *md);
 extern int dev_monome_grid_cols(struct dev_monome *md);
+extern int dev_monome_arc_encs(struct dev_monome *md);
 
 // device management
 extern int dev_monome_init(void *self);

--- a/matron/src/event_types.h
+++ b/matron/src/event_types.h
@@ -25,6 +25,8 @@ typedef enum {
     EVENT_MONOME_REMOVE,
     // monome grid press/lift
     EVENT_GRID_KEY,
+    // monome arc encoder moved
+    EVENT_ARC_ENC,
     // libevdev device added
     EVENT_HID_ADD,
     // libevdev device removed
@@ -96,6 +98,13 @@ struct event_grid_key {
     uint8_t y;
     uint8_t state;
 }; // +4
+
+struct event_arc_enc {
+    struct event_common common;
+    uint8_t id;
+    uint8_t n;
+    int8_t delta;
+};
 
 struct event_hid_add {
     struct event_common common;
@@ -210,6 +219,7 @@ union event_data {
     struct event_monome_add monome_add;
     struct event_monome_remove monome_remove;
     struct event_grid_key grid_key;
+    struct event_arc_enc arc_enc;
     struct event_hid_add hid_add;
     struct event_hid_remove hid_remove;
     struct event_hid_event hid_event;

--- a/matron/src/events.c
+++ b/matron/src/events.c
@@ -196,6 +196,11 @@ static void handle_event(union event_data *ev) {
                           ev->grid_key.y,
                           ev->grid_key.state);
         break;
+    case EVENT_ARC_ENC:
+        w_handle_arc_enc(ev->arc_enc.id,
+                         ev->arc_enc.n,
+                         ev->arc_enc.delta);
+        break;
     case EVENT_HID_ADD:
         w_handle_hid_add(ev->hid_add.dev);
         break;

--- a/matron/src/weaver.c
+++ b/matron/src/weaver.c
@@ -63,6 +63,11 @@ static int _grid_all_led(lua_State *l);
 static int _grid_refresh(lua_State *l);
 static int _grid_rows(lua_State *l);
 static int _grid_cols(lua_State *l);
+// arc
+static int _arc_set_led(lua_State *l);
+static int _arc_all_led(lua_State *l);
+static int _arc_refresh(lua_State *l);
+static int _arc_encs(lua_State *l);
 //screen
 static int _screen_update(lua_State *l);
 static int _screen_font_face(lua_State *l);
@@ -188,6 +193,12 @@ void w_init(void) {
   lua_register(lvm, "grid_refresh", &_grid_refresh);
   lua_register(lvm, "grid_rows", &_grid_rows);
   lua_register(lvm, "grid_cols", &_grid_cols);
+
+  // low-level monome arc control
+  lua_register(lvm, "arc_set_led", &_arc_set_led);
+  lua_register(lvm, "arc_all_led", &_arc_all_led);
+  lua_register(lvm, "arc_refresh", &_arc_refresh);
+  lua_register(lvm, "arc_encs", &_arc_encs);
 
   // register screen funcs
   lua_register(lvm, "s_update", &_screen_update);
@@ -967,6 +978,81 @@ int _grid_cols(lua_State *l) {
   return 1;
 }
 
+/***
+ * arc: set led
+ * @function arc_set_led
+ * @param dev arc device
+ * @param enc enc
+ * @param led led
+ * @param val level (0-15)
+ */
+int _arc_set_led(lua_State *l) {
+  if (lua_gettop(l) != 4) {
+    return luaL_error(l, "wrong number of arguments");
+  }
+
+  luaL_checktype(l, 1, LUA_TLIGHTUSERDATA);
+  struct dev_monome *md = lua_touserdata(l, 1);
+  int enc = (int) luaL_checkinteger(l, 2) - 1; // convert from 1-base
+  int led = (int) luaL_checkinteger(l, 3) - 1; // convert from 1-base
+  int val = (int) luaL_checkinteger(l, 4); // don't convert value!
+  dev_arc_set_led(md, enc, led, val);
+  lua_settop(l, 0);
+  return 0;
+}
+
+/***
+ * arc: set all LEDs
+ * @function arc_all_led
+ * @param dev arc device
+ * @param val level (0-15)
+ */
+int _arc_all_led(lua_State *l) {
+  if (lua_gettop(l) != 2) {
+    return luaL_error(l, "wrong number of arguments");
+  }
+
+  luaL_checktype(l, 1, LUA_TLIGHTUSERDATA);
+  struct dev_monome *md = lua_touserdata(l, 1);
+  int val = (int) luaL_checkinteger(l, 2); // don't convert value!
+  dev_arc_all_led(md, val);
+  lua_settop(l, 0);
+  return 0;
+}
+
+/***
+ * arc: refresh
+ * @function arc_refresh
+ * @param dev arc device
+ */
+int _arc_refresh(lua_State *l) {
+  if (lua_gettop(l) != 1) {
+    return luaL_error(l, "wrong number of arguments");
+  }
+
+  luaL_checktype(l, 1, LUA_TLIGHTUSERDATA);
+  struct dev_monome *md = lua_touserdata(l, 1);
+  dev_monome_refresh(md);
+  lua_settop(l, 0);
+  return 0;
+}
+
+/***
+ * arc: encs
+ * @function arc_encs
+ * @param dev arc device
+ */
+int _arc_encs(lua_State *l) {
+  if (lua_gettop(l) != 1) {
+    return luaL_error(l, "wrong number of arguments");
+  }
+
+  luaL_checktype(l, 1, LUA_TLIGHTUSERDATA);
+  struct dev_monome *md = lua_touserdata(l, 1);
+  lua_pushinteger(l, dev_monome_arc_encs(md));
+  return 1;
+}
+
 //-- audio processing controls
 int _load_engine(lua_State *l) {
   if (lua_gettop(l) != 1) {
@@ -1160,6 +1246,16 @@ _call_grid_handler(int id, int x, int y, int state) {
   l_report(lvm, l_docall(lvm, 4, 0));
 }
 
+// helper for calling arc handlers
+static inline void
+_call_arc_handler(int id, int n, int delta) {
+  _push_norns_func("arc", "enc");
+  lua_pushinteger(lvm, id + 1); // convert to 1-base
+  lua_pushinteger(lvm, n + 1);  // convert to 1-base
+  lua_pushinteger(lvm, delta);
+  l_report(lvm, l_docall(lvm, 3, 0));
+}
+
 void w_handle_monome_add(void *mdev) {
   struct dev_monome *md = (struct dev_monome *)mdev;
   int id = md->dev.id;
@@ -1181,6 +1277,11 @@ void w_handle_monome_remove(int id) {
 
 void w_handle_grid_key(int id, int x, int y, int state) {
   _call_grid_handler(id, x, y, state > 0);
+}
+
+void w_handle_arc_enc(int id, int n, int delta) {
+  _call_arc_handler(id, n, delta);
+  // fprintf(stderr, "w_handle_arc_enc: %d %d %d\n", id, n, delta);
 }
 
 void w_handle_hid_add(void *p) {

--- a/matron/src/weaver.h
+++ b/matron/src/weaver.h
@@ -28,6 +28,7 @@ extern void w_handle_exec_code_line(char *line);
 extern void w_handle_monome_add(void *dev);
 extern void w_handle_monome_remove(int id);
 extern void w_handle_grid_key(int id, int x, int y, int state);
+extern void w_handle_arc_enc(int id, int n, int delta);
 
 extern void w_handle_hid_add(void *dev);
 extern void w_handle_hid_remove(int id);


### PR DESCRIPTION
arc support. i mostly copied the grid implementation, trying to re-use monome naming/functions were possible. i did have to introduce arc specific methods for LED rendering as it's done differently for arcs.

there is a couple of issues with this implementation:
- it will return 0 for number of encoders - from what i can tell libmonome doesn't currently support it, i'll add it once i have a chance to add it to libmonome
- it breaks (error messages in REPL suggest some memory corruption, and then at some point it hangs) if both grid and arc are connected and LEDs are set on both (or if refresh is called). they seem to work separately fine, or if you only update one or the other, so i think it should still be okay to merge this, and i'll fix it in a separate PR.

didn't want to create a global variable `a` so used `arc` instead.