### PR TITLE
Fixes to grid reconnect, cols and rows, midi attached status.

### DIFF
--- a/lua/grid.lua
+++ b/lua/grid.lua
@@ -51,15 +51,11 @@ function Grid.new(id, serial, name, dev)
   local connected = {}
   for i=1,4 do
     table.insert(connected, Grid.vport[i].name)
-    table.insert(connected, Grid.vport[i].cols)
-    table.insert(connected, Grid.vport[i].rows)
   end
   if not tab.contains(connected, name) then
     for i=1,4 do
       if Grid.vport[i].name == "none" then
         Grid.vport[i].name = name
-        Grid.vport[i].cols = grid_cols(dev)
-        Grid.vport[i].rows = grid_rows(dev)
         break
       end
     end
@@ -120,6 +116,8 @@ function Grid.connect(n)
   local d = {
     index = Grid.vport[n].index,
     port = n,
+    cols = function() return Grid.vport[n].cols end,
+    rows = function() return Grid.vport[n].rows end,
     event = function(x,y,z)
         print("grid input")
       end,
@@ -128,7 +126,9 @@ function Grid.connect(n)
     all = function(val) Grid.vport[n].all(val) end,
     refresh = function() Grid.vport[n].refresh() end,
     disconnect = function(self)
-        self.send = function() print("not connected") end
+        self.led = function() end
+        self.all = function() end
+        self.refresh = function() print("refresh: grid not connected") end
         Grid.vport[self.port].callbacks[self.index] = nil
         self.index = nil
         self.port = nil
@@ -138,12 +138,16 @@ function Grid.connect(n)
         if self.index then
           Grid.vport[self.port].callbacks[self.index] = nil
         end
-        self.send = function(data) Grid.vport[p].send(data) end
-        attached = function() return Grid.vport[p].attached end
+        self.attached = function() return Grid.vport[p].attached end
+        self.led = function(x,y,z) Grid.vport[p].led(x,y,z) end
+        self.all = function(val) Grid.vport[p].all(val) end
+        self.refresh = function() Grid.vport[p].refresh() end
         Grid.vport[p].index = Grid.vport[p].index + 1
         self.index = Grid.vport[p].index
         self.port = p
-        Grid.vport[p].callbacks[self.index] = function(data) self.event(data) end
+        self.cols = function() return Grid.vport[p].cols end
+        self.rows = function() return Grid.vport[p].rows end
+        Grid.vport[p].callbacks[self.index] = function(x,y,z) self.event(x,y,z) end
       end
   }
 
@@ -173,8 +177,12 @@ function Grid.update_devices()
     Grid.vport[i].led = function(x, y, val) end
     Grid.vport[i].all = function(val) end
     Grid.vport[i].refresh = function() end
+    Grid.vport[i].cols = 0
+    Grid.vport[i].rows = 0
     for _,device in pairs(Grid.devices) do
       if device.name == Grid.vport[i].name then
+        Grid.vport[i].cols = device.cols
+        Grid.vport[i].rows = device.rows
         Grid.vport[i].led = function(x, y, val) device:led(x, y, val) end
         Grid.vport[i].all = function(val) device:all(val) end
         Grid.vport[i].refresh = function() device:refresh() end

--- a/lua/midi.lua
+++ b/lua/midi.lua
@@ -109,7 +109,7 @@ function Midi.connect(n)
           Midi.vport[self.port].callbacks[self.index] = nil
         end
         self.send = function(data) Midi.vport[p].send(data) end
-        attached = function() return Midi.vport[p].attached end
+        self.attached = function() return Midi.vport[p].attached end
         Midi.vport[p].index = Midi.vport[p].index + 1
         self.index = Midi.vport[p].index
         self.port = p


### PR DESCRIPTION
Found a few odd things working with grids and midi today, here are some fixes:

- Grids now work after `reconnect`. Looked like some things had been copied across from midi that needed updating(?)
- Moved the grid cols/rows code to the `update_devices` method and tidied a bit. They weren't updating correctly on hot swap before, this seems to fix.
- Additionally, I've exposed grid cols/rows so you can access them like this:
`my_grid = grid.connect(1)`
`print(my_grid.cols())`

- MIDI `attached` function just seemed to be missing `self.` when reconnecting.

These are two classes I'm not very familiar with so please give these changes a good looking over 😄 
