### PR TITLE
grid rotation

### DIFF
--- a/lua/grid.lua
+++ b/lua/grid.lua
@@ -18,6 +18,7 @@ for i=1,4 do
     index = 0,
     led = function() end,
     all = function() end,
+    rotation = function() end,
     refresh = function() end,
     cols = 0,
     rows = 0,
@@ -79,6 +80,12 @@ function Grid.reconnect() end
 -- @param dev : a Grid table
 function Grid.remove(dev) end
 
+-- set grid rotation
+-- @tparam integer val : rotation 0,90,180,270 as [0, 3]
+function Grid:rotation(val)
+  grid_set_rotation(self.dev, val)
+end
+
 --- set state of single LED on this grid device
 -- @tparam integer x : column index (1-based!)
 -- @tparam integer y : row index (1-based!)
@@ -124,10 +131,12 @@ function Grid.connect(n)
     attached = function() return Grid.vport[n].attached end,
     led = function(x,y,z) Grid.vport[n].led(x,y,z) end,
     all = function(val) Grid.vport[n].all(val) end,
+    rotation = function(val) Grid.vport[n].rotation(val) end,
     refresh = function() Grid.vport[n].refresh() end,
     disconnect = function(self)
         self.led = function() end
         self.all = function() end
+        self.rotation = function() end
         self.refresh = function() print("refresh: grid not connected") end
         Grid.vport[self.port].callbacks[self.index] = nil
         self.index = nil
@@ -141,6 +150,7 @@ function Grid.connect(n)
         self.attached = function() return Grid.vport[p].attached end
         self.led = function(x,y,z) Grid.vport[p].led(x,y,z) end
         self.all = function(val) Grid.vport[p].all(val) end
+        self.rotation = function(val) Grid.vport[p].rotation(val) end
         self.refresh = function() Grid.vport[p].refresh() end
         Grid.vport[p].index = Grid.vport[p].index + 1
         self.index = Grid.vport[p].index
@@ -176,6 +186,7 @@ function Grid.update_devices()
     Grid.vport[i].attached = false
     Grid.vport[i].led = function(x, y, val) end
     Grid.vport[i].all = function(val) end
+    Grid.vport[i].rotation = function(val) end
     Grid.vport[i].refresh = function() end
     Grid.vport[i].cols = 0
     Grid.vport[i].rows = 0
@@ -185,6 +196,7 @@ function Grid.update_devices()
         Grid.vport[i].rows = device.rows
         Grid.vport[i].led = function(x, y, val) device:led(x, y, val) end
         Grid.vport[i].all = function(val) device:all(val) end
+        Grid.vport[i].rotation = function(val) device:rotation(val) end
         Grid.vport[i].refresh = function() device:refresh() end
         Grid.vport[i].attached = true
         table.insert(device.ports, i)

--- a/matron/src/device/device_monome.c
+++ b/matron/src/device/device_monome.c
@@ -80,6 +80,16 @@ static inline uint8_t dev_monome_quad_offset(uint8_t x, uint8_t y) {
     return ( (y & 7) * 8 ) + (x & 7);
 }
 
+// set grid rotation
+void dev_monome_set_rotation(struct dev_monome *md, uint8_t rotation) {
+	monome_set_rotation(md->m, rotation);
+/*		MONOME_ROTATE_0    = 0
+		MONOME_ROTATE_90   = 1
+		MONOME_ROTATE_180  = 2
+		MONOME_ROTATE_270  = 3
+*/
+}
+
 // set a given LED value
 void dev_monome_grid_set_led(struct dev_monome *md,
                              uint8_t x, uint8_t y, uint8_t val) {

--- a/matron/src/device/device_monome.c
+++ b/matron/src/device/device_monome.c
@@ -83,11 +83,6 @@ static inline uint8_t dev_monome_quad_offset(uint8_t x, uint8_t y) {
 // set grid rotation
 void dev_monome_set_rotation(struct dev_monome *md, uint8_t rotation) {
 	monome_set_rotation(md->m, rotation);
-/*		MONOME_ROTATE_0    = 0
-		MONOME_ROTATE_90   = 1
-		MONOME_ROTATE_180  = 2
-		MONOME_ROTATE_270  = 3
-*/
 }
 
 // set a given LED value

--- a/matron/src/device/device_monome.h
+++ b/matron/src/device/device_monome.h
@@ -35,6 +35,9 @@ extern void dev_monome_refresh(struct dev_monome *md);
 extern int dev_monome_grid_rows(struct dev_monome *md);
 extern int dev_monome_grid_cols(struct dev_monome *md);
 
+// set grid rotation
+extern void dev_monome_set_rotation(struct dev_monome *md, uint8_t val);
+
 // device management
 extern int dev_monome_init(void *self);
 extern void dev_monome_deinit(void *self);

--- a/matron/src/weaver.c
+++ b/matron/src/weaver.c
@@ -1045,7 +1045,7 @@ int _arc_all_led(lua_State *l) {
 /***
  * grid: set rotation
  * @param dev grid device
- * @param z (rotation 0-3)
+ * @param z (rotation 0-3 - or is it 0,90,180,270?)
  */
 int _grid_set_rotation(lua_State *l) {
   if (lua_gettop(l) != 2) {

--- a/matron/src/weaver.c
+++ b/matron/src/weaver.c
@@ -62,6 +62,8 @@ static int _grid_set_led(lua_State *l);
 static int _grid_all_led(lua_State *l);
 static int _grid_rows(lua_State *l);
 static int _grid_cols(lua_State *l);
+static int _grid_set_rotation(lua_State *l);
+
 static int _arc_set_led(lua_State *l);
 static int _arc_all_led(lua_State *l);
 static int _monome_refresh(lua_State *l);
@@ -198,6 +200,7 @@ void w_init(void) {
   lua_register(lvm, "grid_all_led", &_grid_all_led);
   lua_register(lvm, "grid_rows", &_grid_rows);
   lua_register(lvm, "grid_cols", &_grid_cols);
+  lua_register(lvm, "grid_set_rotation", &_grid_set_rotation);
   lua_register(lvm, "arc_set_led", &_arc_set_led);
   lua_register(lvm, "arc_all_led", &_arc_all_led);
   lua_register(lvm, "monome_refresh", &_monome_refresh);
@@ -1037,6 +1040,24 @@ int _grid_all_led(lua_State *l) {
 
 int _arc_all_led(lua_State *l) {
   return _grid_all_led(l);
+}
+
+/***
+ * grid: set rotation
+ * @param dev grid device
+ * @param z (rotation 0-3)
+ */
+int _grid_set_rotation(lua_State *l) {
+  if (lua_gettop(l) != 2) {
+    return luaL_error(l, "wrong number of arguments");
+  }
+
+  luaL_checktype(l, 1, LUA_TLIGHTUSERDATA);
+  struct dev_monome *md = lua_touserdata(l, 1);
+  int z = (int) luaL_checkinteger(l, 2); // don't convert value!
+  dev_monome_set_rotation(md, z);
+  lua_settop(l, 0);
+  return 0;
 }
 
 /***


### PR DESCRIPTION
Adds function to rotate grid.

```
local g = grid.connect()
g.rotation(1) -- 0,1,2,3 are options for 0,90,180,270
```

Needs menu.lua work to make it a configurable setting in menu.