### PR TITLE
remove functionality for duplicate device names

### DIFF
--- a/lua/grid.lua
+++ b/lua/grid.lua
@@ -34,9 +34,9 @@ function Grid.new(id, serial, name, dev)
   g.id = id
   g.serial = serial
   name = name .. " " .. serial
-  while tab.contains(Grid.list,name) do
-    name = name .. "+"
-  end
+  --while tab.contains(Grid.list,name) do
+    --name = name .. "+"
+  --end
   g.name = name
   g.dev = dev -- opaque pointer
   g.key = nil -- key event callback

--- a/lua/midi.lua
+++ b/lua/midi.lua
@@ -26,9 +26,9 @@ function Midi.new(id, name, dev)
   local d = setmetatable({}, Midi)
   d.id = id
   -- append duplicate device names
-  while tab.contains(Midi.list,name) do
-    name = name .. "+"
-  end
+  --while tab.contains(Midi.list,name) do
+    --name = name .. "+"
+  --end
   d.name = name
   d.dev = dev -- opaque pointer
   d.event = nil -- event callback


### PR DESCRIPTION
since USB device removal is flaky (due to the last update to make midi and grids coexist, while we debug the linux usb system) the functionality for same-named usb device causes more problems and does not work correctly.

temporarily commented out until the linux usb is fixed.