### PR TITLE
Add start/stop/continue/clock helpers

### DIFF
--- a/lua/midi.lua
+++ b/lua/midi.lua
@@ -139,16 +139,23 @@ function Midi.connect(n)
       d.send{type="channel_pressure", val=val, ch=ch or 1}
     end
   d.start = function()
-      d.send{0xfa}
+      d.send{type="start"}
     end
   d.stop = function()
-      d.send{0xfc}
+      d.send{type="stop"}
     end
   d.continue = function()
-      d.send{0xfb}
+     d.send{type="continue"}
+      --d.send{0xfb}
     end
   d.clock = function()
-      d.send{0xf8}
+      d.send{type="clock"}
+    end
+  d.song_position = function(lsb, msb)
+      d.send{type="song_position", lsb=lsb, msb=msb}
+    end
+  d.song_select = function(val)
+      d.send{type="song_select", val=val}
     end
 
   return d
@@ -184,8 +191,25 @@ local to_data = {
     end,
   channel_pressure = function(msg)
       return {0xd0 + (msg.ch or 1) - 1, msg.val}
+    end,
+  start = function(msg)
+      return {0xfa}
+    end,
+  stop = function(msg)
+      return {0xfc}
+    end,
+  continue = function(msg)
+      return {0xfb}
+    end,
+  clock = function(msg)
+      return {0xf8}
+    end,
+  song_position = function(msg)
+      return {0xf2, msg.lsb, msg.msb}
+    end,
+  song_select = function(msg)
+      return {0xf3, msg.val}
     end
-  -- start/stop/continue/clock have no data, just use send helper function
 }
 
 --- convert msg to data (midi bytes)
@@ -260,13 +284,26 @@ function Midi.to_msg(data)
   -- clock
   elseif data[1] == 0xf8 then
     msg.type = "clock"
+  -- song position pointer
+  elseif data[1] == 0xf2 then
+    msg = {
+        type = "song_position",
+        lsb = data[2],
+        msb = data[3]
+    }    
+  -- song select
+  elseif data[1] == 0xf3 then
+    msg = {
+        type = "song_select",
+        val = data[2]
+    }    
   -- active sensing (should probably ignore)
   elseif data[1] == 0xfe then
       -- do nothing
   -- everything else
   else
     msg = {
-      type = "other"
+      type = "other",
     }
   end
   return msg


### PR DESCRIPTION
Update to previous midi fixes.

Adds 
- midi send helper functions for start, stop, continue and clock
- `Midi.to_msg(data)` conversions for those types as well.

I did not add `to_data` conversions for these as they have no data so just the send helper function can be used.