### PR TITLE
reset midi callbacks on script clear

### DIFF
--- a/lua/script.lua
+++ b/lua/script.lua
@@ -23,6 +23,9 @@ Script.clear = function()
   g = nil
   -- reset gridkey callback
   gridkey = norns.none
+  -- reset midi callbacks
+  midi.add = norns.none
+  midi.remove = norns.none
   -- stop all timers
   metro.free_all()
   -- stop all polls and clear callbacks


### PR DESCRIPTION
follow-up from https://github.com/monome/dust/pull/131#discussion_r198365764.

to be clear, i have no midi devices handy but based on a related fix for `gridkey` (https://github.com/monome/norns/commit/2e6762b409db0186156772137d1462734fc9ccd6) i'm thinking this is probably right.  would be awesome if someone could confirm. 👍 

/cc @artfwo @tehn 

