### PR TITLE
ws-wrapper: exec child with correct argv

### DIFF
--- a/crone.sh
+++ b/crone.sh
@@ -3,6 +3,5 @@
 # do not try reserving device (disable dbus)
 export JACK_NO_AUDIO_RESERVATION=1
 
-# ipc wrapper requires full path 
 SCLANG=$(which sclang)
-./build/ws-wrapper/ws-wrapper $SCLANG ws://*:5556
+./build/ws-wrapper/ws-wrapper ws://*:5556 $SCLANG

--- a/matron.sh
+++ b/matron.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-./build/ws-wrapper/ws-wrapper ./build/matron/matron ws://*:5555
+./build/ws-wrapper/ws-wrapper ws://*:5555 ./build/matron/matron

--- a/ws-wrapper/src/main.c
+++ b/ws-wrapper/src/main.c
@@ -83,10 +83,10 @@ void launch_thread(pthread_t *tid, void *(*start_routine)(void *),
     pthread_attr_destroy(&attr);
 }
 
-int launch_exe( int argc,  char **argv) {
+int launch_exe(int argc,  char **argv) {
     (void)argc;
-    char *exe = argv[1];
-    char *url_ws = argv[2];
+    char *url_ws = argv[1];
+    char *exe = argv[2];
 
     // create pipes
     if(pipe(pipe_rx) < 0) {
@@ -129,9 +129,9 @@ int launch_exe( int argc,  char **argv) {
         close(pipe_tx[PIPE_WRITE]);
 
         // launch the child executable
-        char **child_argv = &(argv[4]);
-        execv(exe, child_argv);
-        perror("execv"); // shouldn't get here
+        char **child_argv = &(argv[2]);
+        execvp(exe, child_argv);
+        perror("execvp"); // shouldn't get here
     } else {
         // parent continues...
 
@@ -169,10 +169,10 @@ int launch_exe( int argc,  char **argv) {
     return 0;
 }
 
-int main( int argc,  char **argv) {
+int main(int argc,  char **argv) {
     if(argc < 3) {
         printf(
-            "usage: ws-wrapper BINARY WS_SOCKET <child args...>");
+            "usage: ws-wrapper WS_SOCKET BINARY <child args...>");
     }
 
     launch_exe(argc, argv);


### PR DESCRIPTION
- move WS_SOCKET arg before exec [+args]
- treat all args after WS_SOCKET as child args
- fix out of bounds indexing into parent argv
- switch execv to execvp allowing exe to be found via PATH

NOTE: merging this requires merging the companion changes to the systemd units in `norns-image` (forthcoming PR).