### PR TITLE
hid update start

### DIFF
--- a/lua/hid.lua
+++ b/lua/hid.lua
@@ -61,10 +61,6 @@ function Hid.new(id, name, types, codes, dev)
   return d
 end
 
---- write data to a device
-function Hid:write(msg)
-  hid_send(self.dev, msg)
-end
 
 --- static callback when any hid device is added;
 -- user scripts can redefine
@@ -235,7 +231,6 @@ norns.hid.add = function(id, name, types, codes, dev)
   Hid.devices[id] = d
   Hid.update_devices()
   if Hid.add ~= nil then Hid.add(d) end
-  
 end
 
 --- remove a device
@@ -265,14 +260,12 @@ norns.hid.event = function(id, ev_type, ev_code, value)
   local ev_code_name = Hid.event_codes[ev_type][ev_code]
   --print("norns.hid.event ", id, ev_type_name, ev_code_name, value)
   local dev = Hid.devices[id]
-  if  dev then
-    local cb = dev.callbacks[ev_code_name]
-    if cb then
-      cb(value)
-    else
-      -- print("norns.hid.event unhandled ", id, ev_type, ev_type_name, ev_code, ev_code_name, value)
-    end
-  end
+  --if  dev then
+  --  local cb = dev.callbacks[ev_code_name]
+  --  if cb then
+  --   cb(value)
+  --  end
+  --end
 
     if dev ~= nil then
     if dev.event ~= nil then
@@ -572,14 +565,6 @@ Hid.event_codes[Hid.event_types_rev['EV_KEY']] = {
   [0x107] = 'BTN_7',
   [0x108] = 'BTN_8',
   [0x109] = 'BTN_9',
-  -- BTN_10 through BTN_15 are nonstandard, not in libevdev
-  [0x10A] = 'BTN_10',
-  [0x10B] = 'BTN_11',
-  [0x10C] = 'BTN_12',
-  [0x10D] = 'BTN_13',
-  [0x10E] = 'BTN_14',
-  [0x10F] = 'BTN_15',
-  -- end nonstandard codes
   [0x110] = 'BTN_MOUSE',
   [0x110] = 'BTN_LEFT',
   [0x111] = 'BTN_RIGHT',

--- a/lua/hid.lua
+++ b/lua/hid.lua
@@ -61,6 +61,10 @@ function Hid.new(id, name, types, codes, dev)
   return d
 end
 
+--- write data to a device
+function Hid:write(msg)
+  hid_send(self.dev, msg)
+end
 
 --- static callback when any hid device is added;
 -- user scripts can redefine
@@ -231,6 +235,7 @@ norns.hid.add = function(id, name, types, codes, dev)
   Hid.devices[id] = d
   Hid.update_devices()
   if Hid.add ~= nil then Hid.add(d) end
+  
 end
 
 --- remove a device
@@ -260,12 +265,14 @@ norns.hid.event = function(id, ev_type, ev_code, value)
   local ev_code_name = Hid.event_codes[ev_type][ev_code]
   --print("norns.hid.event ", id, ev_type_name, ev_code_name, value)
   local dev = Hid.devices[id]
-  --if  dev then
-  --  local cb = dev.callbacks[ev_code_name]
-  --  if cb then
-  --   cb(value)
-  --  end
-  --end
+  if  dev then
+    local cb = dev.callbacks[ev_code_name]
+    if cb then
+      cb(value)
+    else
+      -- print("norns.hid.event unhandled ", id, ev_type, ev_type_name, ev_code, ev_code_name, value)
+    end
+  end
 
     if dev ~= nil then
     if dev.event ~= nil then
@@ -565,6 +572,14 @@ Hid.event_codes[Hid.event_types_rev['EV_KEY']] = {
   [0x107] = 'BTN_7',
   [0x108] = 'BTN_8',
   [0x109] = 'BTN_9',
+  -- BTN_10 through BTN_15 are nonstandard, not in libevdev
+  [0x10A] = 'BTN_10',
+  [0x10B] = 'BTN_11',
+  [0x10C] = 'BTN_12',
+  [0x10D] = 'BTN_13',
+  [0x10E] = 'BTN_14',
+  [0x10F] = 'BTN_15',
+  -- end nonstandard codes
   [0x110] = 'BTN_MOUSE',
   [0x110] = 'BTN_LEFT',
   [0x111] = 'BTN_RIGHT',

--- a/lua/norns.lua
+++ b/lua/norns.lua
@@ -95,8 +95,8 @@ end
 -- hid callbacks
 norns.hid = {}
 --- HID or other input device added
-norns.hid.add = function(id, serial, name, types, codes)
-   -- print("norns.input.add ", id, serial, name, types, codes)
+norns.hid.add = function(id, name, types, codes, dev)
+   -- print("norns.input.add ", id, name, types, codes, dev)
 end
 norns.hid.event = function(id, ev_type, ev_code, value)
    -- print("norns.input.event ", id, ev_type, ev_code, value)

--- a/lua/script.lua
+++ b/lua/script.lua
@@ -37,6 +37,13 @@ Script.clear = function()
     dev.event = norns.none
   end
   midi.cleanup()
+   -- clear, redirect, and reset hid
+  hid.add = norns.none
+  hid.remove = norns.none
+  for _, dev in pairs(hid.devices) do
+    dev.event = norns.none
+  end
+  hid.cleanup()
   -- stop all timers
   metro.free_all()
   -- stop all polls and clear callbacks
@@ -72,6 +79,7 @@ Script.init = function()
   grid.reconnect()
   midi.reconnect()
   arc.reconnect()
+  hid.reconnect()
 end
 
 --- load a script from the /scripts folder

--- a/lua/state.lua
+++ b/lua/state.lua
@@ -23,6 +23,7 @@ state.resume = function()
   midi.update_devices()
   grid.update_devices()
   arc.update_devices()
+  hid.update_devices()
 
   -- only resume the script if we shut down cleanly
   if state.clean_shutdown and state.script ~= '' then
@@ -72,6 +73,9 @@ state.save_state = function()
   end
   for i=1,4 do
     io.write("arc.vport[" .. i .. "].name = '" .. arc.vport[i].name .. "'\n")
+  end
+  for i=1,4 do
+    io.write("hid.vport[" .. i .. "].name = '" .. hid.vport[i].name .. "'\n")
   end
   io.close(fd)
 end

--- a/matron/src/device/device_hid.c
+++ b/matron/src/device/device_hid.c
@@ -88,7 +88,7 @@ int dev_hid_init(void *self, bool print) {
     struct dev_common *base = (struct dev_common *)self;
     struct libevdev *dev = NULL;
     int ret = 1;
-    int fd = open(d->base.path, O_RDONLY);
+    int fd = open(d->base.path, O_RDWR);
 
     if (fd < 0) {
         fprintf(stderr, "failed to open hid device: %s\n", d->base.path);

--- a/matron/src/device/device_hid.c
+++ b/matron/src/device/device_hid.c
@@ -34,6 +34,9 @@ static void add_codes(struct dev_hid *d) {
         int max_codes, num_codes = 0;
         uint16_t *codes;
         int type = d->types[i];
+        max_codes = libevdev_event_type_get_max(type);
+        // printf("%s: %d\n", libevdev_event_type_get_name(type), libevdev_event_type_get_max(type));
+        /*
         switch(type) {
         case EV_KEY:
             max_codes = KEY_MAX;
@@ -49,13 +52,15 @@ static void add_codes(struct dev_hid *d) {
             break;
         default:
             max_codes = 0;
-        }
+        }*/
+        
         codes = calloc( max_codes, sizeof(dev_code_t) );
-
+		if (max_codes > 0 ){
         for(int code = 0; code < max_codes; code++) {
             if( libevdev_has_event_code(dev, type, code) ) {
                 codes[num_codes++] = code;
             }
+        }
         }
         codes = realloc( codes, num_codes * sizeof(dev_code_t) );
         d->num_codes[i] = num_codes;
@@ -150,8 +155,9 @@ void *dev_hid_start(void *self) {
 
 void dev_hid_deinit(void *self) {
     struct dev_hid *di = (struct dev_hid *)self;
+    //libevdev_free(di->dev);
     for(int i = 0; i < di->num_types; i++) {
-        TEST_NULL_AND_FREE(di->codes[i]);
+        TEST_NULL_AND_FREE(di->codes[i]); 
     }
     TEST_NULL_AND_FREE(di->codes);
     TEST_NULL_AND_FREE(di->num_codes);

--- a/matron/src/device/device_hid.c
+++ b/matron/src/device/device_hid.c
@@ -88,7 +88,7 @@ int dev_hid_init(void *self, bool print) {
     struct dev_common *base = (struct dev_common *)self;
     struct libevdev *dev = NULL;
     int ret = 1;
-    int fd = open(d->base.path, O_RDWR);
+    int fd = open(d->base.path, O_RDONLY);
 
     if (fd < 0) {
         fprintf(stderr, "failed to open hid device: %s\n", d->base.path);

--- a/matron/src/device/device_list.c
+++ b/matron/src/device/device_list.c
@@ -115,7 +115,7 @@ void dev_list_remove(device_t type, const char *node) {
     }
     event_post(ev);
 
-    if(dq.head == dn) { dq.head = NULL; }
+    if(dq.head == dn) { dq.head = dn->next; }
     if(dq.tail == dn) { dq.tail = dn->prev; }
     remque(dn);
     dq.size--;

--- a/matron/src/weaver.c
+++ b/matron/src/weaver.c
@@ -102,8 +102,6 @@ static int _osc_send_crone(lua_State *l);
 // midi
 // midi
 static int _midi_send(lua_State *l);
-// hid
-static int _hid_send(lua_State *l);
 
 // crone
 /// engines
@@ -245,9 +243,6 @@ void w_init(void) {
   // midi
   lua_register(lvm, "midi_send", &_midi_send);
 
-  // hid
-  lua_register(lvm, "hid_send", &_hid_send);
-  
   // get list of available crone engines
   lua_register(lvm, "report_engines", &_request_engine_report);
   // load a named engine
@@ -988,40 +983,6 @@ int _midi_send(lua_State *l) {
   return 0;
 }
 
-/***
- * hid: send
- * @function hid_send
- */
-int _hid_send(lua_State *l) {
-  struct dev_hid *hd;
-  size_t nbytes;
-  uint8_t *data;
-  int file, err;
-   if (lua_gettop(l) != 2) {
-    return luaL_error(l, "wrong number of arguments");
-  }
-   luaL_checktype(l, 1, LUA_TLIGHTUSERDATA);
-  hd = lua_touserdata(l, 1);
-   luaL_checktype(l, 2, LUA_TTABLE);
-  nbytes = lua_rawlen(l, 2);
-  data = malloc(nbytes);
-   for (unsigned int i = 1; i <= nbytes; i++) {
-    lua_pushinteger(l, i);
-    lua_gettable(l, 2);
-     // TODO: lua_isnumber
-    data[i - 1] = lua_tointeger(l, -1);
-    lua_pop(l, 1);
-  }
-   file = libevdev_get_fd(hd->dev);
-  err = write(file, data, nbytes);
-  free(data);
-   if (err < 0) {
-    return luaL_error(l, "could not write to HID device");
-  } else {
-    return 0;
-  }
-}
-  
 /***
  * grid: set led
  * @function grid_set_led

--- a/matron/src/weaver.c
+++ b/matron/src/weaver.c
@@ -1381,7 +1381,8 @@ void w_handle_hid_add(void *p) {
     }
     lua_rawseti(lvm, -2, i + 1);
   }
-  l_report(lvm, l_docall(lvm, 4, 0));
+  lua_pushlightuserdata(lvm, dev);
+  l_report(lvm, l_docall(lvm, 5, 0));
 }
 
 void w_handle_hid_remove(int id) {


### PR DESCRIPTION
I wanted to dig into HID with a keyboard and mouse today and I found it was really confusing.

I thought It might be better to have it's connection method work like grid and midi so I set about rewriting hid.lua

Thus a HID script could be much simpler:
```
local keyb = hid.connect(1)
function keyb.event(typ, code, val)
    print("hid.event ", typ, code, val)
end
```

This is not yet plugged into menu.lua to have hid devices show up in the SYSTEM menus.

I am also getting an error on device removal that I don't understand
```error: double free in device_hid.c```
