### PR TITLE
localize leaked globals

### DIFF
--- a/lua/params/control.lua
+++ b/lua/params/control.lua
@@ -51,7 +51,7 @@ end
 --- set_raw
 -- set 0-1
 function Control:set_raw(value)
-  clamped_value = util.clamp(value, 0, 1)
+  local clamped_value = util.clamp(value, 0, 1)
   if self.raw ~= clamped_value then
     self.raw = clamped_value
     self:bang()

--- a/lua/paramset.lua
+++ b/lua/paramset.lua
@@ -93,7 +93,6 @@ end
 
 --- add option
 function ParamSet:add_option(id, name, options, default)
-  p = option.new(id, name, options, default)
   self:add { param=option.new(id, name, options, default) }
 end
 

--- a/lua/util.lua
+++ b/lua/util.lua
@@ -6,7 +6,7 @@ util = {}
 --- get system time in s+us
 -- @return time
 util.time = function()
-  us,s = get_time()
+  local us,s = get_time()
   return us + s/1000000
 end
 


### PR DESCRIPTION
Cleans up leaked globals:

* `p`
* `us`
* `s`
* `clamped_value`

See: #559.

/cc @catfact @artfwo @tehn 

