### PR TITLE
MIDI channel pressure

### DIFF
--- a/lua/midi.lua
+++ b/lua/midi.lua
@@ -132,8 +132,11 @@ function Midi.connect(n)
   d.pitchbend = function(val, ch)
       d.send{type="pitchbend", val=val, ch=ch or 1}
     end
-  d.aftertouch = function(note, val, ch)
-      d.send{type="aftertouch", note=note, val=val, ch=ch or 1}
+  d.key_pressure = function(note, val, ch)
+      d.send{type="key_pressure", note=note, val=val, ch=ch or 1}
+    end
+  d.channel_pressure = function(val, ch)
+      d.send{type="channel_pressure", val=val, ch=ch or 1}
     end
   return d
 end
@@ -163,8 +166,11 @@ local to_data = {
   pitchbend = function(msg)
       return {0xe0 + (msg.ch or 1) - 1, msg.val & 0x7f, (msg.val >> 7) & 0x7f}
     end,
-  aftertouch = function(msg)
+  key_pressure = function(msg)
       return {0xa0 + (msg.ch or 1) - 1, msg.note, msg.val}
+    end,
+  channel_pressure = function(msg)
+      return {0xd0 + (msg.ch or 1) - 1, msg.val}
     end
 }
 
@@ -210,13 +216,20 @@ function Midi.to_msg(data)
       val = data[2] + (data[3] << 7),
       ch = data[1] - 0xe0 + 1
     }
-  -- aftertouch
+  -- key pressure
   elseif data[1] & 0xf0 == 0xa0 then
     msg = {
-      type = "aftertouch",
+      type = "key_pressure",
       note = data[2],
       val = data[3],
       ch = data[1] - 0xa0 + 1
+    }
+  -- channel pressure
+  elseif data[1] & 0xf0 == 0xd0 then
+    msg = {
+      type = "channel_pressure",
+      val = data[2],
+      ch = data[1] - 0xd0 + 1
     }
   -- everything else
   else


### PR DESCRIPTION
Added support for 'channel pressure' to midi.lua
Also suggesting to rename polyphonic 'aftertouch' -> 'key pressure' for clarity.

This ref seems to use this as preferred naming but I can revert if need be: https://www.midi.org/specifications-old/item/table-1-summary-of-midi-message

Note: I don't have a device which supports polyphonic key pressure to double check it but it should be fine :)