### PR TITLE
menu revision

### DIFF
--- a/lua/encoders.lua
+++ b/lua/encoders.lua
@@ -26,11 +26,11 @@ end
 encoders.set_sens = function(n,s)
   if n == 0 then
     for n=1,3 do
-      encoders.sens[n] = util.clamp(s,0.01,1)
+      encoders.sens[n] = util.clamp(s,1,16)
       encoders.tick[n] = 0
     end
   else
-    encoders.sens[n] = util.clamp(s,0.01,1)
+    encoders.sens[n] = util.clamp(s,1,16)
     encoders.tick[n] = 0
   end
 end
@@ -48,13 +48,12 @@ encoders.process = function(n,d)
     end
   end
 
-  d = d * encoders.sens[n]
-
   encoders.tick[n] = encoders.tick[n] + d
-  if math.abs(encoders.tick[n]) >= 1 then
-    local delta = util.round(encoders.tick[n],1)
-    encoders.callback(n,delta)
-    encoders.tick[n] = encoders.tick[n] - delta
+
+  if math.abs(encoders.tick[n]) >= encoders.sens[n] then
+    local val = math.floor(encoders.tick[n] / encoders.sens[n])
+    encoders.callback(n,val)
+    encoders.tick[n] = 0
   end
 end
 

--- a/lua/menu.lua
+++ b/lua/menu.lua
@@ -1517,6 +1517,8 @@ local TAPE_REC_ARM = 1
 local TAPE_REC_START = 2
 local TAPE_REC_STOP = 3
 
+local p_tape_play
+
 m.tape = {}
 m.tape.mode = TAPE_MODE_PLAY
 m.tape.play = {}
@@ -1551,6 +1553,15 @@ m.key[pTAPE] = function(n,z)
             local ch, samples, rate = sound_file_inspect(path)
             m.tape.play.length = math.floor(samples / rate)
             m.tape.play.length_text = util.s_to_hms(m.tape.play.length)
+            p_tape_play = poll.set("tape_play_pos")
+            p_tape_play.time = 0.25
+            p_tape_play.callback = function(x)
+              m.tape.play.pos_tick = x
+              if menu.mode == true and menu.page == pTAPE then
+                menu.redraw()
+              end
+            end
+            p_tape_play:start()
           else
             m.tape.play.file = nil
           end
@@ -1564,6 +1575,7 @@ m.key[pTAPE] = function(n,z)
         menu.redraw()
       elseif m.tape.play.sel == TAPE_PLAY_STOP then
         tape_stop()
+        p_tape_play:stop()
         m.tape.play.file = nil
         m.tape.play.status = m.tape.play.sel
         m.tape.play.sel = TAPE_PLAY_LOAD
@@ -1634,11 +1646,11 @@ m.redraw[pTAPE] = function()
     screen.move(0,10)
     screen.text(m.tape.play.file)
     screen.move(0,24)
-    screen.text("0:00")
+    screen.text(util.s_to_hms(math.floor(m.tape.play.pos_tick)))
     screen.move(128,24)
     screen.text_right(m.tape.play.length_text)
     screen.level(15)
-    screen.move(m.tape.play.pos_tick,13.5)
+    screen.move((m.tape.play.pos_tick / m.tape.play.length * 128),13.5)
     screen.line_rel(0,2)
     screen.stroke()
     if m.tape.mode==TAPE_MODE_PLAY then
@@ -1730,3 +1742,5 @@ m.init[pTAPE] = function()
   tape_diskfree()
 end
 m.deinit[pTAPE] = norns.none
+
+

--- a/lua/menu.lua
+++ b/lua/menu.lua
@@ -304,7 +304,7 @@ m.redraw[pHOME] = function()
     screen.move(36,20)
     screen.text(norns.temp .. "c")
     screen.move(127,20)
-    screen.text_right("IP 192.168.1.xx")
+    screen.text_right("IP "..wifi.ip)
     if wifi.state > 0 then
       screen.text_right(wifi.ip)
     end

--- a/lua/menu.lua
+++ b/lua/menu.lua
@@ -251,6 +251,7 @@ m.key[pHOME] = function(n,z)
     menu.redraw()
   elseif n == 3 and z == 1 then
     local choices = {pSELECT, pSYSTEM, pSLEEP}
+    if m.home.pos == 2 then m.sel.depth = 0 end -- reset folder position to root
     menu.set_page(choices[m.home.pos])
   end
 end
@@ -353,10 +354,8 @@ m.key[pSELECT] = function(n,z)
   -- back
   if n==2 and z==1 then
     if m.sel.depth > 0 then
-      --print('back')
       m.sel.folders[m.sel.depth] = nil
       m.sel.depth = m.sel.depth - 1
-      -- FIXME return to folder position
       m.sel.list = util.scandir(m.sel.dir())
       m.sel.len = tab.count(m.sel.list)
       m.sel.pos = m.sel.folderpos[m.sel.depth] or 0
@@ -368,7 +367,6 @@ m.key[pSELECT] = function(n,z)
   elseif n==3 and z==1 then
     m.sel.file = m.sel.list[m.sel.pos+1]
     if string.find(m.sel.file,'/') then
-      print("folder")
       m.sel.folderpos[m.sel.depth] = m.sel.pos
       m.sel.depth = m.sel.depth + 1
       m.sel.folders[m.sel.depth] = m.sel.file
@@ -504,6 +502,7 @@ m.key[pPARAMS] = function(n,z)
       menu.redraw()
     end
   elseif n==2 and z==1 then
+    --NOT USED
     --menu.set_page(pHOME)
   elseif n==3 and z==1 then
     if not m.params.midimap then
@@ -793,39 +792,31 @@ m.redraw[pSYSTEM] = function()
     screen.text(m.sys.list[i])
   end
 
-  screen.level(2)
-  screen.move(127,30)
-  if wifi.state == 2 then m.sys.net = wifi.ip
-  else m.sys.net = wifi.status end
-  screen.text_right(m.sys.net)
+  --screen.level(2)
+  --screen.move(127,30)
+  --if wifi.state == 2 then m.sys.net = wifi.ip
+  --else m.sys.net = wifi.status end
+  --screen.text_right(m.sys.net)
 
-  screen.move(127,40)
-  screen.text_right("disk free: "..norns.disk.."MB")
-
-  screen.move(127,50)
-  screen.text_right(norns.version.update)
-
-  screen.move(127,60)
-  screen.text_right(norns.temp .. 'c / ' .. norns.cpu .. '%')
   screen.update()
 end
 
 m.init[pSYSTEM] = function()
-  u.callback = function()
-    m.sysquery()
-    menu.redraw()
-  end
-  u.time = 3
-  u.count = -1
-  u:start()
+  --u.callback = function()
+    --m.sysquery()
+    --menu.redraw()
+  --end
+  --u.time = 3
+  --u.count = -1
+  --u:start()
 end
 
 m.deinit[pSYSTEM] = function()
-  u:stop()
+  --u:stop()
 end
 
 m.sysquery = function()
-  wifi.update()
+  --wifi.update()
 end
 
 
@@ -1517,43 +1508,50 @@ m.redraw[pMIX] = function()
   local x = -40
   screen.level(2)
   n = mix:get_raw("output")*48
-  screen.rect(x+42.5,56.5,2,-n)
+  screen.rect(x+42.5,55.5,2,-n)
   screen.stroke()
 
   screen.level(15)
   n = m.mix.out1/64*48
-  screen.rect(x+48.5,56.5,2,-n)
+  screen.rect(x+48.5,55.5,2,-n)
   screen.stroke()
 
   n = m.mix.out2/64*48
-  screen.rect(x+54.5,56.5,2,-n)
+  screen.rect(x+54.5,55.5,2,-n)
   screen.stroke()
 
   screen.level(2)
   n = mix:get_raw("input")*48
-  screen.rect(x+64.5,56.5,2,-n)
+  screen.rect(x+64.5,55.5,2,-n)
   screen.stroke()
 
   screen.level(15)
   n = m.mix.in1/64*48
-  screen.rect(x+70.5,56.5,2,-n)
+  screen.rect(x+70.5,55.5,2,-n)
   screen.stroke()
   n = m.mix.in2/64*48
-  screen.rect(x+76.5,56.5,2,-n)
+  screen.rect(x+76.5,55.5,2,-n)
   screen.stroke()
 
   screen.level(2)
   n = mix:get_raw("monitor")*48
-  screen.rect(x+86.5,56.5,2,-n)
+  screen.rect(x+86.5,55.5,2,-n)
+  screen.stroke()
+
+  screen.level(2)
+  n = mix:get_raw("tape")*48
+  screen.rect(x+108.5,55.5,2,-n)
   screen.stroke()
 
   screen.level(1)
-  screen.move(2,64)
+  screen.move(2,63)
   screen.text("out")
-  screen.move(24,64)
+  screen.move(24,63)
   screen.text("in")
-  screen.move(46,64)
+  screen.move(46,63)
   screen.text("mon")
+  screen.move(68,63)
+  screen.text("tape")
 
   if tape.selectmode then
     screen.level(10)
@@ -1597,11 +1595,6 @@ m.redraw[pMIX] = function()
     screen.move(90,32)
     screen.text_center(tape.playfile)
   end
-
-  screen.level(1)
-  screen.move(127,64)
-  if menu.alt == false then screen.text_right(norns.battery_percent)
-  else screen.text_right(norns.battery_current.."mA") end
 
   screen.update()
 end

--- a/lua/menu.lua
+++ b/lua/menu.lua
@@ -1557,6 +1557,13 @@ m.key[pTAPE] = function(n,z)
             p_tape_play.time = 0.25
             p_tape_play.callback = function(x)
               m.tape.play.pos_tick = x
+              if x > m.tape.play.length then
+                tape_stop()
+                p_tape_play:stop()
+                m.tape.play.file = nil
+                m.tape.play.stats = TAPE_PLAY_STOP
+                m.tape.play.sel = TAPE_PLAY_LOAD
+              end
               if menu.mode == true and menu.page == pTAPE then
                 menu.redraw()
               end

--- a/lua/menu.lua
+++ b/lua/menu.lua
@@ -796,32 +796,11 @@ m.redraw[pSYSTEM] = function()
     screen.text(m.sys.list[i])
   end
 
-  --screen.level(2)
-  --screen.move(127,30)
-  --if wifi.state == 2 then m.sys.net = wifi.ip
-  --else m.sys.net = wifi.status end
-  --screen.text_right(m.sys.net)
-
   screen.update()
 end
 
-m.init[pSYSTEM] = function()
-  --u.callback = function()
-    --m.sysquery()
-    --menu.redraw()
-  --end
-  --u.time = 3
-  --u.count = -1
-  --u:start()
-end
-
-m.deinit[pSYSTEM] = function()
-  --u:stop()
-end
-
-m.sysquery = function()
-  --wifi.update()
-end
+m.init[pSYSTEM] = norns.none
+m.deinit[pSYSTEM] = norns.none
 
 
 -----------------------------------------

--- a/lua/metro.lua
+++ b/lua/metro.lua
@@ -7,8 +7,8 @@ norns.version.metro = '0.0.3'
 local Metro = {}
 Metro.__index = Metro
 
-Metro.num_metros = 33
-Metro.num_script_metros = 30 -- 31-33 are reserved
+Metro.num_metros = 34
+Metro.num_script_metros = 30 -- 31-34 are reserved
 
 Metro.metros = {}
 Metro.available = {}

--- a/lua/mix.lua
+++ b/lua/mix.lua
@@ -23,13 +23,12 @@ mix:set_action("monitor_mode",
     if x == 1 then norns.audio.monitor_stereo()
     else norns.audio.monitor_mono() end
   end)
+mix:add_control("tape", "tape", cs_MUTE_LEVEL)
+mix:set_action("tape",
+  function(x) tape_level(x) end)
 mix:add_number("headphone", "headphone", 0, 63, 40)
 mix:set_action("headphone",
   function(x) gain_hp(x) end)
-
-mix:add_control("tape", "tape", cs_MUTE_LEVEL)
-mix:set_action("tape",
-  function(x) end)
 
 -- TODO TAPE (rec) modes: OUTPUT, OUTPUT+MONITOR, OUTPUT/MONITOR SPLIT
 -- TODO TAPE (playback) VOL, SPEED?

--- a/lua/mix.lua
+++ b/lua/mix.lua
@@ -29,7 +29,7 @@ mix:set_action("headphone",
 
 mix:add_control("tape", "tape", cs_MUTE_LEVEL)
 mix:set_action("tape",
-  function(x) print(x) end)
+  function(x) end)
 
 -- TODO TAPE (rec) modes: OUTPUT, OUTPUT+MONITOR, OUTPUT/MONITOR SPLIT
 -- TODO TAPE (playback) VOL, SPEED?

--- a/lua/mix.lua
+++ b/lua/mix.lua
@@ -27,6 +27,10 @@ mix:add_number("headphone", "headphone", 0, 63, 40)
 mix:set_action("headphone",
   function(x) gain_hp(x) end)
 
+mix:add_control("tape", "tape", cs_MUTE_LEVEL)
+mix:set_action("tape",
+  function(x) print(x) end)
+
 -- TODO TAPE (rec) modes: OUTPUT, OUTPUT+MONITOR, OUTPUT/MONITOR SPLIT
 -- TODO TAPE (playback) VOL, SPEED?
 

--- a/lua/state.lua
+++ b/lua/state.lua
@@ -2,6 +2,7 @@
 -- @module state
 
 state = {}
+state.tape = 0
 state.script = ''
 state.clean_shutdown = false
 
@@ -60,6 +61,7 @@ state.save_state = function()
   local fd=io.open(data_dir .. "system.lua","w+")
   io.output(fd)
   io.write("-- system state\n")
+  io.write("norns.state.tape = " .. norns.state.tape .. "\n")
   io.write("norns.state.script = '" .. state.script .. "'\n")
   io.write("norns.state.clean_shutdown = " .. (state.clean_shutdown and "true" or "false") .. "\n")
   for i=1,4 do

--- a/lua/util.lua
+++ b/lua/util.lua
@@ -145,4 +145,15 @@ function util.round_up(number, quant)
   end
 end
 
+--- format string, seconds to h:m:s
+-- @param seconds seconds
+-- @return string seconds in h:m:s
+function util.s_to_hms(s)
+  local m = math.floor(s/60)
+  local h = math.floor(m/60)
+  m = m%60
+  s = s%60
+  return h ..":".. string.format("%02d",m) ..":".. string.format("%02d",s)
+end
+
 return util

--- a/matron/src/metro.c
+++ b/matron/src/metro.c
@@ -21,7 +21,7 @@
 #include "events.h"
 #include "metro.h"
 
-#define MAX_NUM_METROS_OK 33
+#define MAX_NUM_METROS_OK 34
 
 enum {
     METRO_STATUS_RUNNING,

--- a/matron/src/oracle.c
+++ b/matron/src/oracle.c
@@ -119,6 +119,10 @@ static int handle_poll_io_levels(const char *path, const char *types,
                                  lo_arg **argv, int argc,
                                  void *data, void *user_data);
 
+static int handle_tape_play_state(const char *path, const char *types,
+                                 lo_arg **argv, int argc,
+                                 void *data, void *user_data);
+
 static void lo_error_handler(int num, const char *m, const char *path);
 
 static void set_need_reports() {
@@ -189,6 +193,9 @@ void o_init(void) {
     // dedicated path for audio I/O levels
     lo_server_thread_add_method(st, "/poll/vu", "b",
                                 handle_poll_io_levels, NULL);
+    // tape reports
+    lo_server_thread_add_method(st, "/tape/play/state", "s",
+                                handle_tape_play_state, NULL);
 
     lo_server_thread_start(st);
 }
@@ -781,6 +788,24 @@ int handle_poll_io_levels(const char *path, const char *types, lo_arg **argv,
 
     return 0;
 }
+
+int handle_tape_play_state(const char *path,
+                                const char *types,
+                                lo_arg **argv,
+                                int argc,
+                                void *data,
+                                void *user_data) {
+    (void)path;
+    (void)types;
+    (void)argc;
+    (void)argv;
+    (void)data;
+    (void)user_data;
+    assert(argc > 0);
+    fprintf(stderr, "tape_play_status %s\n", &argv[0]->s);
+    return 0;
+}
+
 
 void lo_error_handler(int num, const char *m, const char *path) {
     fprintf(stderr, "liblo error %d in path %s: %s\n", num, path, m);

--- a/matron/src/oracle.c
+++ b/matron/src/oracle.c
@@ -802,7 +802,7 @@ int handle_tape_play_state(const char *path,
     (void)data;
     (void)user_data;
     assert(argc > 0);
-    fprintf(stderr, "tape_play_status %s\n", &argv[0]->s);
+    //fprintf(stderr, "tape_play_status %s\n", &argv[0]->s);
     return 0;
 }
 

--- a/matron/src/oracle.c
+++ b/matron/src/oracle.c
@@ -470,6 +470,9 @@ void o_restart_audio() {
 }
 
 //---- tape controls
+void o_tape_level(float level) {
+    lo_send(remote_addr, "/tape/level", "f", level);
+}
 
 void o_tape_new(char *file) {
     lo_send(remote_addr, "/tape/newfile", "s", file);

--- a/matron/src/oracle.h
+++ b/matron/src/oracle.h
@@ -111,6 +111,7 @@ extern void o_set_audio_pitch_on();
 extern void o_set_audio_pitch_off();
 
 //--- tape control
+extern void o_tape_level(float level);
 extern void o_tape_new(char *file);
 extern void o_tape_start_rec();
 extern void o_tape_pause_rec();

--- a/matron/src/weaver.c
+++ b/matron/src/weaver.c
@@ -136,6 +136,7 @@ static int _set_audio_pitch_off(lua_State *l);
 
 // tape control
 
+static int _tape_level(lua_State *l);
 static int _tape_new(lua_State *l);
 static int _tape_start_rec(lua_State *l);
 static int _tape_pause_rec(lua_State *l);
@@ -280,6 +281,7 @@ void w_init(void) {
   lua_register(lvm, "audio_pitch_off", &_set_audio_pitch_off);
 
   // tape controls
+  lua_register(lvm, "tape_level", &_tape_level);
   lua_register(lvm, "tape_new", &_tape_new);
   lua_register(lvm, "tape_start_rec", &_tape_start_rec);
   lua_register(lvm, "tape_pause_rec", &_tape_pause_rec);
@@ -1814,6 +1816,17 @@ int _set_audio_pitch_on(lua_State *l) {
 int _set_audio_pitch_off(lua_State *l) {
   (void)l;
   o_set_audio_pitch_off();
+  return 0;
+}
+
+int _tape_level(lua_State *l) {
+  if (lua_gettop(l) != 1) {
+    return luaL_error(l, "wrong number of arguments");
+  }
+
+  float val = (float) luaL_checknumber(l, 1);
+  o_tape_level(val);
+  lua_settop(l, 0);
   return 0;
 }
 

--- a/sc/core/Crone.sc
+++ b/sc/core/Crone.sc
@@ -504,7 +504,7 @@ Crone {
 			// @function /tape/level
 			'/tape/level':OSCFunc.new({
 			  arg msg, time, addr, recvPort;
-			  Node.basicNew(server, player.id.first).set(\amp, msg[1]);
+			  Node.basicNew(server, player.id.first).set(\amp, msg[1].dbamp);
 			}, '/tape/level'),
 
 			/// stop recording and close file

--- a/sc/core/Crone.sc
+++ b/sc/core/Crone.sc
@@ -237,7 +237,8 @@ Crone {
 
 	*tapeOpenfile { |filename|
 		filename = filename.asString;
-		if (PathName(recordingsDir +/+ filename).isFile) {
+		postln("tape, load:" + filename.quote);
+		if (PathName(filename).isFile) {
 			if (#[playing, paused, fileopened].includes(playerState)) {
 				player.stop;
 			};
@@ -249,7 +250,7 @@ Crone {
 				}).add;
 
 				playerFile = filename;
-				player = SoundFile(recordingsDir +/+ playerFile).cue(
+				player = SoundFile(playerFile).cue(
 					(
 						out: context.out_b,
 						instrument: \cronetape


### PR DESCRIPTION
overhaul of the primary menu system.

ENC1 now changes pages:

`levels` - `tape` - `HOME` - `params`

### levels

KEY2 to toggle active level editing with ENC2/ENC3 (highlight shows edit position)

### tape

KEY2 to toggle between PLAY AND REC

PLAY: KEY3 to select file. KEY3 again to play. KEY3 again to stop. autostop implemented at EOF
REC: KEY3 to arm. KEY3 again to start. KEY3 again to stop. files names by incrementing counter, saved in `dust/data/system.lua`

### home

KEY2 to toggle minimal vs. stats view

### params

same as before. KEY2 unused, but can be allocated to other functionality with forthcoming params revision


---

## other

- tape output has a level (thanks @antonhornquist )
- encoder sensitivity rewritten (massively improved)
- util function s_to_hms (sec to hour:minute:second string format)