### PR TITLE
Add formatters to numbers

### DIFF
--- a/lua/params/number.lua
+++ b/lua/params/number.lua
@@ -6,7 +6,7 @@ Number.__index = Number
 
 local tNUMBER = 1
 
-function Number.new(id, name, min, max, default)
+function Number.new(id, name, min, max, default, formatter)
   local o = setmetatable({}, Number)
   o.t = tNUMBER
   o.id = id
@@ -15,6 +15,7 @@ function Number.new(id, name, min, max, default)
   o.value = o.default
   o.min = min or -2147483648
   o.max = max or 2147483647 -- 32 bit signed
+  o.formatter = formatter
   o.action = function() end
   return o
 end
@@ -44,7 +45,11 @@ function Number:bang()
 end
 
 function Number:string()
-  return self.value
+  if self.formatter then
+    return self.formatter(self)
+  else
+    return self.value
+  end
 end
 
 

--- a/lua/paramset.lua
+++ b/lua/paramset.lua
@@ -61,7 +61,7 @@ function ParamSet:add(args)
     local name = args.name or id
 
     if args.type == "number"  then
-      param = number.new(id, name, args.min, args.max, args.default)
+      param = number.new(id, name, args.min, args.max, args.default, args.formatter)
     elseif args.type == "option" then
       param = option.new(id, name, args.options, args.default)
     elseif args.type == "control" then
@@ -87,8 +87,8 @@ function ParamSet:add(args)
 end
 
 --- add number
-function ParamSet:add_number(id, name, min, max, default)
-  self:add { param=number.new(id, name, min, max, default) }
+function ParamSet:add_number(id, name, min, max, default, formatter)
+  self:add { param=number.new(id, name, min, max, default, formatter) }
 end
 
 --- add option


### PR DESCRIPTION
This adds formatters to numbers, just as controls can have.
Not sure if this goes against design plans but it's useful for displaying MIDI note names in the params menu.