### PR TITLE
Disable acceleration within menu

### DIFF
--- a/lua/menu.lua
+++ b/lua/menu.lua
@@ -302,9 +302,11 @@ menu.set_mode = function(mode)
     screen.line_width(1)
     menu.set_page(menu.page)
     norns.encoders.callback = menu.enc
-    norns.encoders.set_accel(0,true)
+    norns.encoders.set_accel(1,true)
     norns.encoders.set_sens(1,1)
+    norns.encoders.set_accel(2,false)
     norns.encoders.set_sens(2,0.5)
+    norns.encoders.set_accel(3,true)
     norns.encoders.set_sens(3,0.5)
   end
 end


### PR DESCRIPTION
This is a revised version of #467 that only disables acceleration for encoder 2.

Tested navigating through very long and very short menus alike, and it seems good.

Issue #376