### PR TITLE
engine table protection

### DIFF
--- a/lua/startup.lua
+++ b/lua/startup.lua
@@ -1,5 +1,8 @@
 -- STARTUP
 
+tab = require 'tabutil'
+util = require 'util'
+
 require 'math'
 math.randomseed(os.time()) -- more random
 
@@ -13,7 +16,7 @@ metro = require 'metro'
 midi = require 'midi'
 osc = require 'osc'
 poll = require 'poll'
-engine = require 'engine'
+engine = tab.readonly{table = require 'engine', exceptFor = {'name'}}
 wifi = require 'wifi'
 
 fileselect = require 'fileselect'
@@ -24,8 +27,6 @@ paramset = require 'paramset'
 
 params = paramset.new()
 
-tab = require 'tabutil'
-util = require 'util'
 
 -- load menu
 require 'menu'

--- a/lua/startup.lua
+++ b/lua/startup.lua
@@ -16,7 +16,7 @@ metro = require 'metro'
 midi = require 'midi'
 osc = require 'osc'
 poll = require 'poll'
-engine = tab.readonly{table = require 'engine', exceptFor = {'name'}}
+engine = tab.readonly{table = require 'engine', except = {'name'}}
 wifi = require 'wifi'
 
 fileselect = require 'fileselect'

--- a/lua/tabutil.lua
+++ b/lua/tabutil.lua
@@ -181,11 +181,11 @@ end
 --- Create a read-only proxy for a given table.
 -- @params params
 -- @params params.table the table to proxy
--- @params params.exceptFor a list of writable keys
+-- @params params.except a list of writable keys
 -- @return the proxied read-only table
 function tab.readonly(params)
   local t = params.table
-  local exceptions = params.exceptFor or {}
+  local exceptions = params.except or {}
   local proxy = {}
   local mt = {
     __index = t,

--- a/lua/tabutil.lua
+++ b/lua/tabutil.lua
@@ -178,5 +178,29 @@ function tab.load(sfile)
   return tables[1]
 end
 
+--- Create a read-only proxy for a given table.
+-- @params params
+-- @params params.table the table to proxy
+-- @params params.exceptFor a list of writable keys
+-- @return the proxied read-only table
+function tab.readonly(params)
+  local t = params.table
+  local exceptions = params.exceptFor or {}
+  local proxy = {}
+  local mt = {
+    __index = t,
+    __newindex = function (_,k,v)
+      if (tab.contains(exceptions, k)) then
+        t[k] = v
+      else
+        error("'"..k.."', a read-only key, cannot be re-assigned.")
+      end
+    end,
+    __pairs = function (_) return pairs(proxy) end,
+    __ipairs = function (_) return ipairs(proxy) end,
+  }
+  setmetatable(proxy, mt)
+  return proxy
+end
 
 return tab


### PR DESCRIPTION
a crack at guarding tables generally and `engine` in particular.

* adds `readonly` API to `tabutil`
* wraps `engine` import in `startup` with a read-only proxy

![image](https://user-images.githubusercontent.com/67586/49403806-8baa7700-f702-11e8-962b-46f71a17e8f7.png)

closes: #663; fixes: #656 

/cc @tehn @catfact @artfwo 