### PR TITLE
script loading experiments (experimental)

### DIFF
--- a/lua/script.lua
+++ b/lua/script.lua
@@ -44,6 +44,40 @@ Script.init = function()
   end
 end
 
+local function do_load(file)
+  -- print(">> loading from... "..file)
+  
+  -- carve out some space in the global env to track our state
+  _G.__norns_init_state = { }
+
+  local wrapper = { 
+    __index = _G,
+    __newindex = function(_, k, v) 
+      -- store written state for later inspection
+      _G.__norns_init_state[k] = v
+      _G[k] = v
+    end,
+  }
+
+  local env = { }
+  setmetatable(env, wrapper)
+
+  local chunk, status = assert(loadfile(file, "bt", env))
+  if chunk then
+    chunk()
+  end
+
+  -- review overwritten state
+  print("*** overwritten globals: ")
+  for k,_ in pairs(_G.__norns_init_state) do 
+    print("  "..tostring(k))
+  end
+
+  -- todo: consider another metatable and not write to _G (or blanking __norns_init_state)
+
+  return status
+end
+
 --- load a script from the /scripts folder
 -- @param filename (string) - file to load. leave blank to reload current file.
 Script.load = function(filename)
@@ -61,7 +95,7 @@ Script.load = function(filename)
 
     Script.clear() -- clear script variables and functions
     
-    local status = norns.try(function() dofile(filepath) end, "load fail") -- do the new script
+    local status = norns.try(function() do_load(filepath) end, "load fail") -- do the new script
     if status == true then
       norns.log.post("loaded " .. filename) -- post to log
       norns.state.script = filename -- store script name

--- a/lua/script.lua
+++ b/lua/script.lua
@@ -67,8 +67,8 @@ local function do_load(file)
     chunk()
   end
 
-  -- review overwritten state
-  print("*** overwritten globals: ")
+  -- review written state
+  print("*** written globals: ")
   for k,_ in pairs(_G.__norns_init_state) do 
     print("  "..tostring(k))
   end


### PR DESCRIPTION
**(experimental)**

replacing `dofile`  with `loadfile` allows us to pass an env into which script globals get loaded.  this experiment introduces a simple proxy env that is essentially a pass-through to `_G`.  minimally, this proxy gives us hooks to monitor or police global access and (re)definition.  taking it further we could consider expanding on this approach in the service of sandboxing #258.

anyway, this is more modest than that.  as a drop-in replacement for our current `dofile` approach it should “just work” and gives us the opportunity to at least report un-toward re-writes of globals (see: #425).

_note: i’m not proposing this land as is but rather see it as food for thought.  hoping it moves the conversation along._

/cc @catfact @ngwese @tehn 