### PR TITLE
add info to print statement on maxing out metro.alloc

### DIFF
--- a/lua/metro.lua
+++ b/lua/metro.lua
@@ -34,7 +34,7 @@ function Metro.alloc (cb, time, count)
 	if count then m.count= count end
 	return m
     end
-    print("metro.alloc: already used max numbert of allocated script metros")
+    print("metro.alloc: already used max number of allocated script metros")
     return nil
 end
 

--- a/lua/metro.lua
+++ b/lua/metro.lua
@@ -34,7 +34,7 @@ function Metro.alloc (cb, time, count)
 	if count then m.count= count end
 	return m
     end
-    print("metro.alloc: nothing available")
+    print("metro.alloc: already used max numbert of allocated script metros")
     return nil
 end
 


### PR DESCRIPTION
I ran into an issue where I had allocated too many metros.  I wasn't sure what the statement "nothing available" meant, so I had to go look through the code.  This pr just updates what is printed to the REPL in this case to something a bit less ambiguous.