### PR TITLE
Added a __newindex method to protect Engine

### DIFF
--- a/lua/engine.lua
+++ b/lua/engine.lua
@@ -101,6 +101,10 @@ function Engine.__index(self, idx)
   end
 end
 
+function Engine.__newindex(self, idx, val)
+  error("attempted to set a new field of Engine; try engine.field(value) instead")
+end
+
 setmetatable(Engine, Engine)
 
 return Engine


### PR DESCRIPTION
Naive attempt to solve #656 - prevent accidentally messing up the Engine metatable with `engine.cutoff = 100`, e.g.

Still working on getting a local norns dev environment set up, not sure how to properly test this in the meantime.