### PR TITLE
Call collectgarbage() when clearing script

### DIFF
--- a/lua/script.lua
+++ b/lua/script.lua
@@ -54,6 +54,8 @@ Script.clear = function()
   screen.font_face(0)
   screen.font_size(8)
   if status == true then s_save() end
+  -- ensure finalizers run before next script
+  collectgarbage()
 end
 
 Script.init = function()


### PR DESCRIPTION
This ensures that any tables that implement a finalizer with the metatable method `.__gc(self)` will have their finalizers run before the next script loads.

It doesn't look like any scripts currently in `dust` are using finalizers, but this feature is coming in handy while prototyping some `beatclock` changes.