### PR TITLE
[experiment] script state metatable

### DIFF
--- a/lua/script.lua
+++ b/lua/script.lua
@@ -50,6 +50,19 @@ Script.load = function(filename)
   print("# script load")
   if filename == nil then
     filename = norns.state.script end
+
+  -- script local state  
+  local state = { }
+
+  setmetatable(_G, {
+    __index = function (t,k)
+      return state[k]
+    end,
+    __newindex = function(t,k,v)
+      state[k] = v
+    end,
+  })
+
   local filepath = script_dir .. filename
   local f=io.open(filepath,"r")
   if f==nil then


### PR DESCRIPTION
another script environment management experiment. 

sets up a metatable for script state allowing scripts to shadow but not clobber state in `_G` [1]. script state is zeroed on script runs so scripts don't accumulate surprising state.

unlike #426 which introduces a fresh env that scripts are loaded into, this continues to use `_G` and so the repl "just works".

(tested on grid apps; not midi.)

see also: #258 

/cc @catfact @tehn @ngwese 

---
[1] qualification: "shallow" state or something; writing into (pre)existing tables in `_G` will stick.