### PR TITLE
fix battery read buffer size

### DIFF
--- a/matron/src/hardware/battery.c
+++ b/matron/src/hardware/battery.c
@@ -19,7 +19,7 @@
 #define BATTERY_POLL_INTERVAL 5
 
 static int fd[3];
-static char buf[7];
+static char buf[8];
 static pthread_t p;
 
 void *battery_check(void *);


### PR DESCRIPTION
this fixes a compiler warning, since we read 8 bytes into the buffer from `/sys/class/power_supply/bq27441-0/current_now`