### PR TITLE
Support spaces in Wi-Fi network SSIDs and passwords

### DIFF
--- a/lua/menu.lua
+++ b/lua/menu.lua
@@ -1032,7 +1032,7 @@ end
 
 m.wifi.passdone = function(txt)
   if txt ~= nil then
-    os.execute("~/norns/wifi.sh select "..m.wifi.try.." "..txt.." &")
+    os.execute("~/norns/wifi.sh select \""..m.wifi.try.."\" \""..txt.."\" &")
     wifi.on()
   end
   menu.redraw()

--- a/lua/textentry.lua
+++ b/lua/textentry.lua
@@ -4,7 +4,7 @@ local te = {}
 
 te.enter = function(callback, default)
   te.txt = default or ""
-  te.pos = 27
+  te.pos = 28
   if default then te.row=1 else te.row = 0 end
   te.delok = 1
   te.callback = callback
@@ -47,7 +47,7 @@ te.key = function(n,z)
     te.exit()
   elseif n==3 and z==1 then
     if te.row == 0 then
-      local ch = ((5+te.pos)%94)+33
+      local ch = ((5+te.pos)%95)+32
       te.txt = te.txt .. string.char(ch)
       te.redraw()
     else
@@ -68,7 +68,7 @@ te.enc = function(n,delta)
     if te.row == 1 then
       if delta > 0 then te.delok = 1
       else te.delok = 0 end
-    else te.pos = (te.pos + delta) % 94 end
+    else te.pos = (te.pos + delta) % 95 end
     te.redraw()
   elseif n==3 then
     if delta > 0 then te.row = 1
@@ -86,7 +86,7 @@ te.redraw = function()
   for x=0,15 do
     if x==5 and te.row==0 then screen.level(15) else screen.level(2) end
     screen.move(x*8,46)
-    screen.text(string.char((x+te.pos)%94+33))
+    screen.text(string.char((x+te.pos)%95+32))
   end
 
   screen.move(0,60)


### PR DESCRIPTION
I'm one of those unlucky people whose home wifi network has a space both in the network SSID and the password. This PR contains the following changes, which allow me to connect:
* Adds a space character to `textentry.lua`. The space is rendered as a space; a good future enhancement might be to display some kind of dim _ character to make selecting and entering it clearer.
* Quotes the network SSID and password arguments when calling `wifi.sh select`.