### PR TITLE
map incoming osc to params

### DIFF
--- a/lua/menu.lua
+++ b/lua/menu.lua
@@ -48,7 +48,7 @@ menu.scripterror = false
 menu.errormsg = ""
 
 -- mix paramset
-mix = paramset.new()
+mix = paramset.new("mix", "mix")
 cs.MAIN_LEVEL = cs.new(-math.huge,0,'db',0,0,"dB")
 mix:add_control("output", "output", cs.MAIN_LEVEL)
 mix:set_action("output",

--- a/lua/paramset.lua
+++ b/lua/paramset.lua
@@ -16,19 +16,22 @@ local ParamSet = {
   tCONTROL = 3,
   tFILE = 4,
   tTAPER = 5,
-  tTRIGGER = 6
+  tTRIGGER = 6,
+  sets = {}
 }
 
 ParamSet.__index = ParamSet
 
 --- constructor
 -- @param name
-function ParamSet.new(name)
+function ParamSet.new(id, name)
   local ps = setmetatable({}, ParamSet)
+  ps.id = id or ""
   ps.name = name or ""
   ps.params = {}
   ps.count = 0
   ps.lookup = {}
+  ParamSet.sets[ps.id] = ps
   return ps
 end
 


### PR DESCRIPTION
fixes #501 

incoming numeric osc param values should be within the specific parameter range (i.e. -80, 20). file and option params require string argument value.