### PR TITLE
WIP - new crone, standalone jack client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ sc/ugens/SoftCutHead/softcut-test/Index/
 
 # vscode
 .vscode/
+crone/\.idea/
+
+crone/cmake-build-debug/

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ sc/ugens/SoftCutHead/softcut-test/Index/
 crone/\.idea/
 
 crone/cmake-build-debug/
+
+crone/dsp/

--- a/crone/CMakeLists.txt
+++ b/crone/CMakeLists.txt
@@ -4,7 +4,7 @@ project(crone VERSION 1.0.0 DESCRIPTION "main audio DSP process for norns")
 
 set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
 
-set (SRC src/main.cpp src/JackClient.cpp src/AudioMain.cpp src/Utilities.h src/OscInterface.cpp)
+set (SRC src/main.cpp src/JackClient.cpp src/AudioMain.cpp src/Utilities.h src/OscInterface.cpp src/Commands.cpp)
 
 add_executable(crone ${SRC})
 

--- a/crone/CMakeLists.txt
+++ b/crone/CMakeLists.txt
@@ -1,0 +1,24 @@
+cmake_minimum_required(VERSION 3.7)
+project(crone VERSION 1.0.0 DESCRIPTION "main audio DSP process for norns")
+
+
+set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
+
+set (SRC src/main.cpp src/JackClient.cpp src/Utilities.h)
+
+add_executable(crone ${SRC})
+
+#find_library(lo_lib liblo.so REQUIRED)
+#target_link_libraries(crone ${lo_lib}))
+target_link_libraries(crone lo)
+target_link_libraries(crone jack)
+target_link_libraries(crone pthread)
+target_link_libraries(crone asound)
+
+set_target_properties(crone PROPERTIES
+CXX_STANDARD 14
+CXX_STANDARD_REQUIRED YES
+CXX_EXTENSIONS YES
+)
+
+target_compile_options(crone PRIVATE -Wall -Wextra -pedantic)

--- a/crone/CMakeLists.txt
+++ b/crone/CMakeLists.txt
@@ -4,7 +4,7 @@ project(crone VERSION 1.0.0 DESCRIPTION "main audio DSP process for norns")
 
 set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
 
-set (SRC src/main.cpp src/JackClient.cpp src/AudioMain.cpp src/Utilities.h )
+set (SRC src/main.cpp src/JackClient.cpp src/AudioMain.cpp src/Utilities.h src/OscInterface.cpp)
 
 add_executable(crone ${SRC})
 

--- a/crone/CMakeLists.txt
+++ b/crone/CMakeLists.txt
@@ -4,7 +4,7 @@ project(crone VERSION 1.0.0 DESCRIPTION "main audio DSP process for norns")
 
 set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
 
-set (SRC src/main.cpp src/JackClient.cpp src/Utilities.h)
+set (SRC src/main.cpp src/JackClient.cpp src/AudioMain.cpp src/Utilities.h )
 
 add_executable(crone ${SRC})
 

--- a/crone/CMakeLists.txt
+++ b/crone/CMakeLists.txt
@@ -8,8 +8,6 @@ set (SRC src/main.cpp src/JackClient.cpp src/AudioMain.cpp src/Utilities.h src/O
 
 add_executable(crone ${SRC})
 
-#find_library(lo_lib liblo.so REQUIRED)
-#target_link_libraries(crone ${lo_lib}))
 target_link_libraries(crone lo)
 target_link_libraries(crone jack)
 target_link_libraries(crone pthread)

--- a/crone/osc-tests/basic-routing.scd
+++ b/crone/osc-tests/basic-routing.scd
@@ -1,0 +1,27 @@
+n = NetAddr("localhost", 9999);
+
+// test (does nothing, prints "hello")
+n.sendMsg("/hello");
+
+// "master" I/O levels
+n.sendMsg("/set/level/adc", 1.0);
+n.sendMsg("/set/level/dac", 1.0);
+
+// ADC monitor level. this is _before_ the aux effects send
+n.sendMsg("/set/level/monitor", 1.0);
+
+// monitor mix levels. 1st arg is which route in 2x2 matrix:
+// L -> L
+n.sendMsg("/set/level/monitor_mix", 0, 0.5);
+// L -> R
+n.sendMsg("/set/level/monitor_mix", 1, 0.25);
+// R -> L
+n.sendMsg("/set/level/monitor_mix", 2, 0.25);
+// R -> R
+n.sendMsg("/set/level/monitor_mix", 3, 0.5);
+
+// "ext" level (input from supercollider, pd or &c.) also pre-send
+n.sendMsg("/set/level/ext", 0.5);
+
+// quit
+n.sendMsg("/goodbye");

--- a/crone/src/AudioMain.cpp
+++ b/crone/src/AudioMain.cpp
@@ -13,6 +13,9 @@ void AudioMain::processBlock(const float **in_adc, const float **in_ext, float *
     // clear all our internal busses
     clearBusses(numFrames);
 
+    // test..
+    return;
+
     // clear the output
     for(int ch=0; ch<2; ++ch) {
         for (size_t fr=0; fr<numFrames; ++fr) {
@@ -54,7 +57,6 @@ void AudioMain::processBlock(const float **in_adc, const float **in_ext, float *
 #else
     // TODO
 #endif
-
 
     // apply final output level
     bus.dac_in.mixTo(out, numFrames, smoothLevels.dac);

--- a/crone/src/AudioMain.cpp
+++ b/crone/src/AudioMain.cpp
@@ -10,11 +10,14 @@ using namespace crone;
 AudioMain::AudioMain() = default;
 
 void AudioMain::processBlock(const float **in_adc, const float **in_ext, float **out, size_t numFrames) {
+
+    // test..
+    // return;
+
+
     // clear all our internal busses
     clearBusses(numFrames);
 
-    // test..
-    return;
 
     // clear the output
     for(int ch=0; ch<2; ++ch) {

--- a/crone/src/AudioMain.cpp
+++ b/crone/src/AudioMain.cpp
@@ -10,11 +10,6 @@ using namespace crone;
 AudioMain::AudioMain() = default;
 
 void AudioMain::processBlock(const float **in_adc, const float **in_ext, float **out, size_t numFrames) {
-
-    // test..
-    // return;
-
-
     // clear all our internal busses
     clearBusses(numFrames);
 
@@ -118,7 +113,7 @@ void AudioMain::handleCommand(crone::Commands::CommandPacket *p) {
         case Commands::Id::SET_LEVEL_MONITOR_AUX:
             smoothLevels.monitor_aux.setTarget(p->value);
             break;
-        case Commands::Id::SET_LEVEL_INS__MIX:
+        case Commands::Id::SET_LEVEL_INS_MIX:
             smoothLevels.ins_mix.setTarget(p->value);
             break;
         case Commands::Id::SET_LEVEL_MONITOR_MIX:

--- a/crone/src/AudioMain.cpp
+++ b/crone/src/AudioMain.cpp
@@ -3,31 +3,97 @@
 //
 
 #include "AudioMain.h"
+#include "Commands.h"
 
-crone::AudioMain::AudioMain() = default;
+using namespace crone;
 
-void crone::AudioMain::processBlock(const float **in_adc, const float **in_ext, float **out, size_t numFrames) {
+AudioMain::AudioMain() = default;
+
+void AudioMain::processBlock(const float **in_adc, const float **in_ext, float **out, size_t numFrames) {
+    clearBusses(numFrames);
     bus.adc_out.mixFrom(in_adc, numFrames, smoothLevels.adc);
+    bus.ext_out.mixFrom(in_ext, numFrames, smoothLevels.ext);
 
     // TODO: all the things
 
     bus.dac_in.mixTo(out, numFrames, smoothLevels.dac);
 }
 
-crone::AudioMain::BusList::BusList() {
+void AudioMain::clearBusses(size_t numFrames) {
+    bus.adc_out.clear(numFrames);
+    bus.ext_out.clear(numFrames);
+    bus.dac_in.clear(numFrames);
+    bus.ins_in.clear(numFrames);
+    bus.ins_out.clear(numFrames);
+    bus.aux_in.clear(numFrames);
+    bus.aux_out.clear(numFrames);
+    bus.adc_monitor.clear(numFrames);
+}
+
+AudioMain::BusList::BusList() {
     for (auto *p: { &adc_out, &dac_in, &adc_monitor, &aux_in, &aux_out, &ins_in, &ins_out}) {
         p->clear();
     }
 }
 
-crone::AudioMain::SmoothLevelList::SmoothLevelList() {
+AudioMain::SmoothLevelList::SmoothLevelList() {
     for (auto *p : { &adc, &monitor, &monitor_aux, &aux_dac}) {
         p->setTarget(0);
     }
 }
 
-crone::AudioMain::StaticLevelList::StaticLevelList() {
+AudioMain::StaticLevelList::StaticLevelList() {
     for (auto *p : { &monitor_l_l, &monitor_l_r, &monitor_r_l, &monitor_r_r}) {
         *p = 0;
     }
+}
+
+
+void AudioMain::handleCommand(crone::Commands::CommandPacket *p) {
+    switch(p->id) {
+        case Commands::Id::SET_LEVEL_ADC:
+            smoothLevels.adc.setTarget(p->value);
+            break;
+        case Commands::Id::SET_LEVEL_DAC:
+            smoothLevels.dac.setTarget(p->value);
+            break;
+        case Commands::Id::SET_LEVEL_EXT:
+            smoothLevels.ext.setTarget(p->value);
+            break;
+        case Commands::Id::SET_LEVEL_EXT_AUX:
+            smoothLevels.ext_aux.setTarget(p->value);
+            break;
+        case Commands::Id::SET_LEVEL_AUX_DAC:
+            smoothLevels.aux_dac.setTarget(p->value);
+            break;
+        case Commands::Id::SET_LEVEL_MONITOR:
+            smoothLevels.monitor.setTarget(p->value);
+            break;
+        case Commands::Id::SET_LEVEL_MONITOR_AUX:
+            smoothLevels.monitor_aux.setTarget(p->value);
+            break;
+        case Commands::Id::SET_LEVEL_INS__MIX:
+            smoothLevels.ins_mix.setTarget(p->value);
+            break;
+        case Commands::Id::SET_LEVEL_MONITOR_MIX:
+            switch(p->voice) {
+                case 0:
+                    staticLevels.monitor_l_l = p->value;
+                    break;
+                case 1:
+                    staticLevels.monitor_l_r = p->value;
+                    break;
+                case 2:
+                    staticLevels.monitor_r_l = p->value;
+                    break;
+                case 3:
+                    staticLevels.monitor_r_r = p->value;
+                    break;
+                default: ;;
+            }
+            break;
+        default:
+            ;;
+    }
+
 }

--- a/crone/src/AudioMain.cpp
+++ b/crone/src/AudioMain.cpp
@@ -10,9 +10,10 @@ using namespace crone;
 AudioMain::AudioMain() = default;
 
 void AudioMain::processBlock(const float **in_adc, const float **in_ext, float **out, size_t numFrames) {
+    Commands::handlePending(this);
+
     // clear all our internal busses
     clearBusses(numFrames);
-
 
     // clear the output
     for(int ch=0; ch<2; ++ch) {
@@ -40,6 +41,8 @@ void AudioMain::processBlock(const float **in_adc, const float **in_ext, float *
 #endif
 
     // mix to insert bus
+    bus.ins_in.mixFrom(bus.adc_monitor, numFrames, smoothLevels.monitor);
+    bus.ins_in.sumFrom(bus.ext_out, numFrames);
     bus.ins_in.mixFrom(bus.aux_out, numFrames, smoothLevels.aux);
 
     // apply insert fx
@@ -89,7 +92,6 @@ AudioMain::StaticLevelList::StaticLevelList() {
     }
 }
 
-
 void AudioMain::handleCommand(crone::Commands::CommandPacket *p) {
     switch(p->id) {
         case Commands::Id::SET_LEVEL_ADC:
@@ -123,5 +125,4 @@ void AudioMain::handleCommand(crone::Commands::CommandPacket *p) {
         default:
             ;;
     }
-
 }

--- a/crone/src/AudioMain.cpp
+++ b/crone/src/AudioMain.cpp
@@ -12,10 +12,7 @@ void crone::AudioMain::processBlock(const float **in_adc, const float **in_ext, 
     // TODO: all the things
 
     bus.dac_in.mixTo(out, numFrames, smoothLevels.dac);
-
-
 }
-
 
 crone::AudioMain::BusList::BusList() {
     for (auto *p: { &adc_out, &dac_in, &adc_monitor, &aux_in, &aux_out, &ins_in, &ins_out}) {

--- a/crone/src/AudioMain.cpp
+++ b/crone/src/AudioMain.cpp
@@ -1,0 +1,36 @@
+//
+// Created by emb on 11/19/18.
+//
+
+#include "AudioMain.h"
+
+crone::AudioMain::AudioMain() = default;
+
+void crone::AudioMain::processBlock(const float **in_adc, const float **in_ext, float **out, size_t numFrames) {
+    bus.adc_out.mixFrom(in_adc, numFrames, smoothLevels.adc);
+
+    // TODO: all the things
+
+    bus.dac_in.mixTo(out, numFrames, smoothLevels.dac);
+
+
+}
+
+
+crone::AudioMain::BusList::BusList() {
+    for (auto *p: { &adc_out, &dac_in, &adc_monitor, &aux_in, &aux_out, &ins_in, &ins_out}) {
+        p->clear();
+    }
+}
+
+crone::AudioMain::SmoothLevelList::SmoothLevelList() {
+    for (auto *p : { &adc, &monitor, &monitor_aux, &aux_dac}) {
+        p->setTarget(0);
+    }
+}
+
+crone::AudioMain::StaticLevelList::StaticLevelList() {
+    for (auto *p : { &monitor_l_l, &monitor_l_r, &monitor_r_l, &monitor_r_r}) {
+        *p = 0;
+    }
+}

--- a/crone/src/AudioMain.h
+++ b/crone/src/AudioMain.h
@@ -51,16 +51,13 @@ namespace  crone {
             LogRamp ext_aux;
             LogRamp ins_mix;
             LogRamp monitor_aux;
-            LogRamp aux_dac;
+            LogRamp aux;
             SmoothLevelList();
         };
         SmoothLevelList smoothLevels;
 
         struct StaticLevelList {
-            float monitor_l_l;
-            float monitor_l_r;
-            float monitor_r_l;
-            float monitor_r_r;
+            float monitor_mix[4];
             StaticLevelList();
         };
         StaticLevelList staticLevels;

--- a/crone/src/AudioMain.h
+++ b/crone/src/AudioMain.h
@@ -1,0 +1,39 @@
+//
+// Created by emb on 11/19/18.
+//
+
+#ifndef CRONE_AUDIOMAIN_H
+#define CRONE_AUDIOMAIN_H
+
+#include "Bus.h"
+
+namespace  crone {
+    class AudioMain {
+        enum { MAX_BUF_SIZE = 512};
+    private:
+        typedef Bus<2, MAX_BUF_SIZE> StereoBus;
+        struct {
+            StereoBus adc_out;
+            StereoBus dac_in;
+            StereoBus ins_in;
+            StereoBus ins_out;
+            StereoBus aux_in;
+            StereoBus aux_out;
+            StereoBus adc_monitor;
+        } bus;
+        struct {
+            LogRamp adc;
+            LogRamp monitor;
+            LogRamp dac;
+        } smoothLevels;
+
+        struct {
+            float monitor_l_l;
+            float monitor_l_r;
+            float monitor_r_l;
+            float monitor_r_r;
+        } staticLevels;
+    };
+}
+
+#endif //CRONE_AUDIOMAIN_H

--- a/crone/src/AudioMain.h
+++ b/crone/src/AudioMain.h
@@ -9,10 +9,21 @@
 
 namespace  crone {
     class AudioMain {
-        enum { MAX_BUF_SIZE = 512};
+        enum {
+            MAX_BUF_SIZE = 512
+        };
+    public:
+        AudioMain();
+
+        void processBlock(
+                const float *in_adc[2],
+                const float *in_ext[2],
+                float *out[2],
+                size_t numFrames);
+
     private:
         typedef Bus<2, MAX_BUF_SIZE> StereoBus;
-        struct {
+        struct BusList {
             StereoBus adc_out;
             StereoBus dac_in;
             StereoBus ins_in;
@@ -20,19 +31,30 @@ namespace  crone {
             StereoBus aux_in;
             StereoBus aux_out;
             StereoBus adc_monitor;
-        } bus;
-        struct {
-            LogRamp adc;
-            LogRamp monitor;
-            LogRamp dac;
-        } smoothLevels;
+            BusList();
+        };
+        BusList bus;
 
-        struct {
+        struct SmoothLevelList{
+        public:
+            LogRamp adc;
+            LogRamp dac;
+            LogRamp monitor;
+            LogRamp ins_mix;
+            LogRamp monitor_aux;
+            LogRamp aux_dac;
+            SmoothLevelList();
+        };
+        SmoothLevelList smoothLevels;
+
+        struct StaticLevelList {
             float monitor_l_l;
             float monitor_l_r;
             float monitor_r_l;
             float monitor_r_r;
-        } staticLevels;
+            StaticLevelList();
+        };
+        StaticLevelList staticLevels;
     };
 }
 

--- a/crone/src/AudioMain.h
+++ b/crone/src/AudioMain.h
@@ -12,7 +12,7 @@ namespace  crone {
 
     class AudioMain {
         enum {
-            MAX_BUF_SIZE = 512
+            MAX_BUF_SIZE = 2048
         };
     public:
         AudioMain();

--- a/crone/src/AudioMain.h
+++ b/crone/src/AudioMain.h
@@ -6,8 +6,10 @@
 #define CRONE_AUDIOMAIN_H
 
 #include "Bus.h"
+#include "Commands.h"
 
 namespace  crone {
+
     class AudioMain {
         enum {
             MAX_BUF_SIZE = 512
@@ -21,10 +23,15 @@ namespace  crone {
                 float *out[2],
                 size_t numFrames);
 
+        void handleCommand(Commands::CommandPacket *p);
+
+    private:
+        void clearBusses(size_t numFrames);
     private:
         typedef Bus<2, MAX_BUF_SIZE> StereoBus;
         struct BusList {
             StereoBus adc_out;
+            StereoBus ext_out;
             StereoBus dac_in;
             StereoBus ins_in;
             StereoBus ins_out;
@@ -39,7 +46,9 @@ namespace  crone {
         public:
             LogRamp adc;
             LogRamp dac;
+            LogRamp ext;
             LogRamp monitor;
+            LogRamp ext_aux;
             LogRamp ins_mix;
             LogRamp monitor_aux;
             LogRamp aux_dac;

--- a/crone/src/Bus.h
+++ b/crone/src/Bus.h
@@ -88,8 +88,8 @@ namespace  crone {
 
         constexpr void stereoMixFrom(BusT &b, size_t numFrames, float level[4]) {
             for(size_t fr=0; fr<numFrames; ++fr) {
-                buf[0][fr] += b.buf[0][fr] * level[0] + b.buf[1][fr] * level[1];
-                buf[1][fr] += b.buf[0][fr] * level[2] + b.buf[1][fr] * level[3];
+                buf[0][fr] += b.buf[0][fr] * level[0] + b.buf[1][fr] * level[2];
+                buf[1][fr] += b.buf[0][fr] * level[1] + b.buf[1][fr] * level[3];
             }
         }
     };

--- a/crone/src/Bus.h
+++ b/crone/src/Bus.h
@@ -1,0 +1,70 @@
+//
+// Created by emb on 11/19/18.
+//
+
+#ifndef CRONE_BUS_H
+#define CRONE_BUS_H
+
+#include "Utilities.h"
+
+namespace  crone {
+
+    template<size_t NumChannels, size_t BlockSize>
+    class Bus {
+    private:
+        typedef Bus<NumChannels, BlockSize> BusT;
+    public:
+        float buf[NumChannels][BlockSize];
+
+        constexpr void clear() {
+            for(int ch=0; ch<NumChannels; ++ch) {
+                for(int fr=0; fr<BlockSize; ++fr) {
+                    buf[ch][fr] = 0.f;
+                }
+            }
+        }
+
+        constexpr void sumFrom(BusT &b) {
+            for(int ch=0; ch<NumChannels; ++ch) {
+                for(int fr=0; fr<BlockSize; ++fr) {
+                    buf[ch][fr] += b.buf[ch][fr];
+                }
+            }
+        }
+
+        constexpr void mixFrom(BusT &b, float level) {
+            for(int fr=0; fr<BlockSize; ++fr) {
+                for(int ch=0; ch<NumChannels; ++ch) {
+                    buf[ch][fr] += b.buf[ch][fr] * level;
+                }
+            }
+        }
+
+
+        constexpr void mixFrom(BusT &b, LogRamp &level) {
+            for(int fr=0; fr<BlockSize; ++fr) {
+                for(int ch=0; ch<NumChannels; ++ch) {
+                    buf[ch][fr] += b.buf[ch][fr] * level.update();
+                }
+            }
+        }
+
+        constexpr void mixFrom(const float **src, LogRamp &level) {
+            for(int fr=0; fr<BlockSize; ++fr) {
+                for(int ch=0; ch<NumChannels; ++ch) {
+                    buf[ch][fr] += src[ch][fr] * level.update();
+                }
+            }
+        }
+
+        constexpr void stereoMixFrom(BusT &b, float l00, float l01, float l10, float l11) {
+            for(int fr=0; fr<BlockSize; ++fr) {
+                buf[0][fr] += b.buf[0][fr] * l00 + b.buf[1][fr] * l10;
+                buf[1][fr] += b.buf[0][fr] * l01 + b.buf[1][fr] * l11;
+            }
+        }
+    };
+
+}
+
+#endif //CRONE_BUS_H

--- a/crone/src/Bus.h
+++ b/crone/src/Bus.h
@@ -25,6 +25,7 @@ namespace  crone {
             }
         }
 
+        // clear the first N frames in the bus
         constexpr void clear(size_t numFrames) {
             for(size_t ch=0; ch<NumChannels; ++ch) {
                 for(size_t fr=0; fr<numFrames; ++fr) {
@@ -33,6 +34,7 @@ namespace  crone {
             }
         }
 
+        // sum from bus, without amplitude scaling
         constexpr void sumFrom(BusT &b, size_t numFrames) {
             for(size_t ch=0; ch<NumChannels; ++ch) {
                 for(size_t fr=0; fr<numFrames; ++fr) {
@@ -41,6 +43,7 @@ namespace  crone {
             }
         }
 
+        // mix from bus, with fixed amplitude
         constexpr void mixFrom(BusT &b, size_t numFrames, float level) {
             for(size_t ch=0; ch<NumChannels; ++ch) {
                 for(size_t fr=0; fr<numFrames; ++fr) {
@@ -50,6 +53,7 @@ namespace  crone {
         }
 
 
+        // mix from bus, with smoothed amplitude
         void mixFrom(BusT &b, size_t numFrames, LogRamp &level) {
             float l;
             for(size_t fr=0; fr<numFrames; ++fr) {
@@ -60,7 +64,7 @@ namespace  crone {
             }
         }
 
-        // mix from array of pointers
+        // mix from pointer array, with smoothed amplitude
         void mixFrom(const float *src[NumChannels], size_t numFrames, LogRamp &level) {
             float l;
             for(size_t fr=0; fr<numFrames; ++fr) {
@@ -71,8 +75,7 @@ namespace  crone {
             }
         }
 
-
-        // mix to array of pointers
+        // mix to pointer array, with smoothed amplitude
         void mixTo(float *dst[NumChannels], size_t numFrames, LogRamp &level) {
             float l;
             for(size_t fr=0; fr<numFrames; ++fr) {
@@ -83,10 +86,10 @@ namespace  crone {
             }
         }
 
-        constexpr void stereoMixFrom(BusT &b, size_t numFrames, float l00, float l01, float l10, float l11) {
+        constexpr void stereoMixFrom(BusT &b, size_t numFrames, float level[4]) {
             for(size_t fr=0; fr<numFrames; ++fr) {
-                buf[0][fr] += b.buf[0][fr] * l00 + b.buf[1][fr] * l10;
-                buf[1][fr] += b.buf[0][fr] * l01 + b.buf[1][fr] * l11;
+                buf[0][fr] += b.buf[0][fr] * level[0] + b.buf[1][fr] * level[1];
+                buf[1][fr] += b.buf[0][fr] * level[2] + b.buf[1][fr] * level[3];
             }
         }
     };

--- a/crone/src/Commands.cpp
+++ b/crone/src/Commands.cpp
@@ -16,7 +16,7 @@ void Commands::post(Commands::Id id, float value) {
     q.push(p);
 }
 
-void Commands::post(Commands::Id id, int voice, bool value) {
+void Commands::post(Commands::Id id, int voice, float value) {
     CommandPacket p(id, voice, value);
     q.push(p);
 }

--- a/crone/src/Commands.cpp
+++ b/crone/src/Commands.cpp
@@ -1,0 +1,29 @@
+//
+// Created by ezra on 11/3/18.
+//
+
+#include <iostream>
+#include "Commands.h"
+#include "AudioMain.h"
+
+using namespace crone;
+
+// FIXME: can throw, shouldn't be storage level init
+boost::lockfree::spsc_queue <Commands::CommandPacket> Commands::q(100);
+
+void Commands::post(Commands::Id id, float value) {
+    CommandPacket p(id, -1, value);
+    q.push(p);
+}
+
+void Commands::post(Commands::Id id, int voice, bool value) {
+    CommandPacket p(id, voice, value);
+    q.push(p);
+}
+
+void Commands::handlePending(AudioMain* a) {
+    CommandPacket p;
+    while (q.pop(p)) {
+        a->handleCommand(&p);
+    }
+}

--- a/crone/src/Commands.h
+++ b/crone/src/Commands.h
@@ -1,0 +1,81 @@
+//
+// Created by ezra on 11/3/18.
+//
+
+#ifndef SOFTCUT_COMMANDS_H
+#define SOFTCUT_COMMANDS_H
+
+#include <boost/lockfree/spsc_queue.hpp>
+
+
+namespace crone {
+
+    class AudioMain;
+
+    class Commands {
+    public:
+        typedef enum {
+            //-- level commands
+            SET_LEVEL_ADC,
+            SET_LEVEL_DAC,
+            SET_LEVEL_EXT,
+            SET_LEVEL_EXT_AUX,
+            SET_LEVEL_AUX_DAC,
+            SET_LEVEL_MONITOR,
+            SET_LEVEL_MONITOR_MIX,
+            SET_LEVEL_MONITOR_AUX,
+            SET_LEVEL_INS__MIX,
+
+            //-- softcut commands
+            SET_SOFTCUT_RATE,
+            SET_SOFTCUT_LOOP_START,
+            SET_SOFTCUT_LOOP_END,
+            SET_SOFTCUT_LOOP_FLAG,
+            SET_SOFTCUT_FADE_TIME,
+            SET_SOFTCUT_REC_LEVEL,
+            SET_SOFTCUT_PRE_LEVEL,
+            SET_SOFTCUT_REC_FLAG,
+            SET_SOFTCUT_REC_OFFSET,
+            SET_SOFTCUT_POSITION,
+            SET_SOFTCUT_FILTER_FC,
+            SET_SOFTCUT_FILTER_FC_MOD,
+            SET_SOFTCUT_FILTER_RQ,
+            SET_SOFTCUT_FILTER_LP,
+            SET_SOFTCUT_FILTER_HP,
+            SET_SOFTCUT_FILTER_BP,
+            SET_SOFTCUT_FILTER_BR,
+            SET_SOFTCUT_FILTER_DRY,
+            SET_SOFTCUT_AMP_L,
+            SET_SOFTCUT_AMP_R,
+            SET_SOFTCUT_PRE_FADE_WINDOW,
+            SET_SOFTCUT_REC_FADE_DELAY,
+            SET_SOFTCUT_PRE_FADE_SHAPE,
+            SET_SOFTCUT_REC_FADE_SHAPE,
+            SET_SOFTCUT_LEVEL_SLEW_TIME,
+            SET_SOFTCUT_RATE_SLEW_TIME,
+            NUM_COMMANDS
+        } Id;
+
+    public:
+
+        void post(Commands::Id id, float value);
+        void post(Commands::Id id, int voice, bool value);
+        static void handlePending(AudioMain *audio);
+
+        struct CommandPacket {
+            CommandPacket() = default;
+            CommandPacket(Commands::Id i, int v, float f) : id(i), voice(v), value(f) {}
+            //Command type;
+            Id id;
+            int voice;
+            float value;
+        };
+
+    private:
+        static boost::lockfree::spsc_queue <CommandPacket> q;
+
+    };
+
+}
+
+#endif //SOFTCUT_COMMANDS_H

--- a/crone/src/Commands.h
+++ b/crone/src/Commands.h
@@ -65,7 +65,6 @@ namespace crone {
         struct CommandPacket {
             CommandPacket() = default;
             CommandPacket(Commands::Id i, int v, float f) : id(i), voice(v), value(f) {}
-            //Command type;
             Id id;
             int voice;
             float value;
@@ -73,7 +72,6 @@ namespace crone {
 
     private:
         static boost::lockfree::spsc_queue <CommandPacket> q;
-
     };
 
 }

--- a/crone/src/Commands.h
+++ b/crone/src/Commands.h
@@ -24,7 +24,7 @@ namespace crone {
             SET_LEVEL_MONITOR,
             SET_LEVEL_MONITOR_MIX,
             SET_LEVEL_MONITOR_AUX,
-            SET_LEVEL_INS__MIX,
+            SET_LEVEL_INS_MIX,
 
             //-- softcut commands
             SET_SOFTCUT_RATE,
@@ -58,8 +58,8 @@ namespace crone {
 
     public:
 
-        void post(Commands::Id id, float value);
-        void post(Commands::Id id, int voice, bool value);
+        static void post(Commands::Id id, float value);
+        static void post(Commands::Id id, int voice, float value);
         static void handlePending(AudioMain *audio);
 
         struct CommandPacket {

--- a/crone/src/JackClient.cpp
+++ b/crone/src/JackClient.cpp
@@ -1,0 +1,194 @@
+//
+// Created by emb on 11/18/18.
+//
+
+
+#include <cstdio>
+#include <cstdlib>
+
+#include "AudioMain.h"
+#include "JackClient.h"
+#include <jack/jack.h>
+
+using namespace crone;
+
+class JackClient::Imp {
+
+    friend class JackClient;
+private:
+    AudioMain audioMain;
+    jack_port_t *input_port[4];
+    jack_port_t *output_port[2];
+    jack_client_t *client;
+
+    static int process (jack_nframes_t numFrames, void *data) {
+        jack_default_audio_sample_t *in[4], *out[2];
+
+        auto * imp = (JackClient::Imp*)(data);
+
+        in[0] = (jack_default_audio_sample_t *) jack_port_get_buffer (imp->input_port[0], numFrames);
+        in[1] = (jack_default_audio_sample_t *) jack_port_get_buffer (imp->input_port[1], numFrames);
+        in[2] = (jack_default_audio_sample_t *) jack_port_get_buffer (imp->input_port[0], numFrames);
+        in[3] = (jack_default_audio_sample_t *) jack_port_get_buffer (imp->input_port[1], numFrames);
+        out[0] = (jack_default_audio_sample_t *) jack_port_get_buffer (imp->output_port[0], numFrames);
+        out[1] = (jack_default_audio_sample_t *) jack_port_get_buffer (imp->output_port[1], numFrames);
+
+        // test: sum and wire:
+        for(int i=0; i<numFrames; ++i) {
+            out[0][i] = in[0][i] + in[2][i];
+            out[1][i] = in[1][i] + in[3][i];
+        }
+
+        return 0;
+    }
+
+    static void jack_shutdown(void* data) {
+        (void)data;
+        // nothing to do...
+        // but here we would handle forced shutdown from jack server
+    }
+
+
+public:
+    void setup() {
+        const char *client_name = "simple";
+        const char *server_name = nullptr;
+        jack_options_t options = JackNullOption;
+        jack_status_t status;
+
+        /* open a client connection to the JACK server */
+
+        client = jack_client_open (client_name, options, &status, server_name);
+        if (client == nullptr) {
+            fprintf (stderr, "jack_client_open() failed, "
+                             "status = 0x%2.0x\n", status);
+            if (status & JackServerFailed) {
+                fprintf (stderr, "Unable to connect to JACK server\n");
+            }
+            exit (1);
+        }
+        if (status & JackServerStarted) {
+            fprintf (stderr, "JACK server started\n");
+        }
+        if (status & JackNameNotUnique) {
+            client_name = jack_get_client_name(client);
+            fprintf (stderr, "unique name `%s' assigned\n", client_name);
+        }
+
+        printf ("engine sample rate: %" PRIu32 "\n",
+                jack_get_sample_rate (client));
+
+        jack_set_process_callback (client, process, this);
+        jack_on_shutdown (client, jack_shutdown, this);
+
+        // create client ports
+        input_port[0] = jack_port_register (client, "in_0",
+                                            JACK_DEFAULT_AUDIO_TYPE,
+                                            JackPortIsInput, 0);
+        input_port[1] = jack_port_register (client, "in_1",
+                                            JACK_DEFAULT_AUDIO_TYPE,
+                                            JackPortIsInput, 0);
+        input_port[2] = jack_port_register (client, "in_2",
+                                            JACK_DEFAULT_AUDIO_TYPE,
+                                            JackPortIsInput, 0);
+        input_port[3] = jack_port_register (client, "in_3",
+                                            JACK_DEFAULT_AUDIO_TYPE,
+                                            JackPortIsInput, 0);
+        output_port[0] = jack_port_register (client, "out_0",
+                                             JACK_DEFAULT_AUDIO_TYPE,
+                                             JackPortIsOutput, 0);
+        output_port[1] = jack_port_register (client, "out_r",
+                                             JACK_DEFAULT_AUDIO_TYPE,
+                                             JackPortIsOutput, 0);
+
+        if ((input_port == nullptr) || (output_port == nullptr)) {
+            fprintf(stderr, "no more JACK ports available\n");
+            exit (1);
+        }
+
+
+    }
+
+    void start() {
+
+        /* Tell the JACK server that we are ready to roll.  Our
+          * process() callback will start running now. */
+
+        if (jack_activate (client)) {
+            fprintf (stderr, "cannot activate client");
+            exit (1);
+        }
+
+        /* Connect the ports.  You can't do this before the client is
+         * activated, because we can't make connections to clients
+         * that aren't running.  Note the confusing (but necessary)
+         * orientation of the driver backend ports: playback ports are
+         * "input" to the backend, and capture ports are "output" from
+         * it.
+         */
+
+        const char **ports;
+
+        //--- connect input
+        ports = jack_get_ports (client, nullptr, nullptr,
+                                JackPortIsPhysical|JackPortIsOutput);
+        if (ports == nullptr) {
+            fprintf(stderr, "no ADC ports found\n");
+            exit (1);
+        }
+
+        if (jack_connect (client, ports[0], jack_port_name (input_port[0]))) {
+            fprintf (stderr, "cannot connect ADC port 0\n");
+        }
+
+        if (jack_connect (client, ports[1], jack_port_name (input_port[1]))) {
+            fprintf (stderr, "cannot connect ADC port 1\n");
+        }
+
+        free (ports);
+
+        //--- connect output
+        ports = jack_get_ports (client, nullptr, nullptr,
+                                JackPortIsPhysical|JackPortIsInput);
+        if (ports == nullptr) {
+            fprintf(stderr, "no DAC ports found\n");
+            exit (1);
+        }
+
+        if (jack_connect (client, jack_port_name (output_port[0]), ports[0])) {
+            fprintf (stderr, "cannot connect DAC port 0\n");
+        }
+        if (jack_connect (client, jack_port_name (output_port[1]), ports[1])) {
+            fprintf (stderr, "cannot connect DAC port 1\n");
+        }
+
+        free (ports);
+
+    }
+
+    void stop() {
+        jack_deactivate(client);
+    }
+
+    void cleanup() {
+        jack_client_close(client);
+    }
+};
+
+JackClient::Imp JackClient::imp;
+
+void JackClient::setup() {
+    JackClient::imp.setup();
+}
+
+void JackClient::cleanup() {
+    JackClient::imp.cleanup();
+}
+
+void JackClient::start() {
+    JackClient::imp.start();
+}
+
+void JackClient::stop() {
+    JackClient::imp.stop();
+}

--- a/crone/src/JackClient.cpp
+++ b/crone/src/JackClient.cpp
@@ -33,7 +33,6 @@ private:
         in_ext[1] = (jack_default_audio_sample_t *) jack_port_get_buffer (imp->input_port[1], numFrames);
         out[0] = (jack_default_audio_sample_t *) jack_port_get_buffer (imp->output_port[0], numFrames);
         out[1] = (jack_default_audio_sample_t *) jack_port_get_buffer (imp->output_port[1], numFrames);
-
 #if 0
         if(in_adc[0] == nullptr) { return 0; }
         if(in_adc[1] == nullptr) { return 0; }

--- a/crone/src/JackClient.cpp
+++ b/crone/src/JackClient.cpp
@@ -15,8 +15,6 @@ using namespace crone;
 class JackClient::Imp {
 
     friend class JackClient;
-public:
-    Imp() {}
 private:
     AudioMain audioMain;
     jack_port_t *input_port[4];
@@ -35,6 +33,15 @@ private:
         in_ext[1] = (jack_default_audio_sample_t *) jack_port_get_buffer (imp->input_port[1], numFrames);
         out[0] = (jack_default_audio_sample_t *) jack_port_get_buffer (imp->output_port[0], numFrames);
         out[1] = (jack_default_audio_sample_t *) jack_port_get_buffer (imp->output_port[1], numFrames);
+
+#if 0
+        if(in_adc[0] == nullptr) { return 0; }
+        if(in_adc[1] == nullptr) { return 0; }
+        if(in_ext[0] == nullptr) { return 0; }
+        if(in_ext[1] == nullptr) { return 0; }
+        if(out[0] == nullptr) { return 0; }
+        if(out[1] == nullptr) { return 0; }
+#endif
 
         imp->audioMain.processBlock(in_adc, in_ext, out, numFrames);
 
@@ -56,7 +63,7 @@ private:
 
 public:
     void setup() {
-        const char *client_name = "simple";
+        const char *client_name = "crone";
         const char *server_name = nullptr;
         jack_options_t options = JackNullOption;
         jack_status_t status;
@@ -102,7 +109,7 @@ public:
         output_port[0] = jack_port_register (client, "out_0",
                                              JACK_DEFAULT_AUDIO_TYPE,
                                              JackPortIsOutput, 0);
-        output_port[1] = jack_port_register (client, "out_r",
+        output_port[1] = jack_port_register (client, "out_1",
                                              JACK_DEFAULT_AUDIO_TYPE,
                                              JackPortIsOutput, 0);
 
@@ -149,6 +156,8 @@ public:
         if (jack_connect (client, ports[1], jack_port_name (input_port[1]))) {
             fprintf (stderr, "cannot connect ADC port 1\n");
         }
+
+        // FIXME: connect additional input ports to supercollider, &c
 
         free (ports);
 

--- a/crone/src/JackClient.cpp
+++ b/crone/src/JackClient.cpp
@@ -21,34 +21,22 @@ private:
     jack_port_t *output_port[2];
     jack_client_t *client;
 
-    static int process (jack_nframes_t numFrames, void *data) {
-        const jack_default_audio_sample_t *in_adc[2];
-        const jack_default_audio_sample_t *in_ext[2];
-        jack_default_audio_sample_t *out[2];
+    static const jack_default_audio_sample_t *in_adc[2];
+    static const jack_default_audio_sample_t *in_ext[2];
+    static jack_default_audio_sample_t *out[2];
 
-        auto * imp = (JackClient::Imp*)(data);
+    static int process (jack_nframes_t numFrames, void *data) {
+
+        auto *imp = (JackClient::Imp*)(data);
+
         in_adc[0] = (jack_default_audio_sample_t *) jack_port_get_buffer (imp->input_port[0], numFrames);
         in_adc[1] = (jack_default_audio_sample_t *) jack_port_get_buffer (imp->input_port[1], numFrames);
-        in_ext[0] = (jack_default_audio_sample_t *) jack_port_get_buffer (imp->input_port[0], numFrames);
-        in_ext[1] = (jack_default_audio_sample_t *) jack_port_get_buffer (imp->input_port[1], numFrames);
+        in_ext[0] = (jack_default_audio_sample_t *) jack_port_get_buffer (imp->input_port[2], numFrames);
+        in_ext[1] = (jack_default_audio_sample_t *) jack_port_get_buffer (imp->input_port[3], numFrames);
         out[0] = (jack_default_audio_sample_t *) jack_port_get_buffer (imp->output_port[0], numFrames);
         out[1] = (jack_default_audio_sample_t *) jack_port_get_buffer (imp->output_port[1], numFrames);
-#if 0
-        if(in_adc[0] == nullptr) { return 0; }
-        if(in_adc[1] == nullptr) { return 0; }
-        if(in_ext[0] == nullptr) { return 0; }
-        if(in_ext[1] == nullptr) { return 0; }
-        if(out[0] == nullptr) { return 0; }
-        if(out[1] == nullptr) { return 0; }
-#endif
 
         imp->audioMain.processBlock(in_adc, in_ext, out, numFrames);
-
-//        // test: sum and wire:
-//        for(size_t i=0; i<numFrames; ++i) {
-//            out[0][i] = in[0][i] + in[2][i];
-//            out[1][i] = in[1][i] + in[3][i];
-//        }
 
         return 0;
     }
@@ -205,3 +193,8 @@ void JackClient::start() {
 void JackClient::stop() {
     JackClient::imp.stop();
 }
+
+
+const jack_default_audio_sample_t *JackClient::Imp::in_adc[2];
+const jack_default_audio_sample_t *JackClient::Imp::in_ext[2];
+jack_default_audio_sample_t *JackClient::Imp::out[2];

--- a/crone/src/JackClient.h
+++ b/crone/src/JackClient.h
@@ -1,0 +1,27 @@
+//
+// Created by emb on 11/18/18.
+//
+
+#ifndef CRONE_JACKCLIENT_H
+#define CRONE_JACKCLIENT_H
+
+namespace  crone {
+    class JackClient {
+    public:
+        static void setup();
+
+        static void cleanup();
+
+        static void start();
+
+        static void stop();
+
+
+    private:
+        class Imp;
+
+        static Imp imp;
+    };
+}
+
+#endif //CRONE_JACKCLIENT_H

--- a/crone/src/OscInterface.cpp
+++ b/crone/src/OscInterface.cpp
@@ -1,0 +1,25 @@
+//
+// Created by ezra on 11/4/18.
+//
+
+#include "OscInterface.h"
+
+using namespace crone;
+
+bool OscInterface::quitFlag;
+std::string OscInterface::port;
+lo_server_thread OscInterface::st;
+std::vector<OscInterface::OscMethod> OscInterface::methods;
+
+void OscInterface::addServerMethods() {
+    addServerMethod("/hello", "", [](lo_arg **argv, int argc) {
+        (void)argv; (void)argc;
+        std::cout << "hello" << std::endl;
+    });
+
+    addServerMethod("/goodbye", "", [](lo_arg **argv, int argc) {
+        (void)argv; (void)argc;
+        std::cout << "goodbye" << std::endl;
+    });
+
+}

--- a/crone/src/OscInterface.cpp
+++ b/crone/src/OscInterface.cpp
@@ -3,6 +3,7 @@
 //
 
 #include "OscInterface.h"
+#include "Commands.h"
 
 using namespace crone;
 
@@ -22,4 +23,48 @@ void OscInterface::addServerMethods() {
         std::cout << "goodbye" << std::endl;
     });
 
+    addServerMethod("/set/level/adc", "f", [](lo_arg **argv, int argc) {
+        if(argc<1) { return; }
+        Commands::post(Commands::Id::SET_LEVEL_ADC, argv[0]->f);
+    });
+
+    addServerMethod("/set/level/dac", "f", [](lo_arg **argv, int argc) {
+        if(argc<1) { return; }
+        Commands::post(Commands::Id::SET_LEVEL_DAC, argv[0]->f);
+    });
+
+    addServerMethod("/set/level/ext", "f", [](lo_arg **argv, int argc) {
+        if(argc<1) { return; }
+        Commands::post(Commands::Id::SET_LEVEL_EXT, argv[0]->f);
+    });
+
+    addServerMethod("/set/level/ext_aux", "f", [](lo_arg **argv, int argc) {
+        if(argc<1) { return; }
+        Commands::post(Commands::Id::SET_LEVEL_EXT_AUX, argv[0]->f);
+    });
+
+    addServerMethod("/set/level/aux_dac", "f", [](lo_arg **argv, int argc) {
+        if(argc<1) { return; }
+        Commands::post(Commands::Id::SET_LEVEL_AUX_DAC, argv[0]->f);
+    });
+
+    addServerMethod("/set/level/monitor", "f", [](lo_arg **argv, int argc) {
+        if(argc<1) { return; }
+        Commands::post(Commands::Id::SET_LEVEL_MONITOR, argv[0]->f);
+    });
+
+    addServerMethod("/set/level/monitor_mix", "if", [](lo_arg **argv, int argc) {
+        if(argc<2) { return; }
+        Commands::post(Commands::Id::SET_LEVEL_MONITOR_MIX, argv[0]->i, argv[1]->f);
+    });
+
+    addServerMethod("/set/level/monitor_aux", "f", [](lo_arg **argv, int argc) {
+        if(argc<1) { return; }
+        Commands::post(Commands::Id::SET_LEVEL_MONITOR_AUX, argv[0]->f);
+    });
+
+    addServerMethod("/set/level/ins_mix", "f", [](lo_arg **argv, int argc) {
+        if(argc<1) { return; }
+        Commands::post(Commands::Id::SET_LEVEL_INS_MIX, argv[0]->f);
+    });
 }

--- a/crone/src/OscInterface.cpp
+++ b/crone/src/OscInterface.cpp
@@ -1,3 +1,5 @@
+#include <utility>
+
 //
 // Created by ezra on 11/4/18.
 //
@@ -10,7 +12,12 @@ using namespace crone;
 bool OscInterface::quitFlag;
 std::string OscInterface::port;
 lo_server_thread OscInterface::st;
-std::vector<OscInterface::OscMethod> OscInterface::methods;
+std::array<OscInterface::OscMethod, OscInterface::MAX_NUM_METHODS> OscInterface::methods;
+unsigned int OscInterface::numMethods = 0;
+
+
+OscInterface::OscMethod::OscMethod(string p, string f, OscInterface::Handler h)
+: path(std::move(p)), format(std::move(f)), handler(h) {}
 
 void OscInterface::addServerMethods() {
     addServerMethod("/hello", "", [](lo_arg **argv, int argc) {
@@ -68,3 +75,4 @@ void OscInterface::addServerMethods() {
         Commands::post(Commands::Id::SET_LEVEL_INS_MIX, argv[0]->f);
     });
 }
+

--- a/crone/src/OscInterface.cpp
+++ b/crone/src/OscInterface.cpp
@@ -28,6 +28,12 @@ void OscInterface::addServerMethods() {
     addServerMethod("/goodbye", "", [](lo_arg **argv, int argc) {
         (void)argv; (void)argc;
         std::cout << "goodbye" << std::endl;
+        OscInterface::quitFlag = true;
+    });
+
+    addServerMethod("/quit", "", [](lo_arg **argv, int argc) {
+        (void)argv; (void)argc;
+        OscInterface::quitFlag = true;
     });
 
     addServerMethod("/set/level/adc", "f", [](lo_arg **argv, int argc) {

--- a/crone/src/OscInterface.h
+++ b/crone/src/OscInterface.h
@@ -25,7 +25,8 @@ namespace crone {
         static string port;
         static unsigned int numMethods;
         enum { MAX_NUM_METHODS = 256 };
-        // basically wrapper class for passing lambdas to OSC server thread
+
+        // OscMethod: thin wrapper for passing lambdas to OSC server thread
         class OscMethod {
             typedef void(*Handler)(lo_arg **argv, int argc);
             string path;
@@ -54,8 +55,8 @@ namespace crone {
                 (void) path;
                 (void) types;
                 (void) msg;
-                auto m = static_cast<OscMethod*>(data);
-                m->handler(argv, argc);
+                auto pm = static_cast<OscMethod*>(data);
+                pm->handler(argv, argc);
                 return 0;
             }, &(methods[numMethods]));
             numMethods++;

--- a/crone/src/OscInterface.h
+++ b/crone/src/OscInterface.h
@@ -1,3 +1,5 @@
+#include <utility>
+
 //
 // Created by ezra on 11/4/18.
 //
@@ -10,6 +12,7 @@
 #include <vector>
 
 #include <lo/lo.h>
+#include <array>
 
 
 namespace crone {
@@ -20,18 +23,20 @@ namespace crone {
         static lo_server_thread st;
         static bool quitFlag;
         static string port;
-
+        static unsigned int numMethods;
+        enum { MAX_NUM_METHODS = 256 };
         // basically wrapper class for passing lambdas to OSC server thread
         class OscMethod {
             typedef void(*Handler)(lo_arg **argv, int argc);
             string path;
             string format;
         public:
-            OscMethod(string p, string f, Handler h) : path(p), format(f), handler(h) {}
+            OscMethod() = default;
+            OscMethod(string p, string f, Handler h);
             Handler handler;
         };
 
-        static std::vector<OscMethod> methods;
+        static std::array<OscMethod, MAX_NUM_METHODS> methods;
 
     private:
 
@@ -42,7 +47,7 @@ namespace crone {
 
         static void addServerMethod(const char* path, const char* format, Handler handler) {
             OscMethod m(path, format, handler);
-            methods.push_back(m);
+            methods[numMethods] = m;
             lo_server_thread_add_method(st, path, format,
             [] (const char *path, const char *types, lo_arg **argv, int argc, lo_message msg, void *data) -> int
             {
@@ -52,7 +57,8 @@ namespace crone {
                 auto m = static_cast<OscMethod*>(data);
                 m->handler(argv, argc);
                 return 0;
-            }, &methods.back());
+            }, &(methods[numMethods]));
+            numMethods++;
         }
 
         static void addServerMethods();

--- a/crone/src/OscInterface.h
+++ b/crone/src/OscInterface.h
@@ -1,0 +1,76 @@
+//
+// Created by ezra on 11/4/18.
+//
+
+#ifndef SOFTCUT_OSCINTERFACE_H
+#define SOFTCUT_OSCINTERFACE_H
+
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include <lo/lo.h>
+
+
+namespace crone {
+    using std::string;
+
+    class OscInterface {
+    private:
+        static lo_server_thread st;
+        static bool quitFlag;
+        static string port;
+
+        // basically wrapper class for passing lambdas to OSC server thread
+        class OscMethod {
+            typedef void(*Handler)(lo_arg **argv, int argc);
+            string path;
+            string format;
+        public:
+            OscMethod(string p, string f, Handler h) : path(p), format(f), handler(h) {}
+            Handler handler;
+        };
+
+        static std::vector<OscMethod> methods;
+
+    private:
+
+        typedef void(*Handler)(lo_arg **argv, int argc);
+        static void handleLoError(int num, const char *m, const char *path) {
+            std::cerr << "liblo error: " << num << "; " << m << "; " << path << std::endl;
+        }
+
+        static void addServerMethod(const char* path, const char* format, Handler handler) {
+            OscMethod m(path, format, handler);
+            methods.push_back(m);
+            lo_server_thread_add_method(st, path, format,
+            [] (const char *path, const char *types, lo_arg **argv, int argc, lo_message msg, void *data) -> int
+            {
+                (void) path;
+                (void) types;
+                (void) msg;
+                auto m = static_cast<OscMethod*>(data);
+                m->handler(argv, argc);
+                return 0;
+            }, &methods.back());
+        }
+
+        static void addServerMethods();
+
+
+    public:
+        static void init() {
+            quitFlag = false;
+            port = "9999";
+            st = lo_server_thread_new(port.c_str(), handleLoError);
+            addServerMethods();
+            lo_server_thread_start(st);
+        }
+
+        static bool shouldQuit() { return quitFlag; }
+
+        static std::string getPortNumber() { return port; }
+    };
+}
+
+#endif //SOFTCUT_OSCINTERFACE_H

--- a/crone/src/Utilities.h
+++ b/crone/src/Utilities.h
@@ -1,0 +1,234 @@
+//
+// Created by ezra on 11/10/18.
+//
+
+#pragma once
+
+#include <cassert>
+#include <array>
+#include <math.h>
+#include <cmath>
+
+namespace crone {
+
+#ifndef BUILD_SC_UGEN // supercollider headers define these themselves
+    static const float log001 = -6.9078;
+
+    inline float zapgremlins(float x) {
+        float absx = fabs(x);
+        return (absx > (float) 1e-15 && absx < (float) 1e15) ? x : 0.f;
+    }
+#endif
+
+// convert a time-to-convergence to a pole coefficient
+// "ref" argument defines the amount of convergence
+// target ratio is e^ref.
+// -6.9 corresponds to standard -60db convergence
+    static float tau2pole(float t, float sr, float ref = -6.9) {
+        return exp(ref / (t * sr));
+    }
+
+// one-pole lowpass smoother
+// define this here for a consistent interpretation of pole coefficient
+// we use faust's definition where b=0 is instant, b in [0, 1)
+    static float smooth1pole(float x, float x0, float b) {
+        // return x * (1.f - b) + b * x0;f
+        // refactored
+        return x + (x0 - x) * b;
+    }
+
+#if 0 // unused
+    static float dbamp(float db) {
+        return std::isinf(db) ? 0.f : powf(10.f, db * 0.05);
+    }
+
+    static float ampdb(float amp) {
+        return log10(amp) * 20.f;
+    }
+#endif
+
+    template<typename T, size_t size>
+    class RunningAverage {
+    private:
+        // history
+        std::array<T, size> values;
+        // index of oldest value
+        size_t oldIdx;
+        // index of most recent value
+        size_t newIdx;
+        // runnning sum
+        T sum;
+
+        void advanceIdx(size_t &idx) {
+            if (++idx >= size) {idx = 0;}
+        }
+
+    public:
+        RunningAverage() {
+            assert(size >= 2);
+            values.fill(0);
+            oldIdx = 1;
+            newIdx = 0;
+            sum = (T) 0;
+        }
+
+        T update(T value) {
+            values[newIdx] = value;
+            sum += value;
+            sum -= values[oldIdx];
+            advanceIdx(oldIdx);
+            advanceIdx(newIdx);
+            return sum / size;
+        }
+    };
+
+
+    class LinearRamp {
+    private:
+
+        float sampleRate;
+        float target;
+        float inc;
+        float time;
+        float val;
+        bool rising;
+
+    private:
+        void calcInc() {
+            float d = target - val;
+            rising = d > 0.f;
+            inc = d / (time * sampleRate);
+        }
+
+    public:
+        void setSampleRate(float sr) {
+            sampleRate = sr;
+            setTime(time);
+        }
+
+        void setTime(float t) {
+            time = t;
+            calcInc();
+        }
+
+        void setTarget(float t) {
+            target = t;
+            calcInc();
+        }
+
+        LinearRamp(float sr, float t = 0.0001) :
+                sampleRate(sr), target(0.f), val(0.f), rising(false) {
+            setTime(t);
+        }
+
+        float process(float target) {
+            setTarget(target);
+            val += inc;
+            if (rising) {
+                if (val > target) {
+                    val = target;
+                }
+            } else {
+                if (val < target) {
+                    val = target;
+                }
+            }
+            return val;
+        }
+    };
+
+// logarithmic interpolator (aka 1-pole LPF)
+    class LogRamp {
+        float sampleRate;
+        float time;
+        float b;
+        float x0;
+        float y0;
+    public:
+        LogRamp(float sr, float t = 0.001) : sampleRate(sr), b(1.f), x0(0.f), y0(0.f) {
+            sampleRate = sr;
+            setTime(t);
+        }
+
+        ~LogRamp() = default;
+
+        void setSampleRate(float sr) {
+            sampleRate = sr;
+            setTime(time);
+        }
+
+        // in this case, _t_ is the time for the filter to converge within -60dB of target
+        void setTime(float t) {
+            time = t;
+            b = tau2pole(t, sampleRate);
+        }
+
+        // update input only
+        void setTarget(float x) {
+            x0 = x;
+        }
+
+        // update output only
+        float update() {
+            float y = smooth1pole(x0, y0, b);
+            y0 = y;
+            return y;
+        }
+
+        // update input and output
+        float process(float x) {
+            setTarget(x);
+            return this->update();
+        }
+
+        float getTarget() {
+            return x0;
+        }
+
+    };
+
+// a smoother with separate rise and fall times
+// "ye olde AFG"
+    class Slew {
+    private:
+        float sampleRate;
+        float x0;
+        float bR;
+        float bF;
+        float tR;
+        float tF;
+    public:
+        Slew(float sr, float rise = 0.2, float fall = 0.2) :
+            sampleRate(sr), x0(0.f) {
+            setRiseTime(rise);
+            setFallTime(fall);
+        }
+
+
+        void setSampleRate(float sr) {
+            sampleRate = sr;
+            setRiseTime(tR);
+            setFallTime(tF);
+        }
+
+        float process(float x) {
+            float b = x > x0 ? bR : bF;
+            float y = smooth1pole(x, x0, b);
+            // FIXME: zapgremlins is weirdly slow (at least on x86)
+            //x0 = zapgremlins(y);
+            x0 = y;
+            return y;
+        }
+
+        void setRiseTime(float t) {
+            tR = t;
+            bR = tau2pole(tR, sampleRate);
+        }
+
+        void setFallTime(float t) {
+            tF = t;
+            bF = tau2pole(tF, sampleRate);
+        }
+    };
+
+}

--- a/crone/src/Utilities.h
+++ b/crone/src/Utilities.h
@@ -145,8 +145,9 @@ namespace crone {
         float x0;
         float y0;
     public:
-        LogRamp(float sr, float t = 0.001) : sampleRate(sr), b(1.f), x0(0.f), y0(0.f) {
+        explicit LogRamp(float sr=48000, float t=0.001) : sampleRate(sr), b(1.f), x0(0.f), y0(0.f) {
             sampleRate = sr;
+            time = t;
             setTime(t);
         }
 
@@ -170,9 +171,8 @@ namespace crone {
 
         // update output only
         float update() {
-            float y = smooth1pole(x0, y0, b);
-            y0 = y;
-            return y;
+            y0 = smooth1pole(x0, y0, b);
+            return y0;
         }
 
         // update input and output
@@ -212,12 +212,10 @@ namespace crone {
         }
 
         float process(float x) {
-            float b = x > x0 ? bR : bF;
-            float y = smooth1pole(x, x0, b);
             // FIXME: zapgremlins is weirdly slow (at least on x86)
             //x0 = zapgremlins(y);
-            x0 = y;
-            return y;
+            x0 = smooth1pole(x, x0, x > x0 ? bR : bF);
+            return x0;
         }
 
         void setRiseTime(float t) {

--- a/crone/src/main.cpp
+++ b/crone/src/main.cpp
@@ -3,14 +3,18 @@
 //
 
 #include "JackClient.h"
-
+#include "OscInterface.h"
 
 
 int main() {
     using namespace crone;
 
+
+
     JackClient::setup();
     JackClient::start();
+
+    OscInterface::init();
 
     bool quit = false;
 

--- a/crone/src/main.cpp
+++ b/crone/src/main.cpp
@@ -1,0 +1,24 @@
+//
+// Created by emb on 11/18/18.
+//
+
+#include "JackClient.h"
+
+
+
+int main() {
+    using namespace crone;
+
+    JackClient::setup();
+    JackClient::start();
+
+    bool quit = false;
+
+    while(!quit)  {
+        ;;
+    }
+
+    JackClient::stop();
+    JackClient::cleanup();
+
+}

--- a/crone/src/main.cpp
+++ b/crone/src/main.cpp
@@ -9,8 +9,6 @@
 int main() {
     using namespace crone;
 
-
-
     JackClient::setup();
     JackClient::start();
 

--- a/crone/src/main.cpp
+++ b/crone/src/main.cpp
@@ -2,9 +2,17 @@
 // Created by emb on 11/18/18.
 //
 
+#include <iostream>
+#include <chrono>
+#include <thread>
+
 #include "JackClient.h"
 #include "OscInterface.h"
 
+
+static inline void sleep(int ms) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(ms));
+}
 
 int main() {
     using namespace crone;
@@ -14,10 +22,8 @@ int main() {
 
     OscInterface::init();
 
-    bool quit = false;
-
-    while(!quit)  {
-        ;;
+    while(!OscInterface::shouldQuit())  {
+        sleep(100);
     }
 
     JackClient::stop();

--- a/crone/src/softcut/FadeCurves.cpp
+++ b/crone/src/softcut/FadeCurves.cpp
@@ -1,0 +1,152 @@
+//
+// Created by ezra on 11/15/18.
+//
+
+#include <math.h>
+#include <algorithm>
+#include <iostream>
+#include <boost/assert.hpp>
+
+#include "Interpolate.h"
+#include "FadeCurves.h"
+
+using namespace softcut;
+
+static constexpr float fpi = 3.1415926535898f;
+
+float FadeCurves::recDelayRatio;
+float FadeCurves::preWindowRatio;
+unsigned int FadeCurves::recDelayMinFrames;
+unsigned int FadeCurves::preWindowMinFrames;
+float FadeCurves::recFadeBuf[fadeBufSize];
+float FadeCurves::preFadeBuf[fadeBufSize];
+FadeCurves::Shape FadeCurves::recShape = LINEAR;
+FadeCurves::Shape FadeCurves::preShape = LINEAR;
+
+void FadeCurves::calcRecFade() {
+    float buf[fadeBufSize];
+    unsigned int n = fadeBufSize - 1;
+    // build rec-fade curve
+    // this will be scaled by base rec level
+    unsigned int ndr = std::max(recDelayMinFrames,
+                                static_cast<unsigned int>(recDelayRatio * fadeBufSize));
+    unsigned int nr = n - ndr;
+
+    unsigned int i = 0;
+    if(recShape == SINE) {
+        const float phi = fpi / nr;
+        float x = fpi;
+        float y = 0.f;
+        while (i < ndr) {
+            buf[i++] = y;
+        }
+        while (i < n) {
+            y = cosf(x) * 0.5f + 0.5f;
+            buf[i++] = y;
+            x += phi;
+        }
+        buf[n] = 1.f;
+    } else if (recShape == LINEAR) {
+        const float phi = 1.f / nr;
+        float x = 0.f;
+        while (i < ndr) {
+            buf[i++] = x;
+        }
+        while (i < n) {
+            buf[i++] = x;
+            x += phi;
+        }
+        buf[n] = 1.f;
+    } else if (recShape == RAISED) {
+        const float phi = fpi/(nr*2);
+        float x = fpi;
+        float y = 0.f;
+        while (i < ndr) {
+            buf[i++] = y;
+        }
+        while (i < n) {
+            y = sinf(x);
+            buf[i++] = y;
+            x += phi;
+        }
+        buf[n] = 1.f;
+    } else {
+        BOOST_ASSERT_MSG(false, "undefined fade shape");
+    }
+    memcpy(recFadeBuf, buf, fadeBufSize*sizeof(float));
+}
+
+void FadeCurves::calcPreFade() {
+    float buf[fadeBufSize];
+    // build pre-fade curve
+    // this will be scaled and added to the base pre value (mapping [0, 1] -> [pre, 1])
+    unsigned int nwp = std::max(preWindowMinFrames,
+                                static_cast<unsigned int>(preWindowRatio * fadeBufSize));
+
+    unsigned int i = 0;
+    float x = 0.f;
+    if(preShape == SINE) {
+        const float phi = fpi / nwp;
+        while (i < nwp) {
+            buf[i++] = cosf(x) * 0.5f + 0.5f;
+            x += phi;
+        }
+    } else if (preShape == LINEAR){
+        const float phi = 1.f / nwp;
+        while (i < nwp) {
+            buf[i++] = 1.f - x;
+            x += phi;
+        }
+    } else if (recShape == RAISED) {
+        BOOST_ASSERT(preShape == RAISED);
+        const float phi = fpi / (nwp*2);
+        while (i < nwp) {
+            buf[i++] = cosf(x);
+            x += phi;
+        }
+    } else {
+        BOOST_ASSERT_MSG(false, "undefined fade shape");
+    }
+    while(i<fadeBufSize) { buf[i++] = 0.f; }
+    memcpy(preFadeBuf, buf, fadeBufSize*sizeof(float));
+
+}
+
+void FadeCurves::setRecDelayRatio(float x) {
+    recDelayRatio = x;
+    calcRecFade();
+}
+
+void FadeCurves::setPreWindowRatio(float x) {
+    preWindowRatio = x;
+    calcPreFade();
+}
+
+void FadeCurves::setMinRecDelayFrames(unsigned int x) {
+    recDelayMinFrames = x;
+    calcRecFade();
+}
+
+void FadeCurves::setMinPreWindowFrames(unsigned int x) {
+    preWindowMinFrames = x;
+    calcPreFade();
+}
+
+float FadeCurves::getRecFadeValue(float x) {
+    return Interpolate::tabLinear<float, fadeBufSize>(recFadeBuf, x);
+}
+
+
+float FadeCurves::getPreFadeValue(float x) {
+    return Interpolate::tabLinear<float, fadeBufSize>(preFadeBuf, x);
+}
+
+void FadeCurves::setPreShape(FadeCurves::Shape x) {
+    preShape = x;
+    calcPreFade();
+}
+
+void FadeCurves::setRecShape(FadeCurves::Shape x) {
+    recShape = x;
+    calcRecFade();
+}

--- a/crone/src/softcut/FadeCurves.h
+++ b/crone/src/softcut/FadeCurves.h
@@ -1,0 +1,51 @@
+//
+// Created by ezra on 11/15/18.
+//
+// static class for producing curves in fade period
+//
+// FIXME: this should be an object owned by SoftCutHead, passed to child SubHeads
+
+
+#ifndef SOFTCUT_FADECURVES_H
+#define SOFTCUT_FADECURVES_H
+
+namespace softcut {
+
+    class FadeCurves {
+    public:
+        typedef enum { LINEAR=0, SINE=1, RAISED=2 } Shape;
+        static void setRecDelayRatio(float x);
+        static void setPreWindowRatio(float x);
+        static void setMinRecDelayFrames(unsigned int x);
+        static void setMinPreWindowFrames(unsigned int x);
+        // set curve shape
+        static void setPreShape(Shape x);
+        static void setRecShape(Shape x);
+        // x is assumed to be in [0,1]
+        static float getRecFadeValue(float x);
+
+        static float getPreFadeValue(float x);
+
+    private:
+        static void calcPreFade();
+        static void calcRecFade();
+
+    private:
+
+        // xfade curve buffers
+        static constexpr unsigned int fadeBufSize = 1001;
+
+        // record delay and pre window in fade, as proportion of fade time
+        static float recDelayRatio;
+        static float preWindowRatio;
+        // minimum record delay/pre window, in frames
+        static unsigned int recDelayMinFrames;
+        static unsigned int preWindowMinFrames;
+        static float recFadeBuf[fadeBufSize];
+        static float preFadeBuf[fadeBufSize];
+        static Shape recShape;
+        static Shape preShape;
+    };
+}
+
+#endif //SOFTCUT_FADECURVES_H

--- a/crone/src/softcut/Interpolate.h
+++ b/crone/src/softcut/Interpolate.h
@@ -1,0 +1,43 @@
+//
+// Created by ezra on 12/8/17.
+//
+
+#ifndef SOFTCUT_INTERPOLATE_H
+#define SOFTCUT_INTERPOLATE_H
+
+namespace softcut {
+    class Interpolate {
+    public:
+        template<typename T>
+        static inline T hermite(T x, T y0, T y1, T y2, T y3) {
+            // 4-point, 3rd-order Hermite (x-form)
+#if 0
+            T c0 = y1;
+            T c1 = 0.5 * (y2 - y0);
+            T c2 = y0 - 2.5 * y1 + 2. * y2 - 0.5 * y3;
+            T c3 = 0.5 * (y3 - y0) + 1.5 * (y1 - y2);
+            return ((c3 * x + c2) * x + c1) * x + c0;
+#else // inlined:
+            return (((0.5 * (y3 - y0) + 1.5 * (y1 - y2)) * x + (y0 - 2.5 * y1 + 2. * y2 - 0.5 * y3)) * x + 0.5 * (y2 - y0)) * x + y1;
+#endif
+        }
+
+        // super-simple interpolation into a table.
+        // this makes assumptions for speed:
+        // - allocated table size is >= N+1
+        // - index is in [0, 1]
+        template<typename T, int N>
+        static inline T tabLinear(T* buf, float x) {
+            // FIXME: tidy/speed
+            const float fi = x * (N-2);
+            auto i = static_cast<unsigned int>(fi);
+            const float a = buf[i];
+            const float b = buf[i+1];
+            const float c = (fi - static_cast<float>(i));
+            return a + c*(b-a);
+        }
+
+    };
+}
+
+#endif //SOFTCUT_INTERPOLATE_H

--- a/crone/src/softcut/LowpassBrickwall.h
+++ b/crone/src/softcut/LowpassBrickwall.h
@@ -1,0 +1,127 @@
+/* ------------------------------------------------------------
+name: "BrickwallLowpass"
+Code generated with Faust 2.5.30 (https://faust.grame.fr)
+Compilation options: cpp, -scal -ftz 0
+
+output edit for efficiency - don't regenerate!
+
+------------------------------------------------------------ */
+
+#ifndef  __mydsp_H__
+#define  __mydsp_H__
+
+#include <algorithm>
+
+using std::max;
+using std::min;
+
+#ifndef FAUSTFLOAT
+#define FAUSTFLOAT float
+#endif 
+
+#include <cmath>
+#include <math.h>
+
+static float mydsp_faustpower2_f(float value) {
+	return (value * value);
+}
+
+#ifndef FAUSTCLASS 
+#define FAUSTCLASS mydsp
+#endif
+#ifdef __APPLE__ 
+#define exp10f __exp10f
+#define exp10 __exp10
+#endif
+
+class mydsp {
+	
+ private:
+	
+	int fSamplingFreq;
+	float fConst0;
+	float fConst1;
+	float fConst2;
+	float fConst3;
+	float fConst4;
+	float fConst5;
+	float fConst6;
+	float fRec2[3];
+	float fConst7;
+	float fRec1[3];
+	float fConst8;
+	float fRec0[3];
+	
+ public:
+	 void instanceConstants(int samplingFreq) {
+		fSamplingFreq = samplingFreq;
+		fConst0 = tanf((50265.4844f / min(192000.0f, max(1.0f, float(fSamplingFreq)))));
+		fConst1 = (1.0f / fConst0);
+		fConst2 = (1.0f / (((fConst1 + 0.517638087f) / fConst0) + 1.0f));
+		fConst3 = (1.0f / (((fConst1 + 1.41421354f) / fConst0) + 1.0f));
+		fConst4 = (1.0f / (((fConst1 + 1.93185163f) / fConst0) + 1.0f));
+		fConst5 = (2.0f * (1.0f - (1.0f / mydsp_faustpower2_f(fConst0))));
+		fConst6 = (((fConst1 + -1.93185163f) / fConst0) + 1.0f);
+		fConst7 = (((fConst1 + -1.41421354f) / fConst0) + 1.0f);
+		fConst8 = (((fConst1 + -0.517638087f) / fConst0) + 1.0f);
+		
+	}
+
+	 void instanceClear() {
+		for (int l0 = 0; (l0 < 3); l0 = (l0 + 1)) {
+			fRec2[l0] = 0.0f;
+			
+		}
+		for (int l1 = 0; (l1 < 3); l1 = (l1 + 1)) {
+			fRec1[l1] = 0.0f;
+			
+		}
+		for (int l2 = 0; (l2 < 3); l2 = (l2 + 1)) {
+			fRec0[l2] = 0.0f;
+			
+		}
+		
+	}
+	
+	 void init(int samplingFreq) {
+		instanceInit(samplingFreq);
+	}
+	 void instanceInit(int samplingFreq) {
+		instanceConstants(samplingFreq);
+		instanceClear();
+	}
+
+	 void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
+		FAUSTFLOAT* input0 = inputs[0];
+		FAUSTFLOAT* output0 = outputs[0];
+		for (int i = 0; (i < count); i = (i + 1)) {
+            fRec2[0] = (input0[i] - (fConst4 * ((fConst5 * fRec2[1]) + (fConst6 * fRec2[2]))));
+            fRec1[0] = ((fConst4 * (fRec2[2] + (fRec2[0] + (2.0f * fRec2[1])))) -
+                        (fConst3 * ((fConst5 * fRec1[1]) + (fConst7 * fRec1[2]))));
+            fRec0[0] = ((fConst3 * (fRec1[2] + (fRec1[0] + (2.0f * fRec1[1])))) -
+                        (fConst2 * ((fConst5 * fRec0[1]) + (fConst8 * fRec0[2]))));
+            output0[i] = fConst2 * (fRec0[2] + (fRec0[0] + (2.0f * fRec0[1])));
+            fRec2[2] = fRec2[1];
+            fRec2[1] = fRec2[0];
+            fRec1[2] = fRec1[1];
+            fRec1[1] = fRec1[0];
+            fRec0[2] = fRec0[1];
+            fRec0[1] = fRec0[0];
+        }
+	}
+};
+
+class LowpassBrickwall { 
+    mydsp dsp_;
+public:        
+    void init(int sr) {
+        dsp_.instanceConstants(sr);
+        dsp_.instanceClear();
+    }
+
+    void processSample(float* x) {
+        dsp_.compute(1, &x, &x);
+    }
+};
+
+#endif

--- a/crone/src/softcut/Resampler.h
+++ b/crone/src/softcut/Resampler.h
@@ -1,0 +1,177 @@
+//
+// Created by ezra on 4/21/18.
+//
+
+#ifndef SOFTCUTHEAD_RESAMPLER_H
+#define SOFTCUTHEAD_RESAMPLER_H
+
+#include <iostream>
+#include <cmath>
+
+#include <boost/assert.hpp>
+#include "Types.h"
+#include "Interpolate.h"
+
+// ultra-simple resampling class
+// works on mono output buffer and processes one input sample at a time
+
+// uncomment to use linear interpolation. honestly can't hear a huge difference?
+// FIXME: should be template param i guess
+// #define RESAMPLER_INTERPOLATE_LINEAR
+
+namespace softcut {
+
+    class Resampler {
+
+    public:
+
+        enum {
+            IN_BUF_FRAMES = 4, // limits interpolation order
+            IN_BUF_MASK = 3,
+            OUT_BUF_FRAMES = 64 // limits resampling ratio
+        };
+
+        // constructor
+        Resampler() : rate_(1.0), phi_(1.0), phase_(0.0)
+#ifdef RESAMPLER_INTERPOLATE_LINEAR
+#else
+                ,inBufIdx_(0)
+#endif
+        {}
+
+        int processFrame(sample_t x){
+            pushInput(x);
+            if(rate_ > 1.0) {
+                return writeUp();
+            } else {
+                return writeDown();
+            }
+        }
+
+        void setRate(rate_t r) {
+            rate_ = r;
+            phi_ = 1.0 / r;
+        }
+        // void setBuffer(float *buf, int frames);
+        void setPhase(phase_t phase) { phase_ = phase; }
+        const sample_t* output(){
+            return static_cast<const sample_t*>(outBuf_);
+        }
+
+        void reset() {
+
+#ifdef RESAMPLER_INTERPOLATE_LINEAR
+            x_ = 0.f;
+#else
+            for (sample_t &i : inBuf_) { i = 0.f; }
+            for (sample_t &i : outBuf_) { i = 0.f; }
+            inBufIdx_ = 0;
+#endif
+        }
+
+    private:
+        rate_t rate_;
+        // phase increment
+        phase_t phi_;
+        // last written phase
+        phase_t phase_;
+#ifdef RESAMPLER_INTERPOLATE_LINEAR
+        // current input value
+        sample_t x_;
+        // last input value
+        sample_t x_1_;
+#else
+        // input ringbuffer
+        sample_t inBuf_[IN_BUF_FRAMES];
+        unsigned int inBufIdx_;
+#endif
+        // output buffer
+        sample_t outBuf_[OUT_BUF_FRAMES];
+
+    private:
+        // push an input value
+        void pushInput(sample_t x){
+#ifdef RESAMPLER_INTERPOLATE_LINEAR
+            x_1_ = x_;
+            x_ = x;
+#else
+            inBufIdx_ = (inBufIdx_ + 1) & IN_BUF_MASK;
+            inBuf_[inBufIdx_] = x;
+#endif
+        }
+
+        // interpolate the most recent input samples
+        // @param f in [0, 1]
+        sample_t interpolate(phase_t f){
+#ifdef RESAMPLER_INTERPOLATE_LINEAR
+            return x_1_ + (x_ - x_1_) * f;
+#else
+            unsigned int i0, i1, i2, i3;
+            i0 = (inBufIdx_ + 1) & IN_BUF_MASK;
+            i1 = (inBufIdx_ + 2) & IN_BUF_MASK;
+            i2 = (inBufIdx_ + 3) & IN_BUF_MASK;
+            i3 = inBufIdx_;
+            return static_cast<sample_t>(Interpolate::hermite<phase_t>(f, inBuf_[i0],
+                                                                       inBuf_[i1],
+                                                                       inBuf_[i2],
+                                                                       inBuf_[i3]));
+#endif
+        }
+
+
+        // write, upsampling
+        // return frames written (>= 1)
+        // assumptions: input has been pushed. rate_ > 1.0
+        int writeUp(){
+            phase_t p = phase_ + rate_;
+            auto nf = static_cast<unsigned int>(p);
+            // we can assume that n >= 1 here
+            // we want to track fractional output phase for interpolation
+            // this is normalized to the distance between input frames
+            // so: the distance to the first output frame boundary:
+            phase_t f = 1.0 - phase_;
+            // normalized (divided by rate);
+            f = f * phi_;
+            // write the first output frame
+            unsigned int i=0;
+            outBuf_[i] = interpolate(f);
+            while(i < nf) {
+                // distance between output frames in this normalized space is 1/rate
+                f += phi_;
+                outBuf_[i] = interpolate(f);
+                i++;
+            }
+            // store the remainder of the updated, un-normalized output phase
+            phase_ = p - static_cast<phase_t>(nf);
+            return nf;
+        }
+
+
+        // write, downsampling
+        // return frames written (0 or 1)
+        // assumptions: input has been pushed. rate_ <= 1.0
+        int writeDown(){
+            // number of frames will be 1 or 0.
+            // as with upsampling inner loop,
+            // we need to produce a fractional interpolation coefficient,
+            // by "normalizing" to the output phase period
+            phase_t p = phase_ + rate_;
+            BOOST_ASSERT_MSG(p >= 0.0, "resampler encountered negative phase");
+            auto nf = static_cast<unsigned int>(p);
+            if (nf > 0) {
+                phase_t f = 1.0 - phase_;
+                f *= phi_;
+                outBuf_[0] = interpolate(f);
+                phase_ = p - static_cast<phase_t>(nf);
+            } else {
+                phase_ = p;
+            }
+            return nf;
+        }
+
+    };
+
+}
+
+#endif //SOFTCUTHEAD_RESAMPLER_H
+

--- a/crone/src/softcut/SoftClip.h
+++ b/crone/src/softcut/SoftClip.h
@@ -1,0 +1,79 @@
+//
+// Created by ezra on 11/9/18.
+//
+
+#ifndef SOFTCUT_SOFTCLIP_H
+#define SOFTCUT_SOFTCLIP_H
+
+#include <cmath>
+#include <boost/math/special_functions/sign.hpp>
+
+namespace softcut {
+
+    // two-stage quadratic soft clipper with variable gain
+    // nice odd harmonics, kinda carbon-mic sound
+    class SoftClip {
+    private:
+
+        float t; // threshold (beginning of knee)
+        float g;  // gain multiplier
+        float a;  // parabolic coefficient
+        float b;  // parabolic offset ( = max level)
+
+        // update quad multiplier from current settings
+        void calcCoeffs() {
+            // match derivative at knee point
+            // FIXME: should be able to factor this such that b=1 always, user sets g only
+            float t_1 = t - 1.f;
+            if (t_1 < 0.f) {
+                a = g / (2.f * t_1);
+                b = g * t - (a * t_1 * t_1);
+            } else {
+                a = 0.f;
+                b = 1.f;
+            }
+        }
+
+    public:
+        SoftClip(float t_ = 0.68f, float g_ = 1.2f)
+        : t(t_), g(g_) {
+            calcCoeffs();
+        }
+
+        float processSample(float x) {
+            float ax = fabs(x);
+            const float sx = boost::math::sign(x);
+
+            if (ax > 1.f) {
+                ax = 1.f;
+            }
+
+            if (ax < t) {
+                return x * g;
+            } else {
+                const float q = ax - 1.f;
+                const float y = (a * q * q) + b;
+                return sx * y;
+            }
+        }
+
+        void setGain(float r) {
+            g = r;
+            calcCoeffs();
+        }
+
+        void setLowThresh(float amp) {
+            t = amp;
+            calcCoeffs();
+        }
+
+        float getGain() { return g; }
+
+        float getLowThresh() { return t; }
+
+        float getHighThreshDb() { return b; }
+
+    };
+}
+
+#endif //SOFTCUT_SOFTCLIP_H

--- a/crone/src/softcut/SoftCut.cpp
+++ b/crone/src/softcut/SoftCut.cpp
@@ -1,0 +1,181 @@
+//
+// Created by emb on 11/10/18.
+//
+
+#include <thread>
+
+#include "Commands.h"
+#include "FadeCurves.h"
+#include "SoftCut.h"
+
+using namespace softcut;
+
+SoftCut::SoftCut() {
+    init();
+}
+
+void SoftCut::init() {
+
+    for (auto &v : scv) {
+        v.setBuffer(buf, bufFrames);
+    }
+
+    // FIXME? wrong place for this probly
+    FadeCurves::setPreShape(FadeCurves::Shape::LINEAR);
+    FadeCurves::setRecShape(FadeCurves::Shape::RAISED);
+    FadeCurves::setMinPreWindowFrames(0);
+    FadeCurves::setMinRecDelayFrames(0);
+    FadeCurves::setPreWindowRatio(1.f/8);
+    FadeCurves::setRecDelayRatio(1.f/(8*16));
+}
+
+void SoftCut::processBlock(const float *in0, const float* in1, float *out0, float* out1, int numFrames) {
+    (void)in1;
+    Commands::handlePending(this);
+
+    for(int fr=0; fr<numFrames; ++fr) {
+        out0[fr] = 0;
+        out1[fr] = 0;
+    }
+    for (int v=0; v<numVoices; ++v) {
+        scv[v].processBlockMono(in0, outBus, numFrames);
+        float amp0 = outAmp[v][0];
+        float amp1 = outAmp[v][1];
+        for(int fr=0; fr<numFrames; ++fr) {
+            out0[fr] += outBus[fr] * amp0;
+            out1[fr] += outBus[fr] * amp1;
+        }
+    }
+}
+
+void SoftCut::setSampleRate(unsigned int hz) {
+    for (auto &v : scv) {
+        v.setSampleRate(hz);
+    }
+}
+
+void SoftCut::setRate(int voice, float rate) {
+  scv[voice].setRate( rate);
+}
+
+void SoftCut::setLoopStart(int voice, float sec) {
+  scv[voice].setLoopStart( sec);
+}
+
+void SoftCut::setLoopEnd(int voice, float sec) {
+  scv[voice].setLoopEnd( sec);
+}
+
+void SoftCut::setLoopFlag(int voice, bool val) {
+  scv[voice].setLoopFlag( val);
+}
+
+void SoftCut::setFadeTime(int voice, float sec) {
+  scv[voice].setFadeTime( sec);
+}
+
+void SoftCut::setRecLevel(int voice, float amp) {
+  scv[voice].setRecLevel( amp);
+}
+
+void SoftCut::setPreLevel(int voice, float amp) {
+  scv[voice].setPreLevel( amp);
+}
+
+void SoftCut::setRecFlag(int voice, bool val) {
+  scv[voice].setRecFlag( val);
+}
+
+void SoftCut::cutToPos(int voice, float sec) {
+    scv[voice].cutToPos(sec);
+}
+
+void SoftCut::setFilterFc(int voice, float x) {
+  scv[voice].setFilterFc(x);
+}
+
+void SoftCut::setFilterRq(int voice, float x) {
+  scv[voice].setFilterRq(x);
+}
+
+void SoftCut::setFilterLp(int voice, float x) {
+  scv[voice].setFilterLp(x);
+}
+
+void SoftCut::setFilterHp(int voice, float x) {
+  scv[voice].setFilterHp(x);
+}
+
+void SoftCut::setFilterBp(int voice, float x) {
+  scv[voice].setFilterBp(x);
+}
+
+void SoftCut::setFilterBr(int voice, float x) {
+  scv[voice].setFilterBr(x);
+}
+
+void SoftCut::setFilterDry(int voice, float x) {
+  scv[voice].setFilterDry(x);
+}
+
+void SoftCut::setFilterFcMod(int voice, float x) {
+  scv[voice].setFilterFcMod( x);
+}
+
+void SoftCut::setAmpLeft(int voice, float x) {
+    outAmp[voice][0] = x;
+}
+
+void SoftCut::setAmpRight(int voice, float x) {
+    outAmp[voice][1] = x;
+}
+
+// NB fade curve recalculation happens on a separate thread
+// the update function first fills a new buffer, then copies the final values
+// this should mitigate glitches a little, but they can certainly still occur
+// if fade curves are updated while loop recording is active
+void SoftCut::setPreFadeWindow(float x) {
+    auto t = std::thread([x] {
+        FadeCurves::setPreWindowRatio(x);
+    });
+    t.detach();
+}
+
+void SoftCut::setRecFadeDelay(float x) {
+    auto t = std::thread([x] {
+        FadeCurves::setRecDelayRatio(x);
+    });
+    t.detach();
+}
+
+
+void SoftCut::setPreFadeShape(float x) {
+    auto t = std::thread([x] {
+        FadeCurves::setPreShape(static_cast<FadeCurves::Shape>(x));
+    });
+    t.detach();
+}
+
+
+void SoftCut::setRecFadeShape(float x) {
+    auto t = std::thread([x] {
+        FadeCurves::setRecShape(static_cast<FadeCurves::Shape>(x));
+    });
+    t.detach();
+}
+
+void SoftCut::printTestBuffers() {
+    scv[0].printTestBuffers();
+}
+
+void SoftCut::setRecOffset(int i, float d) {
+    scv[i].setRecOffset(d);
+}
+
+void SoftCut::setLevelSlewTime(int i, float d) {
+    scv[i].setLevelSlewTime(d);
+}
+
+void SoftCut::setRateSlewTime(int i, float d) {
+    scv[i].setRateSlewTime(d);
+}

--- a/crone/src/softcut/SoftCut.h
+++ b/crone/src/softcut/SoftCut.h
@@ -1,0 +1,73 @@
+//
+// Created by emb on 11/10/18.
+//
+
+#ifndef SOFTCUT_SOFTCUT_H
+#define SOFTCUT_SOFTCUT_H
+
+#include "SoftCutVoice.h"
+
+namespace softcut {
+
+    class SoftCut {
+
+
+    public:
+        enum { numVoices = 2 };
+        enum { bufFrames = 16777216 };
+        enum { maxBlockSize = 8192 };
+
+        int getNumVoices() { return numVoices; }
+
+        SoftCut();
+
+        void init();
+
+        void processBlock(const float *in0, const float* in1, float *out0, float* out1, int numFrames);
+
+        void setSampleRate(unsigned int i);
+
+        void setRate(int voice, float rate);
+        void setLoopStart(int voice, float sec);
+        void setLoopEnd(int voice, float sec);
+        void setLoopFlag(int voice, bool val);
+        void setFadeTime(int voice, float sec);
+        void setRecLevel(int voice, float amp);
+        void setPreLevel(int voice, float amp);
+        void setRecFlag(int voice, bool val);
+		void cutToPos(int voice, float sec);
+
+        void setFilterFc(int voice, float);
+        void setFilterRq(int voice, float);
+        void setFilterLp(int voice, float);
+        void setFilterHp(int voice, float);
+        void setFilterBp(int voice, float);
+        void setFilterBr(int voice, float);
+        void setFilterDry(int voice, float);
+        void setFilterFcMod(int voice, float x);
+
+        // FIXME: yes this is an ugly API, but easiest r/n to keep consistent count of args for all setters
+		void setAmpLeft(int voice, float x);
+		void setAmpRight(int voice, float x);
+
+		void setPreFadeWindow(float x);
+        void setRecFadeDelay(float x);
+        void setPreFadeShape(float x);
+        void setRecFadeShape(float x);
+
+
+        void setRecOffset(int i, float d);
+		void setLevelSlewTime(int i, float d);
+		void setRateSlewTime(int i, float d);
+
+		void printTestBuffers();
+	private:
+        SoftCutVoice scv[numVoices];
+        float outAmp[numVoices][2];
+        float outBus[maxBlockSize];
+		float buf[bufFrames];
+	};
+}
+
+
+#endif //SOFTCUT_SOFTCUT_H

--- a/crone/src/softcut/SoftCutHead.cpp
+++ b/crone/src/softcut/SoftCutHead.cpp
@@ -1,0 +1,196 @@
+//
+// Created by ezra on 12/6/17.
+//
+#include <cmath>
+#include <limits>
+
+
+#include "Interpolate.h"
+#include "Resampler.h"
+
+#include "SoftCutHead.h"
+
+using namespace softcut;
+using namespace std;
+
+SoftCutHead::SoftCutHead() {
+    this->init();
+}
+
+void SoftCutHead::init() {
+    sr = 44100.f;
+    start = 0.f;
+    end = 0.f;
+    active = 0;
+    rate = 1.f;
+    setFadeTime(0.1f);
+    recFlag = false;
+    testBuf.init();
+}
+
+void SoftCutHead::processSample(sample_t in, float *outPhase, float *outTrig, sample_t *outAudio) {
+
+#if 1 // testing...
+    testBuf.update(static_cast<float>(head[0].phase_), head[0].wrIdx_, head[0].fade_, head[0].state_, head[0].preFade, head[0].recFade);
+#endif
+
+    *outAudio = mixFade(head[0].peek(), head[1].peek(), head[0].fade(), head[1].fade());
+    *outTrig = head[0].trig() + head[1].trig();
+
+    if(outPhase != nullptr) {
+        *outPhase = static_cast<float>(head[active].phase());
+    }
+
+    int numFades = (head[0].state_ == FADEIN || head[0].state_ == FADEOUT)
+            + (head[1].state_ == FADEIN || head[1].state_ == FADEOUT);
+
+    BOOST_ASSERT_MSG(!(head[0].state_ == ACTIVE && head[1].state_ == ACTIVE), "multiple active heads");
+
+
+    // FIXME: should probably continue to push input to resampler when not recording
+    if(recFlag) {
+        head[0].poke(in, pre, rec, numFades);
+        head[1].poke(in, pre, rec, numFades);
+    }
+    takeAction(head[0].updatePhase(start, end, loopFlag));
+    takeAction(head[1].updatePhase(start, end, loopFlag));
+
+    head[0].updateFade(fadeInc);
+    head[1].updateFade(fadeInc);
+
+}
+
+void SoftCutHead::setRate(rate_t x)
+{
+    rate = x;
+    calcFadeInc();
+    head[0].setRate(x);
+    head[1].setRate(x);
+}
+
+void SoftCutHead::setLoopStartSeconds(float x)
+{
+    start = x * sr;
+}
+
+void SoftCutHead::setLoopEndSeconds(float x)
+{
+    end = x * sr;
+}
+
+void SoftCutHead::takeAction(Action act)
+{
+    switch (act) {
+        case Action::LOOP_POS:
+            std::cerr << "looping: go to start" << std::endl;
+            cutToPhase(start);
+            break;
+        case Action::LOOP_NEG:
+            std::cerr << "looping: go to end" << std::endl;
+            cutToPhase(end);
+            break;
+        case Action::STOP:
+        case Action::NONE:
+        default: ;;
+    }
+}
+
+void SoftCutHead::cutToPhase(phase_t pos) {
+    State s = head[active].state();
+
+    // ignore if we are already in a crossfade
+    if(s == State::FADEIN || s == State::FADEOUT) {
+        // std::cout << "skipping phase change due to ongoing xfade" << std::endl;
+        return;
+    }
+
+    // activate the inactive head
+    int newActive = active ^ 1;
+    if(s != State::INACTIVE) {
+        head[active].setState(State::FADEOUT);
+    }
+
+    head[newActive].setState(State::FADEIN);
+    head[newActive].setPhase(pos);
+
+    head[active].active_ = false;
+    head[newActive].active_ = true;
+    active = newActive;
+    std::cerr << "active: " << active << std::endl;
+}
+
+void SoftCutHead::setFadeTime(float secs) {
+    fadeTime = secs;
+    calcFadeInc();
+}
+void SoftCutHead::calcFadeInc() {
+    fadeInc = (float) fabs(rate) / std::max(1.f, (fadeTime * sr));
+    fadeInc = std::max(0.f, std::min(fadeInc, 1.f));
+    // printf("fade time = %f; rate = %f; inc = %f\n", fadeTime, rate, fadeInc);
+}
+
+void SoftCutHead::setBuffer(float *b, uint32_t bf) {
+    buf = b;
+    head[0].setBuffer(b, bf);
+    head[1].setBuffer(b, bf);
+}
+
+void SoftCutHead::setLoopFlag(bool val) {
+    loopFlag = val;
+}
+
+void SoftCutHead::setSampleRate(float sr_) {
+    sr = sr_;
+    head[0].setSampleRate(sr);
+    head[1].setSampleRate(sr);
+}
+
+sample_t SoftCutHead::mixFade(sample_t x, sample_t y, float a, float b) {
+#if 1
+        return x * sinf(a * (float)M_PI_2) + y * sinf(b * (float) M_PI_2);
+#else
+        return (x * a) + (y * b);
+#endif
+}
+
+void SoftCutHead::setRec(float x) {
+    rec = x;
+}
+
+void SoftCutHead::setPre(float x) {
+    pre= x;
+}
+
+void SoftCutHead::setRecRun(bool val) {
+    recFlag = val;
+}
+
+phase_t SoftCutHead::getActivePhase() {
+  return head[active].phase();
+}
+
+float SoftCutHead::getTrig() {
+  return head[0].trig()+ head[1].trig();
+}
+
+void SoftCutHead::resetTrig() {
+  head[0].setTrig(0);
+  head[1].setTrig(0);
+}
+
+void SoftCutHead::cutToPos(float seconds) {
+    cutToPhase(seconds * sr);
+}
+
+rate_t SoftCutHead::getRate() {
+    return rate;
+}
+
+void SoftCutHead::printTestBuffers() {
+    testBuf.print();
+}
+
+void SoftCutHead::setRecOffset(float d) {
+    head[0].setRecOffset(d);
+    head[1].setRecOffset(d);
+}

--- a/crone/src/softcut/SoftCutHead.h
+++ b/crone/src/softcut/SoftCutHead.h
@@ -1,0 +1,77 @@
+//
+// Created by ezra on 12/6/17.
+//
+
+#ifndef CUTFADEVOICE_CUTFADEVOICELOGIC_H
+#define CUTFADEVOICE_CUTFADEVOICELOGIC_H
+
+#include <cstdint>
+#include "SubHead.h"
+#include "Types.h"
+#include "TestBuffers.h"
+
+namespace  softcut{
+
+    class SoftCutHead {
+    public:
+
+        SoftCutHead();
+        void init();
+
+        // per-sample update function
+        void processSample(sample_t in, float *outPhase, float *outTrig, sample_t *outAudio);
+
+        void setSampleRate(float sr);
+        void setBuffer(sample_t *buf, uint32_t size);
+        void setRate(rate_t x);              // set the playback rate (as a ratio)
+        void setLoopStartSeconds(float x);  // set the Voice endpoint in seconds
+        void setLoopEndSeconds(float x);    // set the Voice start point in seconds
+        void setFadeTime(float secs);
+        void setLoopFlag(bool val);
+        void setRec(float x);
+        void setPre(float x);
+        void setRecRun(bool val);
+
+        /// FIXME: this method accepts samples and doesn't wrap.
+        /// should add something like cutToPos(seconds)
+        void cutToPos(float seconds);
+
+        phase_t getActivePhase();
+        float getTrig();
+        void resetTrig();
+
+        rate_t getRate();
+
+        void printTestBuffers();
+
+        void setRecOffset(float d);
+
+    private:
+        // fade in to new position (given in samples)
+        // assumption: phase is in range!
+        void cutToPhase(phase_t newPhase);
+        void takeAction(Action act);
+        sample_t mixFade(sample_t x, sample_t y, float a, float b); // mix two inputs with phases
+        void calcFadeInc();
+
+    private:
+        SubHead head[2];
+
+        sample_t *buf;     // audio buffer (allocated elsewhere)
+        float sr;       // sample rate
+        phase_t start;    // start/end points
+        phase_t end;
+        float fadeTime; // fade time in seconds
+        float fadeInc;  // linear fade increment per sample
+
+        int active;     // current active play head index (0 or 1)
+        bool loopFlag;  // set to loop, unset for 1-shot
+        float pre; // pre-record level
+        float rec; // record level
+        bool recFlag;
+
+        rate_t rate;
+        TestBuffers testBuf;
+    };
+}
+#endif //CUTFADEVOICE_CUTFADEVOICELOGIC_H

--- a/crone/src/softcut/SoftCutVoice.cpp
+++ b/crone/src/softcut/SoftCutVoice.cpp
@@ -1,0 +1,153 @@
+//
+// Created by ezra on 11/3/18.
+//
+// main audo
+//
+
+#include "Commands.h"
+#include "SoftCutVoice.h"
+
+using namespace softcut;
+
+SoftCutVoice::SoftCutVoice() :
+rateRamp(48000, 0.1),
+preRamp(48000, 0.1),
+recRamp(48000, 0.1)
+{
+    fcBase = 16000;
+    sch.init();
+    svf.setLpMix(1.0);
+    svf.setHpMix(0.0);
+    svf.setBpMix(0.0);
+    svf.setBrMix(0.0);
+    svf.setRq(20.0);
+    svf.setFc(fcBase);
+    svfDryLevel = 1.0;
+}
+
+void SoftCutVoice:: processBlockMono(const float *in, float *out, int numFrames) {
+    float trigDummy;
+    float phaseDummy;
+
+    float x;
+    for(int i=0; i<numFrames; ++i) {
+#if 1
+        x = svf.getNextSample(in[i]) + in[i]*svfDryLevel;
+#else
+        x = in[i];
+#endif
+        sch.setRate(rateRamp.update());
+        sch.setPre(preRamp.update());
+        sch.setRec(recRamp.update());
+        sch.processSample(x, &phaseDummy, &trigDummy, &(out[i]));
+    }
+}
+
+void SoftCutVoice::setSampleRate(float hz) {
+    sampleRate = hz;
+    rateRamp.setSampleRate(hz);
+    preRamp.setSampleRate(hz);
+    recRamp.setSampleRate(hz);
+    sch.setSampleRate(sampleRate);
+    svf.setSampleRate(hz);
+}
+
+void SoftCutVoice::setRate(float rate) {
+    rateRamp.setTarget(rate);
+    updateFilterFc();
+}
+
+void SoftCutVoice::setLoopStart(float sec) {
+    sch.setLoopStartSeconds(sec);
+}
+
+void SoftCutVoice::setLoopEnd(float sec) {
+    sch.setLoopEndSeconds(sec);
+}
+
+void SoftCutVoice::setFadeTime(float sec) {
+    sch.setFadeTime(sec);
+}
+
+void SoftCutVoice::cutToPos(float sec) {
+    sch.cutToPos(sec);
+}
+
+void SoftCutVoice::setRecLevel(float amp) {
+    recRamp.setTarget(amp);
+}
+
+void SoftCutVoice::setPreLevel(float amp) {
+    preRamp.setTarget(amp);
+}
+
+void SoftCutVoice::setRecFlag(bool val) {
+    sch.setRecRun(val);
+}
+
+void SoftCutVoice::setLoopFlag(bool val) {
+    sch.setLoopFlag(val);
+}
+
+void SoftCutVoice::setFilterFc(float x) {
+    fcBase = x;
+    updateFilterFc();
+}
+
+void SoftCutVoice::setFilterRq(float x) {
+    svf.setRq(x);
+}
+
+void SoftCutVoice::setFilterLp(float x) {
+    svf.setLpMix(x);
+}
+
+void SoftCutVoice::setFilterHp(float x) {
+    svf.setHpMix(x);
+}
+
+void SoftCutVoice::setFilterBp(float x) {
+    svf.setBpMix(x);
+}
+
+void SoftCutVoice::setFilterBr(float x) {
+    svf.setBrMix(x);
+}
+
+void SoftCutVoice::setFilterDry(float x) {
+    svfDryLevel = x;
+}
+
+void SoftCutVoice::setFilterFcMod(float x) {
+    fcMod = x;
+}
+
+void SoftCutVoice::updateFilterFc() {
+    float fc = std::min(fcBase, fcBase * std::fabs(static_cast<float>(sch.getRate())));
+    // std::cout << fc << std::endl;
+    svf.setFc(fc*fcMod + (1.f-fcMod )*svf.getFc());
+}
+
+void SoftCutVoice::setBuffer(float *b, unsigned int nf) {
+    buf = b;
+    bufFrames = nf;
+    sch.setBuffer(buf, bufFrames);
+}
+
+void SoftCutVoice::printTestBuffers() {
+    sch.printTestBuffers();
+}
+
+void SoftCutVoice::setRecOffset(float d) {
+    sch.setRecOffset(d);
+}
+
+void SoftCutVoice::setLevelSlewTime(float d) {
+    recRamp.setTime(d);
+    preRamp.setTime(d);
+}
+
+void SoftCutVoice::setRateSlewTime(float d) {
+    rateRamp.setTime(d);
+}
+

--- a/crone/src/softcut/SoftCutVoice.h
+++ b/crone/src/softcut/SoftCutVoice.h
@@ -1,0 +1,80 @@
+//
+// Created by ezra on 11/3/18.
+//
+
+#ifndef SOFTCUT_SOFTCUTVOICE_H
+#define SOFTCUT_SOFTCUTVOICE_H
+
+#include <array>
+#include "SoftCutHead.h"
+#include "Svf.h"
+#include "Utilities.h"
+
+namespace softcut {
+    class SoftCutVoice {
+    public:
+        SoftCutVoice();
+        void setBuffer(float* buf, unsigned int numFrames);
+
+        void setSampleRate(float hz);
+        void setRate(float rate);
+        void setLoopStart(float sec);
+        void setLoopEnd(float sec);
+        void setLoopFlag(bool val);
+
+        void setFadeTime(float sec);
+
+        void setRecLevel(float amp);
+        void setPreLevel(float amp);
+        void setRecFlag(bool val);
+
+        void setFilterFc(float);
+        void setFilterRq(float);
+        void setFilterLp(float);
+        void setFilterHp(float);
+        void setFilterBp(float);
+        void setFilterBr(float);
+        void setFilterDry(float);
+        void setFilterFcMod(float x);
+
+        void cutToPos(float sec);
+        // process a single channel
+        void processBlockMono(const float* in, float* out, int numFrames);
+
+        void printTestBuffers();
+
+        void setRecOffset(float d);
+
+        void setLevelSlewTime(float d);
+
+        void setRateSlewTime(float d);
+
+    private:
+        float* buf;
+        int bufFrames;
+        float sampleRate;
+
+        // xfaded read/write head
+        SoftCutHead sch;
+        // input filter
+        Svf svf;
+        // rate ramp
+        LogRamp rateRamp;
+        // pre-level ramp
+        LogRamp preRamp;
+        // record-level ramp
+        LogRamp recRamp;
+
+        // default frequency for SVF
+        // reduced automatically when setting rate
+        float fcBase;
+        // the amount by which SVF frequency is modulated by rate
+        float fcMod = 1.0;
+        float svfDryLevel = 1.0;
+
+        void updateFilterFc();
+    };
+}
+
+
+#endif //SOFTCUT_SOFTCUTVOICE_H

--- a/crone/src/softcut/SubHead.cpp
+++ b/crone/src/softcut/SubHead.cpp
@@ -1,0 +1,210 @@
+//
+// Created by ezra on 4/21/18.
+//
+
+#include <string.h>
+#include <limits>
+
+#include "Interpolate.h"
+#include "FadeCurves.h"
+#include "SubHead.h"
+
+using namespace softcut;
+
+
+SubHead::SubHead() {
+    this->init();
+}
+
+void SubHead::init() {
+    phase_ = 0;
+    fade_ = 0;
+    trig_ = 0;
+    state_ = INACTIVE;
+    resamp_.setPhase(0);
+    inc_dir_ = 1;
+    recOffset_ = -8;
+}
+
+Action SubHead::updatePhase(phase_t start, phase_t end, bool loop) {
+    Action res = NONE;
+    trig_ = 0.f;
+    phase_t p;
+    switch(state_) {
+        case FADEIN:
+        case FADEOUT:
+        case ACTIVE:
+            p = phase_ + rate_;
+            if(active_) {
+                // FIXME: should refactor this a bit.
+                if (rate_ > 0.f) {
+                    if (p > end || p < start) {
+                        if (loop) {
+                            trig_ = 1.f;
+                            res = LOOP_POS;
+                        } else {
+                            state_ = FADEOUT;
+                            res = STOP;
+                        }
+                    }
+                } else { // negative rate
+                    if (p > end || p < start) {
+                        if(loop) {
+                            trig_ = 1.f;
+                            res = LOOP_NEG;
+                        } else {
+                            state_ = FADEOUT;
+                            res = STOP;
+                        }
+                    }
+                } // rate sign check
+            } // /active check
+            phase_ = p;
+            break;
+        case INACTIVE:
+        default:
+            ;; // nothing to do
+    }
+    return res;
+}
+
+void SubHead::updateFade(float inc) {
+    switch(state_) {
+        case FADEIN:
+            fade_ += inc;
+            if (fade_ > 1.f) {
+                fade_ = 1.f;
+                state_ = ACTIVE;
+            }
+            break;
+        case FADEOUT:
+            fade_ -= inc;
+            if (fade_ < 0.f) {
+                fade_ = 0.f;
+                state_ = INACTIVE;
+            }
+            break;
+        case ACTIVE:
+        case INACTIVE:
+        default:;; // nothing to do
+    }
+}
+
+#if 0
+/// test: no resampling
+void SubHead::poke(float in, float pre, float rec, int numFades) {
+    sample_t* p = &buf_[static_cast<unsigned int>(phase_)&bufMask_];
+    *p *= pre;
+    *p += (in * rec);
+}
+#else
+void SubHead::poke(float in, float pre, float rec, int numFades) {
+    (void)numFades;
+    // FIXME: since there's never really a reason to not push input, or to reset input ringbuf,
+    // it follows that all resamplers can share an input ringbuf
+    int nframes = resamp_.processFrame(in);
+
+    if(state_ == INACTIVE) {
+        return;
+    }
+
+    BOOST_ASSERT_MSG(fade_ >= 0.f && fade_ <= 1.f, "bad fade coefficient in poke()");
+
+#if 0 // test
+    preFade = pre;
+    recFade = rec * fade_;
+#else
+    preFade = pre + (1.f-pre) * FadeCurves::getPreFadeValue(fade_);
+    recFade = rec * FadeCurves::getRecFadeValue(fade_);
+#endif
+    sample_t y; // write value
+    const sample_t* src = resamp_.output();
+
+    for(int i=0; i<nframes; ++i) {
+        y = src[i];
+
+#if 1 // soft clipper
+        y = clip_.processSample(y);
+#endif
+#if 1 // lowpass filter
+        lpf_.processSample(&y);
+#endif
+        buf_[wrIdx_] *= preFade;
+        buf_[wrIdx_] += y * recFade;
+
+        wrIdx_ = wrapBufIndex(wrIdx_ + inc_dir_);
+    }
+}
+#endif
+
+float SubHead::peek() {
+    return peek4();
+}
+
+float SubHead::peek4() {
+    int phase1 = static_cast<int>(phase_);
+    int phase0 = phase1 - 1;
+    int phase2 = phase1 + 1;
+    int phase3 = phase1 + 2;
+
+    float y0 = buf_[wrapBufIndex(phase0)];
+    float y1 = buf_[wrapBufIndex(phase1)];
+    float y3 = buf_[wrapBufIndex(phase3)];
+    float y2 = buf_[wrapBufIndex(phase2)];
+
+    auto x = static_cast<float>(phase_ - (float)phase1);
+    return Interpolate::hermite<float>(x, y0, y1, y2, y3);
+}
+
+unsigned int SubHead::wrapBufIndex(int x) {
+    x += bufFrames_;
+    BOOST_ASSERT_MSG(x >= 0, "buffer index before masking is non-negative");
+    return x & bufMask_;
+}
+
+void SubHead::setSampleRate(float sr) {
+    lpf_.init(static_cast<int>(sr));
+}
+
+void SubHead::setPhase(phase_t phase) {
+    phase_ = phase;
+    wrIdx_ = wrapBufIndex(static_cast<int>(phase_) + (inc_dir_ * recOffset_));
+    std::cerr << "new phase="<<phase_ << "; wrIdx="<<wrIdx_ << std::endl;
+    // FIXME: we are hitting this sometimes. fade is always quite small...
+    // rounding error? wrong order of calculations?
+#if 0
+    if(fade_ > std::numeric_limits<float>::epsilon()) {
+        std::cerr << "fade=" << fade_ << std::endl;
+        BOOST_ASSERT_MSG(false, "changing phase with fade>0");
+    }
+#endif
+
+    // NB: not resetting the resampler here:
+    // - it's ok to keep history of input when changing positions.
+    // - resmp output doesn't need clearing b/c we write/read from beginning on each sample anyway
+}
+
+// !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+// **NB** buffer size must be a power of two!!!!
+void SubHead::setBuffer(float *buf, unsigned int frames) {
+    buf_  = buf;
+    bufFrames_ = frames;
+    bufMask_ = frames - 1;
+    BOOST_ASSERT_MSG((bufFrames_ != 0) && !(bufFrames_ & bufMask_), "buffer size is not 2^N");
+}
+
+void SubHead::setRate(rate_t rate) {
+    rate_ = rate;
+    inc_dir_ = boost::math::sign(rate);
+    // NB: resampler doesn't handle negative rates.
+    // instead we copy the resampler output backwards into the buffer when rate < 0.
+    resamp_.setRate(std::fabs(rate));
+}
+
+
+void SubHead::setState(State state) { state_ = state; }
+void SubHead::setTrig(float trig) { trig_ = trig; }
+
+void SubHead::setRecOffset(float d) {
+    recOffset_  = static_cast<int>(d);
+}

--- a/crone/src/softcut/SubHead.h
+++ b/crone/src/softcut/SubHead.h
@@ -1,0 +1,92 @@
+//
+// Created by ezra on 4/21/18.
+//
+
+/*
+ * this class implements one half of a crossfaded read/write sch.
+ */
+
+#ifndef SOFTCUTHEAD_SUBHEAD_H
+#define SOFTCUTHEAD_SUBHEAD_H
+
+#include <boost/math/special_functions/sign.hpp>
+
+#include "Resampler.h"
+#include "LowpassBrickwall.h"
+#include "SoftClip.h"
+#include "Types.h"
+
+namespace softcut {
+
+    typedef enum { ACTIVE=0, INACTIVE=1, FADEIN=2, FADEOUT=3 } State;
+    typedef enum { NONE, STOP, LOOP_POS, LOOP_NEG } Action ;
+
+    class SubHead {
+        friend class SoftCutHead;
+    public:
+        SubHead();
+        void init();
+        void setSampleRate(float sr);
+    private:
+        sample_t peek4();
+        unsigned int wrapBufIndex(int x);
+
+    protected:
+        sample_t peek();
+        //! poke
+        //! @param in: input value
+        //! @param pre: scaling level for previous buffer content
+        //! @param rec: scaling level for new content
+        //! @param numFades: number of heads currently in crossfade
+        void poke(sample_t in, float pre, float rec, int numFades);
+        Action updatePhase(phase_t start, phase_t end, bool loop);
+        void updateFade(float inc);
+
+        // getters
+        phase_t phase() { return phase_; }
+        float fade() { return fade_; }
+        float trig() { return trig_; }
+        State state() { return state_; }
+        
+        // setters
+        void setState(State state);
+        void setTrig(float trig);
+        void setPhase(phase_t phase);
+
+        // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+        // **NB** buffer size must be a power of two!!!!
+        void setBuffer(sample_t *buf, unsigned int frames);
+        void setRate(rate_t rate);
+
+
+    private:
+        Resampler resamp_;
+        LowpassBrickwall lpf_;
+        SoftClip clip_;
+
+        sample_t* buf_; // output buffer
+        unsigned int wrIdx_; // write index
+        unsigned int bufFrames_;
+        unsigned int bufMask_;
+
+        State state_;
+        rate_t rate_;
+        int inc_dir_;
+        phase_t phase_;
+        float fade_;
+        float trig_; // output trigger value
+        bool active_;
+        int recOffset_;
+
+        // test...
+    public:
+        float preFade;
+        float recFade;
+
+        void setRecOffset(float d);
+    };
+
+}
+
+
+#endif //SOFTCUTHEAD_SUBHEAD_H

--- a/crone/src/softcut/Svf.cpp
+++ b/crone/src/softcut/Svf.cpp
@@ -1,0 +1,97 @@
+//
+// Created by ezra on 11/8/18.
+//
+
+#include <math.h>
+#include "Svf.h"
+
+Svf::Svf() = default;
+
+float Svf::getNextSample(float x) {
+    svf_update(&svf, x);
+    return svf.lp * lpMix + svf.hp * hpMix + svf.bp * bpMix + svf.br * brMix;
+}
+
+void Svf::setSampleRate(float sr) {
+    svf_set_sr(&svf, sr);
+}
+
+void Svf::setFc(float fc) {
+    svf_set_fc(&svf, fc);
+}
+
+void Svf::setRq(float rq) {
+    svf_set_rq(&svf, rq);
+}
+
+void Svf::setLpMix(float mix) {
+    lpMix = mix;
+}
+
+void Svf::setHpMix(float mix) {
+    hpMix = mix;
+}
+
+void Svf::setBpMix(float mix) {
+    bpMix = mix;
+}
+
+void Svf::setBrMix(float mix) {
+        brMix = mix;
+}
+
+/////////////////
+// C implementation
+
+void Svf::svf_calc_coeffs(t_svf* svf) {
+    svf->g = static_cast<float>(tan(M_PI * svf->fc / svf->sr));
+    svf->g1 = svf->g / (1.f + svf->g * (svf->g + svf->rq));
+    svf->g2 = 2.f * (svf->g + svf->rq) * svf->g1;
+    svf->g3 = svf->g * svf->g1;
+    svf->g4 = 2.f * svf->g1;
+}
+
+void Svf::svf_init(t_svf* svf) {
+    svf_clear_state(svf);
+}
+
+void Svf::svf_clear_state(t_svf* svf) {
+    svf->v0z = 0;
+    svf->v1 = 0;
+    svf->v2 = 0;
+}
+
+void Svf::svf_set_sr(t_svf* svf, float sr) {
+    svf->sr = sr;
+    svf_calc_coeffs(svf);
+}
+
+void Svf::svf_set_fc(t_svf* svf, float fc) {
+    svf->fc = fc;
+    svf_calc_coeffs(svf);
+}
+
+void Svf::svf_set_rq(t_svf* svf, float rq) {
+    svf->rq = rq;
+    svf_calc_coeffs(svf);
+}
+
+void Svf::svf_update(t_svf* svf, float in) {
+    // update
+    svf->v0 = in;
+    svf->v1z = svf->v1;
+    svf->v2z = svf->v2;
+    svf->v3 = svf->v0 + svf->v0z - 2.f * svf->v2z;
+    svf->v1 += svf->g1 * svf->v3 - svf->g2 * svf->v1z;
+    svf->v2 += svf->g3 * svf->v3 + svf->g4 * svf->v1z;
+    svf->v0z = svf->v0;
+    // output
+    svf->lp = svf->v2;
+    svf->bp = svf->v1;
+    svf->hp = svf->v0 - svf->rq * svf->v1 - svf->v2;
+    svf->br = svf->v0 - svf->rq * svf->v1;
+}
+
+float Svf::getFc() {
+    return svf.fc;
+}

--- a/crone/src/softcut/Svf.h
+++ b/crone/src/softcut/Svf.h
@@ -1,0 +1,77 @@
+//
+// Created by ezra on 11/8/18.
+//
+// state variable filter
+// after Hal Chamberlin, Andy Simper
+
+#ifndef SOFTCUT_SVF_H
+#define SOFTCUT_SVF_H
+
+#include <memory>
+
+class Svf {
+public:
+    //---------------
+    //-- C++ wrapper
+    Svf();
+    float getNextSample(float x);
+    void setSampleRate(float sr);
+    void setFc(float fc);
+    void setRq(float rq);
+    void setLpMix(float mix);
+    void setHpMix(float mix);
+    void setBpMix(float mix);
+    void setBrMix(float mix);
+
+    float getFc();
+
+private:
+    float lpMix;
+    float hpMix;
+    float bpMix;
+    float brMix;
+
+    //------------------
+    //-- C implementation
+    typedef struct _svf {
+        // sample rate
+        float sr;
+        // corner frequency in hz
+        float fc;
+        // reciprocal of Q in [0,1]
+        float rq;
+        // intermediate coefficients
+        float g;
+        float g1;
+        float g2;
+        float g3;
+        float g4;
+        // state variables
+        float v0;
+        float v1;
+        float v2;
+        float v0z;
+        float v1z;
+        float v2z;
+        float v3;
+        // outputs
+        float lp; // lowpass
+        float hp; // highpass
+        float bp; // bandpass
+        float br; // bandreject
+    } t_svf;
+
+    t_svf svf;
+
+    static void svf_calc_coeffs(t_svf* svf);
+    static void svf_init(t_svf* svf);
+    static void svf_clear_state(t_svf* svf);
+    static void svf_set_sr(t_svf* svf, float sr);
+    static void svf_set_fc(t_svf* svf, float fc);
+    static void svf_set_rq(t_svf* svf, float rq);
+    static void svf_update(t_svf* svf, float in);
+
+};
+
+
+#endif //SOFTCUT_SVF_H

--- a/crone/src/softcut/TestBuffers.cpp
+++ b/crone/src/softcut/TestBuffers.cpp
@@ -1,0 +1,5 @@
+//
+// Created by ezra on 11/16/18.
+//
+
+#include "TestBuffers.h"

--- a/crone/src/softcut/TestBuffers.h
+++ b/crone/src/softcut/TestBuffers.h
@@ -1,0 +1,60 @@
+//
+// Created by ezra on 11/16/18.
+//
+
+#ifndef SOFTCUT_TESTBUFFERS_H
+#define SOFTCUT_TESTBUFFERS_H
+
+#include <iostream>
+#include <fstream>
+
+namespace softcut {
+class TestBuffers {
+public:
+    typedef enum { Read, Write, Fade, State, Pre, Rec, numChannels } Channel;
+    enum { numFrames = 131072, frameMask = 131071 };
+
+    float buf[numChannels][numFrames]{};
+    unsigned int idx = 0;
+
+    void init() {
+        for (int ch=0; ch<numChannels; ++ch) {
+            for (int fr=0; fr<numFrames; ++fr) {
+                buf[ch][fr] = 0.f;
+            }
+        }
+    }
+
+    void update(float readPhase, float writePhase, float fade, float state, float pre, float rec) {
+        buf[Read][idx] = readPhase;
+        buf[Write][idx] = writePhase;
+        buf[Fade][idx] = fade;
+        buf[State][idx] = state;
+        buf[Pre][idx] = pre;
+        buf[Rec][idx] = rec;
+        idx = (idx+1)&frameMask;
+    }
+
+    // print buffer contents in matlab format
+    void print() {
+        using std::endl;
+        std::ofstream ofs ("softcut_test_buffers.m", std::ofstream::out);
+        ofs << "function y = softcut_test_buffers() " << endl;
+        ofs << "  y = [" << endl;
+        for (int ch=0; ch<numChannels; ++ch) {
+            ofs << "    [ ";
+            for (int fr=0; fr<numFrames; ++fr) {
+                ofs << buf[ch][fr] << " ";
+            }
+            ofs << "    ]," << endl << endl;
+        }
+        ofs << "  ];" << endl;
+        ofs << "end" << endl;
+
+        ofs.close();
+    }
+};
+}
+
+
+#endif //SOFTCUT_TESTBUFFERS_H

--- a/crone/src/softcut/Types.h
+++ b/crone/src/softcut/Types.h
@@ -1,0 +1,14 @@
+//
+// Created by ezra on 11/10/18.
+//
+
+#ifndef SOFTCUT_TYPES_H
+#define SOFTCUT_TYPES_H
+
+namespace softcut {
+
+    typedef float sample_t;
+    typedef double phase_t;
+    typedef double rate_t;
+}
+#endif //SOFTCUT_TYPES_H

--- a/lua/encoders.lua
+++ b/lua/encoders.lua
@@ -26,11 +26,11 @@ end
 encoders.set_sens = function(n,s)
   if n == 0 then
     for n=1,3 do
-      encoders.sens[n] = util.clamp(s,0.01,1)
+      encoders.sens[n] = util.clamp(s,1,16)
       encoders.tick[n] = 0
     end
   else
-    encoders.sens[n] = util.clamp(s,0.01,1)
+    encoders.sens[n] = util.clamp(s,1,16)
     encoders.tick[n] = 0
   end
 end
@@ -48,13 +48,12 @@ encoders.process = function(n,d)
     end
   end
 
-  d = d * encoders.sens[n]
-
   encoders.tick[n] = encoders.tick[n] + d
-  if math.abs(encoders.tick[n]) >= 1 then
-    local delta = util.round(encoders.tick[n],1)
-    encoders.callback(n,delta)
-    encoders.tick[n] = encoders.tick[n] - delta
+
+  if math.abs(encoders.tick[n]) >= encoders.sens[n] then
+    local val = math.floor(encoders.tick[n] / encoders.sens[n])
+    encoders.callback(n,val)
+    encoders.tick[n] = 0
   end
 end
 

--- a/lua/menu.lua
+++ b/lua/menu.lua
@@ -251,6 +251,7 @@ m.key[pHOME] = function(n,z)
     menu.redraw()
   elseif n == 3 and z == 1 then
     local choices = {pSELECT, pSYSTEM, pSLEEP}
+    if m.home.pos == 2 then m.sel.depth = 0 end -- reset folder position to root
     menu.set_page(choices[m.home.pos])
   end
 end
@@ -353,10 +354,8 @@ m.key[pSELECT] = function(n,z)
   -- back
   if n==2 and z==1 then
     if m.sel.depth > 0 then
-      --print('back')
       m.sel.folders[m.sel.depth] = nil
       m.sel.depth = m.sel.depth - 1
-      -- FIXME return to folder position
       m.sel.list = util.scandir(m.sel.dir())
       m.sel.len = tab.count(m.sel.list)
       m.sel.pos = m.sel.folderpos[m.sel.depth] or 0
@@ -368,7 +367,6 @@ m.key[pSELECT] = function(n,z)
   elseif n==3 and z==1 then
     m.sel.file = m.sel.list[m.sel.pos+1]
     if string.find(m.sel.file,'/') then
-      print("folder")
       m.sel.folderpos[m.sel.depth] = m.sel.pos
       m.sel.depth = m.sel.depth + 1
       m.sel.folders[m.sel.depth] = m.sel.file
@@ -504,6 +502,7 @@ m.key[pPARAMS] = function(n,z)
       menu.redraw()
     end
   elseif n==2 and z==1 then
+    --NOT USED
     --menu.set_page(pHOME)
   elseif n==3 and z==1 then
     if not m.params.midimap then
@@ -793,39 +792,31 @@ m.redraw[pSYSTEM] = function()
     screen.text(m.sys.list[i])
   end
 
-  screen.level(2)
-  screen.move(127,30)
-  if wifi.state == 2 then m.sys.net = wifi.ip
-  else m.sys.net = wifi.status end
-  screen.text_right(m.sys.net)
+  --screen.level(2)
+  --screen.move(127,30)
+  --if wifi.state == 2 then m.sys.net = wifi.ip
+  --else m.sys.net = wifi.status end
+  --screen.text_right(m.sys.net)
 
-  screen.move(127,40)
-  screen.text_right("disk free: "..norns.disk.."MB")
-
-  screen.move(127,50)
-  screen.text_right(norns.version.update)
-
-  screen.move(127,60)
-  screen.text_right(norns.temp .. 'c / ' .. norns.cpu .. '%')
   screen.update()
 end
 
 m.init[pSYSTEM] = function()
-  u.callback = function()
-    m.sysquery()
-    menu.redraw()
-  end
-  u.time = 3
-  u.count = -1
-  u:start()
+  --u.callback = function()
+    --m.sysquery()
+    --menu.redraw()
+  --end
+  --u.time = 3
+  --u.count = -1
+  --u:start()
 end
 
 m.deinit[pSYSTEM] = function()
-  u:stop()
+  --u:stop()
 end
 
 m.sysquery = function()
-  wifi.update()
+  --wifi.update()
 end
 
 
@@ -1517,43 +1508,50 @@ m.redraw[pMIX] = function()
   local x = -40
   screen.level(2)
   n = mix:get_raw("output")*48
-  screen.rect(x+42.5,56.5,2,-n)
+  screen.rect(x+42.5,55.5,2,-n)
   screen.stroke()
 
   screen.level(15)
   n = m.mix.out1/64*48
-  screen.rect(x+48.5,56.5,2,-n)
+  screen.rect(x+48.5,55.5,2,-n)
   screen.stroke()
 
   n = m.mix.out2/64*48
-  screen.rect(x+54.5,56.5,2,-n)
+  screen.rect(x+54.5,55.5,2,-n)
   screen.stroke()
 
   screen.level(2)
   n = mix:get_raw("input")*48
-  screen.rect(x+64.5,56.5,2,-n)
+  screen.rect(x+64.5,55.5,2,-n)
   screen.stroke()
 
   screen.level(15)
   n = m.mix.in1/64*48
-  screen.rect(x+70.5,56.5,2,-n)
+  screen.rect(x+70.5,55.5,2,-n)
   screen.stroke()
   n = m.mix.in2/64*48
-  screen.rect(x+76.5,56.5,2,-n)
+  screen.rect(x+76.5,55.5,2,-n)
   screen.stroke()
 
   screen.level(2)
   n = mix:get_raw("monitor")*48
-  screen.rect(x+86.5,56.5,2,-n)
+  screen.rect(x+86.5,55.5,2,-n)
+  screen.stroke()
+
+  screen.level(2)
+  n = mix:get_raw("tape")*48
+  screen.rect(x+108.5,55.5,2,-n)
   screen.stroke()
 
   screen.level(1)
-  screen.move(2,64)
+  screen.move(2,63)
   screen.text("out")
-  screen.move(24,64)
+  screen.move(24,63)
   screen.text("in")
-  screen.move(46,64)
+  screen.move(46,63)
   screen.text("mon")
+  screen.move(68,63)
+  screen.text("tape")
 
   if tape.selectmode then
     screen.level(10)
@@ -1597,11 +1595,6 @@ m.redraw[pMIX] = function()
     screen.move(90,32)
     screen.text_center(tape.playfile)
   end
-
-  screen.level(1)
-  screen.move(127,64)
-  if menu.alt == false then screen.text_right(norns.battery_percent)
-  else screen.text_right(norns.battery_current.."mA") end
 
   screen.update()
 end

--- a/lua/metro.lua
+++ b/lua/metro.lua
@@ -7,8 +7,8 @@ norns.version.metro = '0.0.3'
 local Metro = {}
 Metro.__index = Metro
 
-Metro.num_metros = 33
-Metro.num_script_metros = 30 -- 31-33 are reserved
+Metro.num_metros = 34
+Metro.num_script_metros = 30 -- 31-34 are reserved
 
 Metro.metros = {}
 Metro.available = {}

--- a/lua/mix.lua
+++ b/lua/mix.lua
@@ -29,7 +29,7 @@ mix:set_action("headphone",
 
 mix:add_control("tape", "tape", cs_MUTE_LEVEL)
 mix:set_action("tape",
-  function(x) print(x) end)
+  function(x) end)
 
 -- TODO TAPE (rec) modes: OUTPUT, OUTPUT+MONITOR, OUTPUT/MONITOR SPLIT
 -- TODO TAPE (playback) VOL, SPEED?

--- a/lua/mix.lua
+++ b/lua/mix.lua
@@ -27,6 +27,10 @@ mix:add_number("headphone", "headphone", 0, 63, 40)
 mix:set_action("headphone",
   function(x) gain_hp(x) end)
 
+mix:add_control("tape", "tape", cs_MUTE_LEVEL)
+mix:set_action("tape",
+  function(x) print(x) end)
+
 -- TODO TAPE (rec) modes: OUTPUT, OUTPUT+MONITOR, OUTPUT/MONITOR SPLIT
 -- TODO TAPE (playback) VOL, SPEED?
 

--- a/lua/state.lua
+++ b/lua/state.lua
@@ -2,6 +2,7 @@
 -- @module state
 
 state = {}
+state.tape = 0
 state.script = ''
 state.clean_shutdown = false
 
@@ -60,6 +61,7 @@ state.save_state = function()
   local fd=io.open(data_dir .. "system.lua","w+")
   io.output(fd)
   io.write("-- system state\n")
+  io.write("norns.state.tape = " .. norns.state.tape .. "\n")
   io.write("norns.state.script = '" .. state.script .. "'\n")
   io.write("norns.state.clean_shutdown = " .. (state.clean_shutdown and "true" or "false") .. "\n")
   for i=1,4 do

--- a/lua/util.lua
+++ b/lua/util.lua
@@ -145,4 +145,15 @@ function util.round_up(number, quant)
   end
 end
 
+--- format string, seconds to h:m:s
+-- @param seconds seconds
+-- @return string seconds in h:m:s
+function util.s_to_hms(s)
+  local m = math.floor(s/60)
+  local h = math.floor(m/60)
+  m = m%60
+  s = s%60
+  return h ..":".. string.format("%02d",m) ..":".. string.format("%02d",s)
+end
+
 return util

--- a/matron/src/metro.c
+++ b/matron/src/metro.c
@@ -21,7 +21,7 @@
 #include "events.h"
 #include "metro.h"
 
-#define MAX_NUM_METROS_OK 33
+#define MAX_NUM_METROS_OK 34
 
 enum {
     METRO_STATUS_RUNNING,

--- a/matron/src/oracle.c
+++ b/matron/src/oracle.c
@@ -119,6 +119,10 @@ static int handle_poll_io_levels(const char *path, const char *types,
                                  lo_arg **argv, int argc,
                                  void *data, void *user_data);
 
+static int handle_tape_play_state(const char *path, const char *types,
+                                 lo_arg **argv, int argc,
+                                 void *data, void *user_data);
+
 static void lo_error_handler(int num, const char *m, const char *path);
 
 static void set_need_reports() {
@@ -189,6 +193,9 @@ void o_init(void) {
     // dedicated path for audio I/O levels
     lo_server_thread_add_method(st, "/poll/vu", "b",
                                 handle_poll_io_levels, NULL);
+    // tape reports
+    lo_server_thread_add_method(st, "/tape/play/state", "s",
+                                handle_tape_play_state, NULL);
 
     lo_server_thread_start(st);
 }
@@ -781,6 +788,24 @@ int handle_poll_io_levels(const char *path, const char *types, lo_arg **argv,
 
     return 0;
 }
+
+int handle_tape_play_state(const char *path,
+                                const char *types,
+                                lo_arg **argv,
+                                int argc,
+                                void *data,
+                                void *user_data) {
+    (void)path;
+    (void)types;
+    (void)argc;
+    (void)argv;
+    (void)data;
+    (void)user_data;
+    assert(argc > 0);
+    fprintf(stderr, "tape_play_status %s\n", &argv[0]->s);
+    return 0;
+}
+
 
 void lo_error_handler(int num, const char *m, const char *path) {
     fprintf(stderr, "liblo error %d in path %s: %s\n", num, path, m);

--- a/sc/core/Crone.sc
+++ b/sc/core/Crone.sc
@@ -237,7 +237,8 @@ Crone {
 
 	*tapeOpenfile { |filename|
 		filename = filename.asString;
-		if (PathName(recordingsDir +/+ filename).isFile) {
+		postln("tape, load:" + filename.quote);
+		if (PathName(filename).isFile) {
 			if (#[playing, paused, fileopened].includes(playerState)) {
 				player.stop;
 			};
@@ -249,7 +250,7 @@ Crone {
 				}).add;
 
 				playerFile = filename;
-				player = SoundFile(recordingsDir +/+ playerFile).cue(
+				player = SoundFile(playerFile).cue(
 					(
 						out: context.out_b,
 						instrument: \cronetape


### PR DESCRIPTION
`norns/crone` contains a new jack client designed to replace some of the Crone supercollider components.

it has 4 inputs and 2 outputs. the idea is that the first pair of inputs are to be connected to system capture ports, 2nd pair is connected to supercollider playback, and outputs are connected to system playback.

`crone` will perform mixing and routing, host "built-in" effects and the `softcut` engine.

this is WIP:
- currently, there is only basic routing: ADC mix to monitor bus, bus to DAC, ext input to DAC.
- the interface is still OSC, which is overkill.
- none of the necessary changes to supercollider classes have been made.

will make some roadmap issues and update this PR accordingly.

but for now:
- the very first step is for  people to try building and running this project on the norns (requirements: `cmake`, `libboost-dev`, `libjack-dev`)

- i will be stitching fx and softcut into here shortly

- `norns/sc/core` needs to be updated; engines can send directly to jack client output ports.

- need to programmatically connect jack clients `supernova` -> `crone` (and disconnect `supernova`->system)

- as an interim measure, we could make an OSC bridge in `sclang` for routing/level commands; or, go straight to making changes in `matron/oracle`.