### PR TITLE
vport api overhaul

### DIFF
--- a/lua/core/arc.lua
+++ b/lua/core/arc.lua
@@ -15,8 +15,8 @@ for i=1,4 do
   Arc.vports[i] = {
     name = "none",
 
-    delta = function() end,
-    key = function() end,
+    delta = nil,
+    key = nil,
 
     led = function() end,
     all = function() end,
@@ -143,8 +143,8 @@ end
 --- clear handlers
 function Arc.cleanup()
   for i=1,4 do
-    Arc.vports[i].delta = function() end
-    Arc.vports[i].key = function() end
+    Arc.vports[i].delta = nil
+    Arc.vports[i].key = nil
   end
 end
 

--- a/lua/core/arc.lua
+++ b/lua/core/arc.lua
@@ -14,14 +14,15 @@ Arc.vports = {}
 for i=1,4 do
   Arc.vports[i] = {
     name = "none",
+    device = nil,
 
     delta = nil,
     key = nil,
 
-    led = function() end,
-    all = function() end,
-    refresh = function() end,
-    segment = function() end,
+    led = function(self, ...) if self.device then self.device:led(...) end end,
+    all = function(self, ...) if self.device then self.device:all(...) end end,
+    refresh = function(self, ...) if self.device then self.device:refresh(...) end end,
+    segment = function(self, ...) if self.device then self.device:segment(...) end end,
   }
 end
 
@@ -149,24 +150,18 @@ function Arc.cleanup()
 end
 
 function Arc.update_devices()
+  -- reset vports for existing devices
   for _, device in pairs(Arc.devices) do
     device.port = nil
   end
 
   -- connect available devices to vports
   for i=1,4 do
-    Arc.vports[i].led = function() end
-    Arc.vports[i].all = function() end
-    Arc.vports[i].refresh = function() end
-    Arc.vports[i].segment = function() end
+    Arc.vports[i].device = nil
 
     for _, device in pairs(Arc.devices) do
       if device.name == Arc.vports[i].name then
-        Arc.vports[i].led = function(ring, x, val) device:led(ring, x, val) end
-        Arc.vports[i].all = function(val) device:all(val) end
-        Arc.vports[i].refresh = function() device:refresh() end
-        Arc.vports[i].segment = function(ring, from, to, val) device:segment(ring, from, to, val) end
-
+        Arc.vports[i].device = device
         device.port = i
       end
     end

--- a/lua/core/arc.lua
+++ b/lua/core/arc.lua
@@ -47,7 +47,7 @@ function Arc.new(id, serial, name, dev)
   for i=1,4 do
     table.insert(connected, Arc.vports[i].name)
   end
-  if not tab.contains(connected, name) then
+  if not tab.contains(connected, device.name) then
     for i=1,4 do
       if Arc.vports[i].name == "none" then
         Arc.vports[i].name = device.name

--- a/lua/core/arc.lua
+++ b/lua/core/arc.lua
@@ -9,12 +9,12 @@ local Arc = {}
 Arc.__index = Arc
 
 Arc.devices = {}
-Arc.list = {}
 Arc.vports = {}
 
 for i=1,4 do
   Arc.vports[i] = {
     name = "none",
+
     delta = function() end,
     key = function() end,
 
@@ -33,11 +33,7 @@ function Arc.new(id, serial, name, dev)
   local device = setmetatable({}, Arc)
   device.id = id
   device.serial = serial
-  name = name .. " " .. serial
-  --while tab.contains(Arc.list, name) do
-  --  name = name .. "+"
-  --end
-  device.name = name
+  device.name = name.." "..serial
   device.dev = dev -- opaque pointer
   device.delta = nil -- delta event callback
   device.key = nil -- key event callback
@@ -52,7 +48,7 @@ function Arc.new(id, serial, name, dev)
   if not tab.contains(connected, name) then
     for i=1,4 do
       if Arc.vports[i].name == "none" then
-        Arc.vports[i].name = name
+        Arc.vports[i].name = device.name
         break
       end
     end
@@ -111,12 +107,10 @@ function Arc.cleanup()
 end
 
 function Arc.update_devices()
-  -- build list of available devices
-  Arc.list = {}
   for _, device in pairs(Arc.devices) do
-    table.insert(Arc.list, device.name)
     device.port = nil
   end
+
   -- connect available devices to vports
   for i=1,4 do
     Arc.vports[i].led = function(ring, x, val) end

--- a/lua/core/arc.lua
+++ b/lua/core/arc.lua
@@ -5,6 +5,8 @@
 ---------------------------------
 -- Arc device class
 
+local vport = require 'vport'
+
 local Arc = {}
 Arc.__index = Arc
 
@@ -19,10 +21,10 @@ for i=1,4 do
     delta = nil,
     key = nil,
 
-    led = function(self, ...) if self.device then self.device:led(...) end end,
-    all = function(self, ...) if self.device then self.device:all(...) end end,
-    refresh = function(self, ...) if self.device then self.device:refresh(...) end end,
-    segment = function(self, ...) if self.device then self.device:segment(...) end end,
+    let = vport.wrap_method('led'),
+    all = vport.wrap_method('all'),
+    refresh = vport.wrap_method('refresh'),
+    segment = vport.wrap_method('segment'),
   }
 end
 

--- a/lua/core/arc.lua
+++ b/lua/core/arc.lua
@@ -31,6 +31,7 @@ end
 -- @tparam userdata dev : opaque pointer to device
 function Arc.new(id, serial, name, dev)
   local device = setmetatable({}, Arc)
+
   device.id = id
   device.serial = serial
   device.name = name.." "..serial
@@ -154,7 +155,11 @@ norns.arc.delta = function(id, n, delta)
   local device = Arc.devices[id]
 
   if device ~= nil then
-    if (device.port) then
+    if device.delta then
+      device.delta(n, delta)
+    end
+
+    if device.port then
       Arc.vports[device.port].delta(n, delta)
     end
   else
@@ -166,7 +171,11 @@ norns.arc.key = function(id, n, s)
   local device = Arc.devices[id]
 
   if device ~= nil then
-    if (device.port) then
+    if device.key then
+      device.key(n, s)
+    end
+
+    if device.port then
       Arc.vports[device.port].key(n, s)
     end
   else

--- a/lua/core/arc.lua
+++ b/lua/core/arc.lua
@@ -200,7 +200,9 @@ norns.arc.delta = function(id, n, delta)
     end
 
     if device.port then
-      Arc.vports[device.port].delta(n, delta)
+      if Arc.vports[device.port].delta then
+        Arc.vports[device.port].delta(n, delta)
+      end
     end
   else
     error('no entry for arc '..id)
@@ -216,7 +218,9 @@ norns.arc.key = function(id, n, s)
     end
 
     if device.port then
-      Arc.vports[device.port].key(n, s)
+      if Arc.vports[device.port].key then
+        Arc.vports[device.port].key(n, s)
+      end
     end
   else
     error('no entry for arc '..id)

--- a/lua/core/arc.lua
+++ b/lua/core/arc.lua
@@ -6,22 +6,23 @@
 -- Arc device class
 
 local Arc = {}
+Arc.__index = Arc
+
 Arc.devices = {}
 Arc.list = {}
-Arc.vport = {}
+Arc.vports = {}
+
 for i=1,4 do
-  Arc.vport[i] = {
+  Arc.vports[i] = {
     name = "none",
-    delta_callbacks = {},
-    key_callbacks = {},
-    index = 0,
+    delta = function() end,
+    key = function() end,
+
     led = function() end,
     all = function() end,
     refresh = function() end,
-    attached = false
   }
 end
-Arc.__index = Arc
 
 --- constructor
 -- @tparam integer id : arbitrary numeric identifier
@@ -41,17 +42,17 @@ function Arc.new(id, serial, name, dev)
   device.delta = nil -- delta event callback
   device.key = nil -- key event callback
   device.remove = nil -- device unplug callback
-  device.ports = {} -- list of virtual ports this device is attached to
+  device.port = nil
 
   -- autofill next postiion
   local connected = {}
   for i=1,4 do
-    table.insert(connected, Arc.vport[i].name)
+    table.insert(connected, Arc.vports[i].name)
   end
   if not tab.contains(connected, name) then
     for i=1,4 do
-      if Arc.vport[i].name == "none" then
-        Arc.vport[i].name = name
+      if Arc.vports[i].name == "none" then
+        Arc.vports[i].name = name
         break
       end
     end
@@ -94,72 +95,18 @@ function Arc:refresh()
   monome_refresh(self.dev)
 end
 
---- print a description of this arc device
-function Arc:print()
-  for k, v in pairs(self) do
-    print('>> ', k, v)
-  end
-end
-
 --- create device, returns object with handler and send
 function Arc.connect(n)
   local n = n or 1
-  if n > 4 then n = 4 end
 
-  Arc.vport[n].index = Arc.vport[n].index + 1
-
-  local d = {
-    index = Arc.vport[n].index,
-    port = n,
-    delta = function(n, delta)
-      print("arc input")
-    end,
-    key = function(n, s)
-      print("arc input")
-    end,
-    attached = function() return Arc.vport[n].attached end,
-    led = function(ring, x, val) Arc.vport[n].led(ring, x, val) end,
-    all = function(val) Arc.vport[n].all(val) end,
-    refresh = function() Arc.vport[n].refresh() end,
-    disconnect = function(self)
-      self.led = function() end
-      self.all = function() end
-      self.refresh = function() print("refresh: arc not connected") end
-      Arc.vport[self.port].delta_callbacks[self.index] = nil
-      Arc.vport[self.port].key_callbacks[self.index] = nil
-      self.index = nil
-      self.port = nil
-    end,
-    reconnect = function(self, p)
-      p = p or 1
-      if self.index then
-        Arc.vport[self.port].delta_callbacks[self.index] = nil
-        Arc.vport[self.port].key_callbacks[self.index] = nil
-      end
-      self.attached = function() return Arc.vport[p].attached end
-      self.led = function(ring, x, val) Arc.vport[p].led(ring, x, val) end
-      self.all = function(val) Arc.vport[p].all(val) end
-      self.refresh = function() Arc.vport[p].refresh() end
-      Arc.vport[p].index = Arc.vport[p].index + 1
-      self.index = Arc.vport[p].index
-      self.port = p
-      Arc.vport[p].delta_callbacks[self.index] = function(n, delta) self.delta(n, delta) end
-      Arc.vport[p].key_callbacks[self.index] = function(n, s) self.key(n, s) end
-    end
-  }
-
-  Arc.vport[n].delta_callbacks[d.index] = function(n, delta) d.delta(n, delta) end
-  Arc.vport[n].key_callbacks[d.index] = function(n, s) d.key(n, s) end
-
-  return d
+  return Arc.vports[n]
 end
 
 --- clear handlers
 function Arc.cleanup()
   for i=1,4 do
-    Arc.vport[i].delta_callbacks = {}
-    Arc.vport[i].key_callbacks = {}
-    Arc.vport[i].index = 0
+    Arc.vports[i].delta = function() end
+    Arc.vports[i].key = function() end
   end
 end
 
@@ -168,21 +115,19 @@ function Arc.update_devices()
   Arc.list = {}
   for _, device in pairs(Arc.devices) do
     table.insert(Arc.list, device.name)
-    device.ports = {}
+    device.port = nil
   end
   -- connect available devices to vports
   for i=1,4 do
-    Arc.vport[i].attached = false
-    Arc.vport[i].led = function(ring, x, val) end
-    Arc.vport[i].all = function(val) end
-    Arc.vport[i].refresh = function() end
+    Arc.vports[i].led = function(ring, x, val) end
+    Arc.vports[i].all = function(val) end
+    Arc.vports[i].refresh = function() end
     for _, device in pairs(Arc.devices) do
-      if device.name == Arc.vport[i].name then
-        Arc.vport[i].led = function(ring, x, val) device:led(ring, x, val) end
-        Arc.vport[i].all = function(val) device:all(val) end
-        Arc.vport[i].refresh = function() device:refresh() end
-        Arc.vport[i].attached = true
-        table.insert(device.ports, i)
+      if device.name == Arc.vports[i].name then
+        Arc.vports[i].led = function(ring, x, val) device:led(ring, x, val) end
+        Arc.vports[i].all = function(val) device:all(val) end
+        Arc.vports[i].refresh = function() device:refresh() end
+        device.port = i
       end
     end
   end
@@ -215,13 +160,11 @@ norns.arc.delta = function(id, n, delta)
   local device = Arc.devices[id]
 
   if device ~= nil then
-    for _, i in pairs(device.ports) do
-      for _, callback in pairs(Arc.vport[i].delta_callbacks) do
-        callback(n, delta)
-      end
+    if (device.port) then
+      Arc.vports[device.port].delta(n, delta)
     end
   else
-    print('>> error: no entry for arc ' .. id)
+    error('no entry for arc '..id)
   end
 end
 
@@ -229,13 +172,11 @@ norns.arc.key = function(id, n, s)
   local device = Arc.devices[id]
 
   if device ~= nil then
-    for _, i in pairs(device.ports) do
-      for _, callback in pairs(Arc.vport[i].key_callbacks) do
-        callback(n, s)
-      end
+    if (device.port) then
+      Arc.vports[device.port].key(n, s)
     end
   else
-    print('>> error: no entry for arc ' .. id)
+    error('no entry for arc '..id)
   end
 end
 

--- a/lua/core/grid.lua
+++ b/lua/core/grid.lua
@@ -5,6 +5,8 @@
 ---------------------------------
 -- Grid device class
 
+local vport = require 'vport'
+
 local Grid = {}
 Grid.__index = Grid
 
@@ -18,10 +20,10 @@ for i=1,4 do
 
     key = nil,
 
-    led = function(self, ...) if self.device then self.device:led(...) end end,
-    all = function(self, ...) if self.device then self.device:all(...) end end,
-    refresh = function(self, ...) if self.device then self.device:refresh(...) end end,
-    rotation = function(self, ...) if self.device then self.device:rotation(...) end end,
+    led = vport.wrap_method('led'),
+    all = vport.wrap_method('all'),
+    refresh = vport.wrap_method('refresh'),
+    rotation = vport.wrap_method('rotation'),
 
     cols = 0,
     rows = 0,

--- a/lua/core/grid.lua
+++ b/lua/core/grid.lua
@@ -114,7 +114,6 @@ end
 --- create device, returns object with handler and send
 function Grid.connect(n)
   local n = n or 1
-  if n>4 then n=4 end
 
   Grid.vport[n].index = Grid.vport[n].index + 1
 

--- a/lua/core/grid.lua
+++ b/lua/core/grid.lua
@@ -6,24 +6,27 @@
 -- Grid device class
 
 local Grid = {}
+Grid.__index = Grid
+
 Grid.devices = {}
-Grid.list = {}
-Grid.vport = {}
+Grid.vports = {}
+
 for i=1,4 do
-  Grid.vport[i] = {
+  Grid.vports[i] = {
     name = "none",
-    callbacks = {},
-    index = 0,
-    led = function() end,
-    all = function() end,
-    rotation = function() end,
-    refresh = function() end,
+    device = nil,
+
+    key = nil,
+
+    led = function(self, ...) if self.device then self.device:led(...) end end,
+    all = function(self, ...) if self.device then self.device:all(...) end end,
+    refresh = function(self, ...) if self.device then self.device:refresh(...) end end,
+    rotation = function(self, ...) if self.device then self.device:rotation(...) end end,
+
     cols = 0,
     rows = 0,
-    attached = false
   }
 end
-Grid.__index = Grid
 
 --- constructor
 -- @tparam integer id : arbitrary numeric identifier
@@ -32,29 +35,26 @@ Grid.__index = Grid
 -- @tparam userdata dev : opaque pointer to device
 function Grid.new(id, serial, name, dev)
   local g = setmetatable({}, Grid)
+
   g.id = id
   g.serial = serial
-  name = name .. " " .. serial
-  --while tab.contains(Grid.list,name) do
-  --  name = name .. "+"
-  --end
-  g.name = name
+  g.name = name.." "..serial
   g.dev = dev -- opaque pointer
   g.key = nil -- key event callback
   g.remove = nil -- device unplug callback
   g.rows = grid_rows(dev)
   g.cols = grid_cols(dev)
-  g.ports = {} -- list of virtual ports this device is attached to
+  g.port = nil
 
   -- autofill next postiion
   local connected = {}
   for i=1,4 do
-    table.insert(connected, Grid.vport[i].name)
+    table.insert(connected, Grid.vports[i].name)
   end
-  if not tab.contains(connected, name) then
+  if not tab.contains(connected, g.name) then
     for i=1,4 do
-      if Grid.vport[i].name == "none" then
-        Grid.vport[i].name = name
+      if Grid.vports[i].name == "none" then
+        Grid.vports[i].name = g.name
         break
       end
     end
@@ -103,71 +103,17 @@ function Grid:refresh()
   monome_refresh(self.dev)
 end
 
---- print a description of this grid device
-function Grid:print()
-  for k,v in pairs(self) do
-    print('>> ', k,v)
-  end
-end
-
-
 --- create device, returns object with handler and send
 function Grid.connect(n)
   local n = n or 1
 
-  Grid.vport[n].index = Grid.vport[n].index + 1
-
-  local d = {
-    index = Grid.vport[n].index,
-    port = n,
-    cols = function() return Grid.vport[n].cols end,
-    rows = function() return Grid.vport[n].rows end,
-    event = function(x,y,z)
-        print("grid input")
-      end,
-    attached = function() return Grid.vport[n].attached end,
-    led = function(x,y,z) Grid.vport[n].led(x,y,z) end,
-    all = function(val) Grid.vport[n].all(val) end,
-    rotation = function(val) Grid.vport[n].rotation(val) end,
-    refresh = function() Grid.vport[n].refresh() end,
-    disconnect = function(self)
-        self.led = function() end
-        self.all = function() end
-        self.rotation = function() end
-        self.refresh = function() print("refresh: grid not connected") end
-        Grid.vport[self.port].callbacks[self.index] = nil
-        self.index = nil
-        self.port = nil
-      end,
-    reconnect = function(self, p)
-        p = p or 1
-        if self.index then
-          Grid.vport[self.port].callbacks[self.index] = nil
-        end
-        self.attached = function() return Grid.vport[p].attached end
-        self.led = function(x,y,z) Grid.vport[p].led(x,y,z) end
-        self.all = function(val) Grid.vport[p].all(val) end
-        self.rotation = function(val) Grid.vport[p].rotation(val) end
-        self.refresh = function() Grid.vport[p].refresh() end
-        Grid.vport[p].index = Grid.vport[p].index + 1
-        self.index = Grid.vport[p].index
-        self.port = p
-        self.cols = function() return Grid.vport[p].cols end
-        self.rows = function() return Grid.vport[p].rows end
-        Grid.vport[p].callbacks[self.index] = function(x,y,z) self.event(x,y,z) end
-      end
-  }
-
-	Grid.vport[n].callbacks[d.index] = function(x,y,z) d.event(x,y,z) end
-
-  return d
+  return Grid.vports[n]
 end
 
 --- clear handlers
 function Grid.cleanup()
   for i=1,4 do
-    Grid.vport[i].callbacks = {}
-		Grid.vport[i].index = 0
+    Grid.vports[i].key = nil
   end
 end
 
@@ -175,33 +121,25 @@ function Grid.update_devices()
   -- build list of available devices
   Grid.list = {}
   for _,device in pairs(Grid.devices) do
-    table.insert(Grid.list, device.name)
-    device.ports = {}
+    device.port = nil
   end
+
   -- connect available devices to vports
   for i=1,4 do
-    Grid.vport[i].attached = false
-    Grid.vport[i].led = function(x, y, val) end
-    Grid.vport[i].all = function(val) end
-    Grid.vport[i].rotation = function(val) end
-    Grid.vport[i].refresh = function() end
-    Grid.vport[i].cols = 0
-    Grid.vport[i].rows = 0
+    Grid.vports[i].device = nil
+
     for _,device in pairs(Grid.devices) do
-      if device.name == Grid.vport[i].name then
-        Grid.vport[i].cols = device.cols
-        Grid.vport[i].rows = device.rows
-        Grid.vport[i].led = function(x, y, val) device:led(x, y, val) end
-        Grid.vport[i].all = function(val) device:all(val) end
-        Grid.vport[i].rotation = function(val) device:rotation(val) end
-        Grid.vport[i].refresh = function() device:refresh() end
-        Grid.vport[i].attached = true
-        table.insert(device.ports, i)
+      if device.name == Grid.vports[i].name then
+        Grid.vports[i].device = device
+        Grid.vports[i].rows = device.rows
+        Grid.vports[i].cols = device.cols
+        device.port = i
       end
     end
   end
 end
 
+norns.grid = {}
 
 -- grid devices
 norns.grid.add = function(id, serial, name, dev)
@@ -225,21 +163,20 @@ norns.grid.remove = function(id)
 end
 
 --- redefine global grid key input handler
-norns.grid.key = function(id, x, y, z)
+norns.grid.key = function(id, x, y, s)
   local g = Grid.devices[id]
   if g ~= nil then
     if g.key ~= nil then
-      g.key(x, y, z)
+      g.key(x, y, s)
     end
 
-    for _,n in pairs(g.ports) do
-      for _,event in pairs(Grid.vport[n].callbacks) do
-        --print("vport " .. n)
-        event(x,y,z)
+    if g.port then
+      if Grid.vports[g.port].key then
+        Grid.vports[g.port].key(x, y, s)
       end
     end
   else
-    print('>> error: no entry for grid ' .. id)
+    error('no entry for grid '..id)
   end
 end
 

--- a/lua/core/hid.lua
+++ b/lua/core/hid.lua
@@ -5,8 +5,13 @@
 ---------------------------------
 -- Hid device class
 
+local hid_events = require 'hid_events'
+
 local Hid = {}
 Hid.__index = Hid
+
+Hid.types = hid_events.types
+Hid.codes = hid_events.codes
 
 Hid.devices = {}
 Hid.vports = {}

--- a/lua/core/hid.lua
+++ b/lua/core/hid.lua
@@ -5,6 +5,7 @@
 ---------------------------------
 -- Hid device class
 
+local vport = require 'vport'
 local hid_events = require 'hid_events'
 
 local Hid = {}
@@ -35,7 +36,7 @@ function Hid.new(id, name, types, codes, dev)
   local device = setmetatable({}, Hid)
 
   device.id = id
-  device.name = name
+  device.name = vport.get_unique_device_name(name, Hid.devices)
   device.dev = dev -- opaque pointer
   device.event = nil -- event callback
   device.remove = nil -- device unplug callback

--- a/lua/core/hid.lua
+++ b/lua/core/hid.lua
@@ -130,12 +130,12 @@ norns.hid.event = function(id, type, code, value)
 
   if device ~= nil then
     if device.event then
-      device.event(id, type, code, value)
+      device.event(type, code, value)
     end
 
     if device.port then
       if Hid.vports[device.port].event then
-        Hid.vports[device.port].event(id, type, code, value)
+        Hid.vports[device.port].event(type, code, value)
       end
     end
   else

--- a/lua/core/hid.lua
+++ b/lua/core/hid.lua
@@ -25,7 +25,8 @@ end
 -- @tparam string name : name
 -- @tparam string types : array of supported event types. keys are type codes, values are strings
 -- @tparam userdata codes : array of supported codes. each entry is a table of codes of a given type. subtables are indexed by supported code numbers; values are code names
-function Hid.new(id, name, types, codes)
+-- @tparam userdata dev : opaque pointer to device
+function Hid.new(id, name, types, codes, dev)
   local device = setmetatable({}, Hid)
 
   device.id = id
@@ -56,7 +57,7 @@ end
 -- user scripts can redefine
 -- @param dev : a Hid table
 function Hid.add(dev)
-  print("hid added:", dev.id, dev.name, dev.serial)
+  print("hid added:", dev.id, dev.name)
 end
 
 --- scan device list and grab one, redefined later
@@ -104,8 +105,8 @@ end
 norns.hid = {}
 
 -- hid devices
-norns.hid.add = function(id, serial, name, dev)
-  local g = Hid.new(id, serial, name, dev)
+norns.hid.add = function(id, name, types, codes, dev)
+  local g = Hid.new(id, name, types, codes, dev)
   Hid.devices[id] = g
   Hid.update_devices()
   if Hid.add ~= nil then Hid.add(g) end

--- a/lua/core/hid.lua
+++ b/lua/core/hid.lua
@@ -1,842 +1,144 @@
---- hid devices
+--- Hid class
 -- @module hid
 -- @alias Hid
+
+---------------------------------
+-- Hid device class
 
 local Hid = {}
 Hid.__index = Hid
 
 Hid.devices = {}
+Hid.vports = {}
 
---- device-added callback;
--- script should redefine to handle device hotplug events
--- @param device - a Hid
-Hid.add = function(device)
-  print("device added: ", device.id, device.name)
+for i=1,4 do
+  Hid.vports[i] = {
+    name = "none",
+    device = nil,
+
+    event = nil,
+  }
 end
 
---- device-removed callbacks;
--- script should redefine to handle device hotplug events
--- @param device - a Hid
-Hid.remove = function(device)
-  print("device removed: ", device.id, device.name)
-end
-
--- `codes` is indexed by event type, values are subtables
--- @tparam integer id : arbitrary numberical index of the device
--- @tparam string name: device name string from USB
--- @param types: array of supported event types. keys are type codes, values are strings
--- @param codes: array of supported codes. each entry is a table of codes of a given type. subtables are indexed by supported code numbers; values are code names
+--- constructor
+-- @tparam integer id : arbitrary numeric identifier
+-- @tparam string name : name
+-- @tparam string types : array of supported event types. keys are type codes, values are strings
+-- @tparam userdata codes : array of supported codes. each entry is a table of codes of a given type. subtables are indexed by supported code numbers; values are code names
 function Hid.new(id, name, types, codes)
-  local d = setmetatable({}, Hid)
-  -- print(id, name, types, codes)
-  d.id = id
-  d.name = name
-  d.types = types
-  d.codes = {}
-  d.callbacks = {}
-  for i,t in pairs(types) do
-    if Hid.event_types[t] ~= nil then
-   d.codes[t] = {}
-   for j,c in pairs(codes[i]) do
-     d.codes[t][c] = Hid.event_codes[t][c]
-   end
+  local device = setmetatable({}, Hid)
+
+  device.id = id
+  device.name = name
+  device.dev = dev -- opaque pointer
+  device.event = nil -- event callback
+  device.remove = nil -- device unplug callback
+  device.port = nil
+
+  -- autofill next postiion
+  local connected = {}
+  for i=1,4 do
+    table.insert(connected, Hid.vports[i].name)
+  end
+  if not tab.contains(connected, device.name) then
+    for i=1,4 do
+      if Hid.vports[i].name == "none" then
+        Hid.vports[i].name = device.name
+        break
+      end
     end
   end
-  return d
+
+  return device
 end
 
---- return the first available device that supports the given event
--- @tparam string ev_type - event type name, e.g. 'EV_KEY'
--- @tparam string ev_code - event code name, e.g. 'BTN_START'
--- @return - a Hid or nil
-function Hid.find_device_supporting(ev_type, ev_code)
-  local ev_type_num = Hid.event_types_rev[ev_type]
-  if ev_type_num == nil then return nil end
-  local ev_code_num = Hid.event_codes_rev[ev_type][ev_code]
-  if ev_code_num == nil then return nil end
-  -- only reason we don't call Hid:supports here is to save cycles + allocations
-  for i,v in pairs(Hid.devices) do
-    if v.types[ev_type_num] then
-      if v.codes[ev_type_num][ev_code_num] then return v end
-    end
+--- static callback when any hid device is added;
+-- user scripts can redefine
+-- @param dev : a Hid table
+function Hid.add(dev)
+  print("hid added:", dev.id, dev.name, dev.serial)
+end
+
+--- scan device list and grab one, redefined later
+function Hid.reconnect() end
+
+--- static callback when any hid device is removed;
+-- user scripts can redefine
+-- @param dev : a Hid table
+function Hid.remove(dev) end
+
+
+--- create device, returns object with handler and send
+function Hid.connect(n)
+  local n = n or 1
+
+  return Hid.vports[n]
+end
+
+--- clear handlers
+function Hid.cleanup()
+  for i=1,4 do
+    Hid.vports[i].event = nil
   end
-  return nil -- didn't find any
 end
 
--- ----------------------------------
--- instance methods
-
---- unset all callbacks
-function Hid:clearCallbacks()
-  for code, cb in self.callbacks do
-    self.callbacks[code] = nil
+function Hid.update_devices()
+  -- reset vports for existing devices
+  for _, device in pairs(Hid.devices) do
+    device.port = nil
   end
-end
 
---- test if device supports given event type and code
--- @tparam string ev_type - event type name, e.g. 'EV_REL'
--- @tparam string ev_code - event code name, e.g. 'REL_X',
--- @treturn boolean
-function Hid:supports(ev_type, ev_code)
-  local ev_type_num = Hid.event_types_rev[ev_type]
-  if ev_type_num == nil then return false end
-  local ev_code_num = Hid.event_codes_rev[ev_type][ev_code]
-  if ev_code_num == nil then return false end
-  if self.types[ev_type_num] then
-    if self.codes[ev_type_num][ev_code_num] then return true end
-  end
-  return false
-end
+  -- connect available devices to vports
+  for i=1,4 do
+    Hid.vports[i].device = nil
 
---- print some information about a device
-function Hid:print()
-  print(self.id, self.name)
-  print('supported events: ')
-  for t,arr in pairs(self.codes) do
-    if Hid.event_types[t] ~= nil then
-      print(t, Hid.event_types[t])
-    else
-      print(t, '(unsupported)')
-    end
-    for id,name in pairs(arr) do
-      print('', id, name)
+    for _, device in pairs(Hid.devices) do
+      if device.name == Hid.vports[i].name then
+        Hid.vports[i].device = device
+        device.port = i
+      end
     end
   end
 end
 
--- -------------------------------------------------
--- global norns functions (C glue)
+norns.hid = {}
 
---- add a device
--- @param id - arbitrary id number (int)
--- @param name (string)
--- @param types - table of event types  (int)
--- @param codes - table of table of event codes (int), indexed by type (int)
-norns.hid.add = function(id, name, types, codes)
-  local d = Hid.new(id, name, types, codes)
-  Hid.devices[id] = d
-  if Hid.add ~= nil then Hid.add(d) end
+-- hid devices
+norns.hid.add = function(id, serial, name, dev)
+  local g = Hid.new(id, serial, name, dev)
+  Hid.devices[id] = g
+  Hid.update_devices()
+  if Hid.add ~= nil then Hid.add(g) end
 end
 
---- remove a device
--- @param id - arbitrary id numer (int)
 norns.hid.remove = function(id)
-  local d = Hid.devices[id]
-  if d then
-    if Hid.remove then Hid.remove(d) end
-    Hid.devices[id] = nil
-  end
-end
-
---- handle a hid event
--- @tparam integer id- arbitrary device id number
--- @tparam integer ev_type - event type id
--- @tparam integer ev_code - event code id
--- @tparam integer value
-norns.hid.event = function(id, ev_type, ev_code, value)
-  local ev_type_name = Hid.event_types[ev_type]
-  assert(ev_type_name)
-  local ev_code_name = Hid.event_codes[ev_type][ev_code]
-  -- print("norns.hid.event ", id, ev_type_name, ev_code_name, value)
-  local dev = Hid.devices[id]
-  if  dev then
-    local cb = dev.callbacks[ev_code_name]
-    if cb then
-   cb(value)
+  if Hid.devices[id] then
+    if Hid.remove ~= nil then
+      Hid.remove(Hid.devices[id])
+    end
+    if Hid.devices[id].remove then
+      Hid.devices[id].remove()
     end
   end
+  Hid.devices[id] = nil
+  Hid.update_devices()
 end
 
--- --------------------------------
--- input event codes
--- FIXME: we shouldn't need any of this mess. just get matron to send us code names instead of [type, code] numbers.
+norns.hid.event = function(id, type, code, value)
+  local device = Hid.devices[id]
 
+  if device ~= nil then
+    if device.event then
+      device.event(id, type, code, value)
+    end
 
--- tables and reverse tables mapping hex to string for event types and codes
-
-
--- event types
-Hid.event_types = {
-  [0x01] = 'EV_KEY',
-  [0x02] = 'EV_REL',
-  [0x03] = 'EV_ABS',
-  [0x05] = 'EV_SW',
-  [0x11] = 'EV_LED',
-}
-
-Hid.event_types_rev = {}
-for k,v in pairs(Hid.event_types) do
-  Hid.event_types_rev[v] = k
-end
-
-Hid.event_codes = {}
-Hid.event_codes[Hid.event_types_rev['EV_KEY']] = {
-  [0] = 'KEY_RESERVED',
-  [1] = 'KEY_ESC',
-  [2] = 'KEY_1',
-  [3] = 'KEY_2',
-  [4] = 'KEY_3',
-  [5] = 'KEY_4',
-  [6] = 'KEY_5',
-  [7] = 'KEY_6',
-  [8] = 'KEY_7',
-  [9] = 'KEY_8',
-  [10] = 'KEY_9',
-  [11] = 'KEY_0',
-  [12] = 'KEY_MINUS',
-  [13] = 'KEY_EQUAL',
-  [14] = 'KEY_BACKSPACE',
-  [15] = 'KEY_TAB',
-  [16] = 'KEY_Q',
-  [17] = 'KEY_W',
-  [18] = 'KEY_E',
-  [19] = 'KEY_R',
-  [20] = 'KEY_T',
-  [21] = 'KEY_Y',
-  [22] = 'KEY_U',
-  [23] = 'KEY_I',
-  [24] = 'KEY_O',
-  [25] = 'KEY_P',
-  [26] = 'KEY_LEFTBRACE',
-  [27] = 'KEY_RIGHTBRACE',
-  [28] = 'KEY_ENTER',
-  [29] = 'KEY_LEFTCTRL',
-  [30] = 'KEY_A',
-  [31] = 'KEY_S',
-  [32] = 'KEY_D',
-  [33] = 'KEY_F',
-  [34] = 'KEY_G',
-  [35] = 'KEY_H',
-  [36] = 'KEY_J',
-  [37] = 'KEY_K',
-  [38] = 'KEY_L',
-  [39] = 'KEY_SEMICOLON',
-  [40] = 'KEY_APOSTROPHE',
-  [41] = 'KEY_GRAVE',
-  [42] = 'KEY_LEFTSHIFT',
-  [43] = 'KEY_BACKSLASH',
-  [44] = 'KEY_Z',
-  [45] = 'KEY_X',
-  [46] = 'KEY_C',
-  [47] = 'KEY_V',
-  [48] = 'KEY_B',
-  [49] = 'KEY_N',
-  [50] = 'KEY_M',
-  [51] = 'KEY_COMMA',
-  [52] = 'KEY_DOT',
-  [53] = 'KEY_SLASH',
-  [54] = 'KEY_RIGHTSHIFT',
-  [55] = 'KEY_KPASTERISK',
-  [56] = 'KEY_LEFTALT',
-  [57] = 'KEY_SPACE',
-  [58] = 'KEY_CAPSLOCK',
-  [59] = 'KEY_F1',
-  [60] = 'KEY_F2',
-  [61] = 'KEY_F3',
-  [62] = 'KEY_F4',
-  [63] = 'KEY_F5',
-  [64] = 'KEY_F6',
-  [65] = 'KEY_F7',
-  [66] = 'KEY_F8',
-  [67] = 'KEY_F9',
-  [68] = 'KEY_F10',
-  [69] = 'KEY_NUMLOCK',
-  [70] = 'KEY_SCROLLLOCK',
-  [71] = 'KEY_KP7',
-  [72] = 'KEY_KP8',
-  [73] = 'KEY_KP9',
-  [74] = 'KEY_KPMINUS',
-  [75] = 'KEY_KP4',
-  [76] = 'KEY_KP5',
-  [77] = 'KEY_KP6',
-  [78] = 'KEY_KPPLUS',
-  [79] = 'KEY_KP1',
-  [80] = 'KEY_KP2',
-  [81] = 'KEY_KP3',
-  [82] = 'KEY_KP0',
-  [83] = 'KEY_KPDOT',
-  [85] = 'KEY_ZENKAKUHANKAKU',
-  [86] = 'KEY_102ND',
-  [87] = 'KEY_F11',
-  [88] = 'KEY_F12',
-  [89] = 'KEY_RO',
-  [90] = 'KEY_KATAKANA',
-  [91] = 'KEY_HIRAGANA',
-  [92] = 'KEY_HENKAN',
-  [93] = 'KEY_KATAKANAHIRAGANA',
-  [94] = 'KEY_MUHENKAN',
-  [95] = 'KEY_KPJPCOMMA',
-  [96] = 'KEY_KPENTER',
-  [97] = 'KEY_RIGHTCTRL',
-  [98] = 'KEY_KPSLASH',
-  [99] = 'KEY_SYSRQ',
-  [100] = 'KEY_RIGHTALT',
-  [101] = 'KEY_LINEFEED',
-  [102] = 'KEY_HOME',
-  [103] = 'KEY_UP',
-  [104] = 'KEY_PAGEUP',
-  [105] = 'KEY_LEFT',
-  [106] = 'KEY_RIGHT',
-  [107] = 'KEY_END',
-  [108] = 'KEY_DOWN',
-  [109] = 'KEY_PAGEDOWN',
-  [110] = 'KEY_INSERT',
-  [111] = 'KEY_DELETE',
-  [112] = 'KEY_MACRO',
-  [113] = 'KEY_MUTE',
-  [114] = 'KEY_VOLUMEDOWN',
-  [115] = 'KEY_VOLUMEUP',
-  [116] = 'KEY_POWER',
-  [117] = 'KEY_KPEQUAL',
-  [118] = 'KEY_KPPLUSMINUS',
-  [119] = 'KEY_PAUSE',
-  [120] = 'KEY_SCALE',
-  [121] = 'KEY_KPCOMMA',
-  [122] = 'KEY_HANGEUL',
-  -- [KEY_HANGEUL] = 'KEY_HANGUEL',
-  [123] = 'KEY_HANJA',
-  [124] = 'KEY_YEN',
-  [125] = 'KEY_LEFTMETA',
-  [126] = 'KEY_RIGHTMETA',
-  [127] = 'KEY_COMPOSE',
-  [128  ] = 'KEY_STOP',
-  [129] = 'KEY_AGAIN',
-  [130] = 'KEY_PROPS',
-  [131] = 'KEY_UNDO',
-  [132] = 'KEY_FRONT',
-  [133] = 'KEY_COPY',
-  [134] = 'KEY_OPEN',
-  [135] = 'KEY_PASTE',
-  [136] = 'KEY_FIND',
-  [137] = 'KEY_CUT',
-  [138] = 'KEY_HELP',
-  [139] = 'KEY_MENU',
-  [140] = 'KEY_CALC',
-  [141] = 'KEY_SETUP',
-  [142] = 'KEY_SLEEP',
-  [143] = 'KEY_WAKEUP',
-  [144] = 'KEY_FILE',
-  [145] = 'KEY_SENDFILE',
-  [146] = 'KEY_DELETEFILE',
-  [147] = 'KEY_XFER',
-  [148] = 'KEY_PROG1',
-  [149] = 'KEY_PROG2',
-  [150] = 'KEY_WWW',
-  [151] = 'KEY_MSDOS',
-  [152] = 'KEY_COFFEE',
-  -- [KEY_COFFEE] = 'KEY_SCREENLOCK',
-  [153] = 'KEY_ROTATE_DISPLAY',
-  -- [KEY_ROTATE_DISPLAY] = 'KEY_DIRECTION',
-  [154] = 'KEY_CYCLEWINDOWS',
-  [155] = 'KEY_MAIL',
-  [156] = 'KEY_BOOKMARKS',
-  [157] = 'KEY_COMPUTER',
-  [158] = 'KEY_BACK',
-  [159] = 'KEY_FORWARD',
-  [160] = 'KEY_CLOSECD',
-  [161] = 'KEY_EJECTCD',
-  [162] = 'KEY_EJECTCLOSECD',
-  [163] = 'KEY_NEXTSONG',
-  [164] = 'KEY_PLAYPAUSE',
-  [165] = 'KEY_PREVIOUSSONG',
-  [166] = 'KEY_STOPCD',
-  [167] = 'KEY_RECORD',
-  [168] = 'KEY_REWIND',
-  [169] = 'KEY_PHONE',
-  [170] = 'KEY_ISO',
-  [171] = 'KEY_CONFIG',
-  [172] = 'KEY_HOMEPAGE',
-  [173] = 'KEY_REFRESH',
-  [174] = 'KEY_EXIT',
-  [175] = 'KEY_MOVE',
-  [176] = 'KEY_EDIT',
-  [177] = 'KEY_SCROLLUP',
-  [178] = 'KEY_SCROLLDOWN',
-  [179] = 'KEY_KPLEFTPAREN',
-  [180] = 'KEY_KPRIGHTPAREN',
-  [181] = 'KEY_NEW',
-  [182] = 'KEY_REDO',
-  [183] = 'KEY_F13',
-  [184] = 'KEY_F14',
-  [185] = 'KEY_F15',
-  [186] = 'KEY_F16',
-  [187] = 'KEY_F17',
-  [188] = 'KEY_F18',
-  [189] = 'KEY_F19',
-  [190] = 'KEY_F20',
-  [191] = 'KEY_F21',
-  [192] = 'KEY_F22',
-  [193] = 'KEY_F23',
-  [194] = 'KEY_F24',
-  [200] = 'KEY_PLAYCD',
-  [201] = 'KEY_PAUSECD',
-  [202] = 'KEY_PROG3',
-  [203] = 'KEY_PROG4',
-  [204] = 'KEY_DASHBOARD',
-  [205] = 'KEY_SUSPEND',
-  [206] = 'KEY_CLOSE',
-  [207] = 'KEY_PLAY',
-  [208] = 'KEY_FASTFORWARD',
-  [209] = 'KEY_BASSBOOST',
-  [210] = 'KEY_PRINT',
-  [211] = 'KEY_HP',
-  [212] = 'KEY_CAMERA',
-  [213] = 'KEY_SOUND',
-  [214] = 'KEY_QUESTION',
-  [215] = 'KEY_EMAIL',
-  [216] = 'KEY_CHAT',
-  [217] = 'KEY_SEARCH',
-  [218] = 'KEY_CONNECT',
-  [219] = 'KEY_FINANCE',
-  [220] = 'KEY_SPORT',
-  [221] = 'KEY_SHOP',
-  [222] = 'KEY_ALTERASE',
-  [223] = 'KEY_CANCEL',
-  [224] = 'KEY_BRIGHTNESSDOWN',
-  [225] = 'KEY_BRIGHTNESSUP',
-  [226] = 'KEY_MEDIA',
-  [227] = 'KEY_SWITCHVIDEOMODE',
-  [228] = 'KEY_KBDILLUMTOGGLE',
-  [229] = 'KEY_KBDILLUMDOWN',
-  [230] = 'KEY_KBDILLUMUP',
-  [231] = 'KEY_SEND',
-  [232] = 'KEY_REPLY',
-  [233] = 'KEY_FORWARDMAIL',
-  [234] = 'KEY_SAVE',
-  [235] = 'KEY_DOCUMENTS',
-  [236] = 'KEY_BATTERY',
-  [237] = 'KEY_BLUETOOTH',
-  [238] = 'KEY_WLAN',
-  [239] = 'KEY_UWB',
-  [240] = 'KEY_UNKNOWN',
-  [241] = 'KEY_VIDEO_NEXT',
-  [242] = 'KEY_VIDEO_PREV',
-  [243] = 'KEY_BRIGHTNESS_CYCLE',
-  [244  ] = 'KEY_BRIGHTNESS_AUTO',
-  -- [KEY_BRIGHTNESS_AUTO] = 'KEY_BRIGHTNESS_ZERO',
-  [245] = 'KEY_DISPLAY_OFF',
-  [246] = 'KEY_WWAN',
-  -- [KEY_WWAN] = 'KEY_WIMAX',
-  [247] = 'KEY_RFKILL',
-  [248] = 'KEY_MICMUTE',
-  [0x100] = 'BTN_MISC',
-  [0x100] = 'BTN_0',
-  [0x101] = 'BTN_1',
-  [0x102] = 'BTN_2',
-  [0x103] = 'BTN_3',
-  [0x104] = 'BTN_4',
-  [0x105] = 'BTN_5',
-  [0x106] = 'BTN_6',
-  [0x107] = 'BTN_7',
-  [0x108] = 'BTN_8',
-  [0x109] = 'BTN_9',
-  [0x110] = 'BTN_MOUSE',
-  [0x110] = 'BTN_LEFT',
-  [0x111] = 'BTN_RIGHT',
-  [0x112] = 'BTN_MIDDLE',
-  [0x113] = 'BTN_SIDE',
-  [0x114] = 'BTN_EXTRA',
-  [0x115] = 'BTN_FORWARD',
-  [0x116] = 'BTN_BACK',
-  [0x117] = 'BTN_TASK',
-  [0x120] = 'BTN_JOYSTICK',
-  [0x120] = 'BTN_TRIGGER',
-  [0x121] = 'BTN_THUMB',
-  [0x122] = 'BTN_THUMB2',
-  [0x123] = 'BTN_TOP',
-  [0x124] = 'BTN_TOP2',
-  [0x125] = 'BTN_PINKIE',
-  [0x126] = 'BTN_BASE',
-  [0x127] = 'BTN_BASE2',
-  [0x128] = 'BTN_BASE3',
-  [0x129] = 'BTN_BASE4',
-  [0x12a] = 'BTN_BASE5',
-  [0x12b] = 'BTN_BASE6',
-  [0x12f] = 'BTN_DEAD',
-  --[0x130] = 'BTN_GAMEPAD', -- why is this duplicated??
-  [0x130] = 'BTN_SOUTH',
-  -- FIXME: these aliases should be preserved
-  -- [BTN_SOUTH] = 'BTN_A',
-  [0x131] = 'BTN_EAST',
-  -- [BTN_EAST] = 'BTN_B',
-  [0x132] = 'BTN_C',
-  [0x133] = 'BTN_NORTH',
-  -- [BTN_NORTH] = 'BTN_X',
-  [0x134] = 'BTN_WEST',
-  -- [BTN_WEST] = 'BTN_Y',
-  [0x135] = 'BTN_Z',
-  [0x136] = 'BTN_TL',
-  [0x137] = 'BTN_TR',
-  [0x138] = 'BTN_TL2',
-  [0x139] = 'BTN_TR2',
-  [0x13a] = 'BTN_SELECT',
-  [0x13b] = 'BTN_START',
-  [0x13c] = 'BTN_MODE',
-  [0x13d] = 'BTN_THUMBL',
-  [0x13e] = 'BTN_THUMBR',
-  [0x140] = 'BTN_DIGI',
-  [0x140] = 'BTN_TOOL_PEN',
-  [0x141] = 'BTN_TOOL_RUBBER',
-  [0x142] = 'BTN_TOOL_BRUSH',
-  [0x143] = 'BTN_TOOL_PENCIL',
-  [0x144] = 'BTN_TOOL_AIRBRUSH',
-  [0x145] = 'BTN_TOOL_FINGER',
-  [0x146] = 'BTN_TOOL_MOUSE',
-  [0x147] = 'BTN_TOOL_LENS',
-  [0x148] = 'BTN_TOOL_QUINTTAP',
-  [0x14a] = 'BTN_TOUCH',
-  [0x14b] = 'BTN_STYLUS',
-  [0x14c] = 'BTN_STYLUS2',
-  [0x14d] = 'BTN_TOOL_DOUBLETAP',
-  [0x14e] = 'BTN_TOOL_TRIPLETAP',
-  [0x14f] = 'BTN_TOOL_QUADTAP',
-  [0x150] = 'BTN_WHEEL',
-  [0x150] = 'BTN_GEAR_DOWN',
-  [0x151] = 'BTN_GEAR_UP',
-  [0x160] = 'KEY_OK',
-  [0x161] = 'KEY_SELECT',
-  [0x162] = 'KEY_GOTO',
-  [0x163] = 'KEY_CLEAR',
-  [0x164] = 'KEY_POWER2',
-  [0x165] = 'KEY_OPTION',
-  [0x166] = 'KEY_INFO',
-  [0x167] = 'KEY_TIME',
-  [0x168] = 'KEY_VENDOR',
-  [0x169] = 'KEY_ARCHIVE',
-  [0x16a] = 'KEY_PROGRAM',
-  [0x16b] = 'KEY_CHANNEL',
-  [0x16c] = 'KEY_FAVORITES',
-  [0x16d] = 'KEY_EPG',
-  [0x16e] = 'KEY_PVR',
-  [0x16f] = 'KEY_MHP',
-  [0x170] = 'KEY_LANGUAGE',
-  [0x171] = 'KEY_TITLE',
-  [0x172] = 'KEY_SUBTITLE',
-  [0x173] = 'KEY_ANGLE',
-  [0x174] = 'KEY_ZOOM',
-  [0x175] = 'KEY_MODE',
-  [0x176] = 'KEY_KEYBOARD',
-  [0x177] = 'KEY_SCREEN',
-  [0x178] = 'KEY_PC',
-  [0x179] = 'KEY_TV',
-  [0x17a] = 'KEY_TV2',
-  [0x17b] = 'KEY_VCR',
-  [0x17c] = 'KEY_VCR2',
-  [0x17d] = 'KEY_SAT',
-  [0x17e] = 'KEY_SAT2',
-  [0x17f] = 'KEY_CD',
-  [0x180] = 'KEY_TAPE',
-  [0x181] = 'KEY_RADIO',
-  [0x182] = 'KEY_TUNER',
-  [0x183] = 'KEY_PLAYER',
-  [0x184] = 'KEY_TEXT',
-  [0x185] = 'KEY_DVD',
-  [0x186] = 'KEY_AUX',
-  [0x187] = 'KEY_MP3',
-  [0x188] = 'KEY_AUDIO',
-  [0x189] = 'KEY_VIDEO',
-  [0x18a] = 'KEY_DIRECTORY',
-  [0x18b] = 'KEY_LIST',
-  [0x18c] = 'KEY_MEMO',
-  [0x18d] = 'KEY_CALENDAR',
-  [0x18e] = 'KEY_RED',
-  [0x18f] = 'KEY_GREEN',
-  [0x190] = 'KEY_YELLOW',
-  [0x191] = 'KEY_BLUE',
-  [0x192] = 'KEY_CHANNELUP',
-  [0x193] = 'KEY_CHANNELDOWN',
-  [0x194] = 'KEY_FIRST',
-  [0x195] = 'KEY_LAST',
-  [0x196] = 'KEY_AB',
-  [0x197] = 'KEY_NEXT',
-  [0x198] = 'KEY_RESTART',
-  [0x199] = 'KEY_SLOW',
-  [0x19a] = 'KEY_SHUFFLE',
-  [0x19b] = 'KEY_BREAK',
-  [0x19c] = 'KEY_PREVIOUS',
-  [0x19d] = 'KEY_DIGITS',
-  [0x19e] = 'KEY_TEEN',
-  [0x19f] = 'KEY_TWEN',
-  [0x1a0] = 'KEY_VIDEOPHONE',
-  [0x1a1] = 'KEY_GAMES',
-  [0x1a2] = 'KEY_ZOOMIN',
-  [0x1a3] = 'KEY_ZOOMOUT',
-  [0x1a4] = 'KEY_ZOOMRESET',
-  [0x1a5] = 'KEY_WORDPROCESSOR',
-  [0x1a6] = 'KEY_EDITOR',
-  [0x1a7] = 'KEY_SPREADSHEET',
-  [0x1a8] = 'KEY_GRAPHICSEDITOR',
-  [0x1a9] = 'KEY_PRESENTATION',
-  [0x1aa] = 'KEY_DATABASE',
-  [0x1ab] = 'KEY_NEWS',
-  [0x1ac] = 'KEY_VOICEMAIL',
-  [0x1ad] = 'KEY_ADDRESSBOOK',
-  [0x1ae] = 'KEY_MESSENGER',
-  [0x1af] = 'KEY_DISPLAYTOGGLE',
-  -- [KEY_DISPLAYTOGGLE] = 'KEY_BRIGHTNESS_TOGGLE',
-  [0x1b0] = 'KEY_SPELLCHECK',
-  [0x1b1] = 'KEY_LOGOFF',
-  [0x1b2] = 'KEY_DOLLAR',
-  [0x1b3] = 'KEY_EURO',
-  [0x1b4] = 'KEY_FRAMEBACK',
-  [0x1b5] = 'KEY_FRAMEFORWARD',
-  [0x1b6] = 'KEY_CONTEXT_MENU',
-  [0x1b7] = 'KEY_MEDIA_REPEAT',
-  [0x1b8] = 'KEY_10CHANNELSUP',
-  [0x1b9] = 'KEY_10CHANNELSDOWN',
-  [0x1ba] = 'KEY_IMAGES',
-  [0x1c0] = 'KEY_DEL_EOL',
-  [0x1c1] = 'KEY_DEL_EOS',
-  [0x1c2] = 'KEY_INS_LINE',
-  [0x1c3] = 'KEY_DEL_LINE',
-  [0x1d0] = 'KEY_FN',
-  [0x1d1] = 'KEY_FN_ESC',
-  [0x1d2] = 'KEY_FN_F1',
-  [0x1d3] = 'KEY_FN_F2',
-  [0x1d4] = 'KEY_FN_F3',
-  [0x1d5] = 'KEY_FN_F4',
-  [0x1d6] = 'KEY_FN_F5',
-  [0x1d7] = 'KEY_FN_F6',
-  [0x1d8] = 'KEY_FN_F7',
-  [0x1d9] = 'KEY_FN_F8',
-  [0x1da] = 'KEY_FN_F9',
-  [0x1db] = 'KEY_FN_F10',
-  [0x1dc] = 'KEY_FN_F11',
-  [0x1dd] = 'KEY_FN_F12',
-  [0x1de] = 'KEY_FN_1',
-  [0x1df] = 'KEY_FN_2',
-  [0x1e0] = 'KEY_FN_D',
-  [0x1e1] = 'KEY_FN_E',
-  [0x1e2] = 'KEY_FN_F',
-  [0x1e3] = 'KEY_FN_S',
-  [0x1e4] = 'KEY_FN_B',
-  [0x1f1] = 'KEY_BRL_DOT1',
-  [0x1f2] = 'KEY_BRL_DOT2',
-  [0x1f3] = 'KEY_BRL_DOT3',
-  [0x1f4] = 'KEY_BRL_DOT4',
-  [0x1f5] = 'KEY_BRL_DOT5',
-  [0x1f6] = 'KEY_BRL_DOT6',
-  [0x1f7] = 'KEY_BRL_DOT7',
-  [0x1f8] = 'KEY_BRL_DOT8',
-  [0x1f9] = 'KEY_BRL_DOT9',
-  [0x1fa] = 'KEY_BRL_DOT10',
-  [0x200] = 'KEY_NUMERIC_0',
-  [0x201] = 'KEY_NUMERIC_1',
-  [0x202] = 'KEY_NUMERIC_2',
-  [0x203] = 'KEY_NUMERIC_3',
-  [0x204] = 'KEY_NUMERIC_4',
-  [0x205] = 'KEY_NUMERIC_5',
-  [0x206] = 'KEY_NUMERIC_6',
-  [0x207] = 'KEY_NUMERIC_7',
-  [0x208] = 'KEY_NUMERIC_8',
-  [0x209] = 'KEY_NUMERIC_9',
-  [0x20a] = 'KEY_NUMERIC_STAR',
-  [0x20b] = 'KEY_NUMERIC_POUND',
-  [0x20c] = 'KEY_NUMERIC_A',
-  [0x20d] = 'KEY_NUMERIC_B',
-  [0x20e] = 'KEY_NUMERIC_C',
-  [0x20f] = 'KEY_NUMERIC_D',
-  [0x210] = 'KEY_CAMERA_FOCUS',
-  [0x211] = 'KEY_WPS_BUTTON',
-  [0x212] = 'KEY_TOUCHPAD_TOGGLE',
-  [0x213] = 'KEY_TOUCHPAD_ON',
-  [0x214] = 'KEY_TOUCHPAD_OFF',
-  [0x215] = 'KEY_CAMERA_ZOOMIN',
-  [0x216] = 'KEY_CAMERA_ZOOMOUT',
-  [0x217] = 'KEY_CAMERA_UP',
-  [0x218] = 'KEY_CAMERA_DOWN',
-  [0x219] = 'KEY_CAMERA_LEFT',
-  [0x21a] = 'KEY_CAMERA_RIGHT',
-  [0x21b] = 'KEY_ATTENDANT_ON',
-  [0x21c] = 'KEY_ATTENDANT_OFF',
-  [0x21d] = 'KEY_ATTENDANT_TOGGLE',
-  [0x21e] = 'KEY_LIGHTS_TOGGLE',
-  [0x220] = 'BTN_DPAD_UP',
-  [0x221] = 'BTN_DPAD_DOWN',
-  [0x222] = 'BTN_DPAD_LEFT',
-  [0x223] = 'BTN_DPAD_RIGHT',
-  [0x230] = 'KEY_ALS_TOGGLE',
-  [0x240] = 'KEY_BUTTONCONFIG',
-  [0x241] = 'KEY_TASKMANAGER',
-  [0x242] = 'KEY_JOURNAL',
-  [0x243] = 'KEY_CONTROLPANEL',
-  [0x244] = 'KEY_APPSELECT',
-  [0x245] = 'KEY_SCREENSAVER',
-  [0x246] = 'KEY_VOICECOMMAND',
-  [0x250] = 'KEY_BRIGHTNESS_MIN',
-  [0x251] = 'KEY_BRIGHTNESS_MAX',
-  [0x260] = 'KEY_KBDINPUTASSIST_PREV',
-  [0x261] = 'KEY_KBDINPUTASSIST_NEXT',
-  [0x262] = 'KEY_KBDINPUTASSIST_PREVGROUP',
-  [0x263] = 'KEY_KBDINPUTASSIST_NEXTGROUP',
-  [0x264] = 'KEY_KBDINPUTASSIST_ACCEPT',
-  [0x265] = 'KEY_KBDINPUTASSIST_CANCEL',
-  [0x266] = 'KEY_RIGHT_UP',
-  [0x267] = 'KEY_RIGHT_DOWN',
-  [0x268] = 'KEY_LEFT_UP',
-  [0x269] = 'KEY_LEFT_DOWN',
-  [0x26a] = 'KEY_ROOT_MENU',
-  [0x26b] = 'KEY_MEDIA_TOP_MENU',
-  [0x26c] = 'KEY_NUMERIC_11',
-  [0x26d] = 'KEY_NUMERIC_12',
-  [0x26e] = 'KEY_AUDIO_DESC',
-  [0x26f] = 'KEY_3D_MODE',
-  [0x270] = 'KEY_NEXT_FAVORITE',
-  [0x271] = 'KEY_STOP_RECORD',
-  [0x272] = 'KEY_PAUSE_RECORD',
-  [0x273] = 'KEY_VOD',
-  [0x274] = 'KEY_UNMUTE',
-  [0x275] = 'KEY_FASTREVERSE',
-  [0x276] = 'KEY_SLOWREVERSE',
-  [0x277] = 'KEY_DATA',
-  [0x2c0] = 'BTN_TRIGGER_HAPPY',
-  [0x2c0] = 'BTN_TRIGGER_HAPPY1',
-  [0x2c1] = 'BTN_TRIGGER_HAPPY2',
-  [0x2c2] = 'BTN_TRIGGER_HAPPY3',
-  [0x2c3] = 'BTN_TRIGGER_HAPPY4',
-  [0x2c4] = 'BTN_TRIGGER_HAPPY5',
-  [0x2c5] = 'BTN_TRIGGER_HAPPY6',
-  [0x2c6] = 'BTN_TRIGGER_HAPPY7',
-  [0x2c7] = 'BTN_TRIGGER_HAPPY8',
-  [0x2c8] = 'BTN_TRIGGER_HAPPY9',
-  [0x2c9] = 'BTN_TRIGGER_HAPPY10',
-  [0x2ca] = 'BTN_TRIGGER_HAPPY11',
-  [0x2cb] = 'BTN_TRIGGER_HAPPY12',
-  [0x2cc] = 'BTN_TRIGGER_HAPPY13',
-  [0x2cd] = 'BTN_TRIGGER_HAPPY14',
-  [0x2ce] = 'BTN_TRIGGER_HAPPY15',
-  [0x2cf] = 'BTN_TRIGGER_HAPPY16',
-  [0x2d0] = 'BTN_TRIGGER_HAPPY17',
-  [0x2d1] = 'BTN_TRIGGER_HAPPY18',
-  [0x2d2] = 'BTN_TRIGGER_HAPPY19',
-  [0x2d3] = 'BTN_TRIGGER_HAPPY20',
-  [0x2d4] = 'BTN_TRIGGER_HAPPY21',
-  [0x2d5] = 'BTN_TRIGGER_HAPPY22',
-  [0x2d6] = 'BTN_TRIGGER_HAPPY23',
-  [0x2d7] = 'BTN_TRIGGER_HAPPY24',
-  [0x2d8] = 'BTN_TRIGGER_HAPPY25',
-  [0x2d9] = 'BTN_TRIGGER_HAPPY26',
-  [0x2da] = 'BTN_TRIGGER_HAPPY27',
-  [0x2db] = 'BTN_TRIGGER_HAPPY28',
-  [0x2dc] = 'BTN_TRIGGER_HAPPY29',
-  [0x2dd] = 'BTN_TRIGGER_HAPPY30',
-  [0x2de] = 'BTN_TRIGGER_HAPPY31',
-  [0x2df] = 'BTN_TRIGGER_HAPPY32',
-  [0x2e0] = 'BTN_TRIGGER_HAPPY33',
-  [0x2e1] = 'BTN_TRIGGER_HAPPY34',
-  [0x2e2] = 'BTN_TRIGGER_HAPPY35',
-  [0x2e3] = 'BTN_TRIGGER_HAPPY36',
-  [0x2e4] = 'BTN_TRIGGER_HAPPY37',
-  [0x2e5] = 'BTN_TRIGGER_HAPPY38',
-  [0x2e6] = 'BTN_TRIGGER_HAPPY39',
-  [0x2e7] = 'BTN_TRIGGER_HAPPY40',
-  -- [KEY_MUTE] = 'KEY_MIN_INTERESTING',
-  [0x2ff] = 'KEY_MAX',
-}
-
-
-Hid.event_codes[Hid.event_types_rev['EV_REL']] = {
-  [0x00] = 'REL_X',
-  [0x01] = 'REL_Y',
-  [0x02] = 'REL_Z',
-  [0x03] = 'REL_RX',
-  [0x04] = 'REL_RY',
-  [0x05] = 'REL_RZ',
-  [0x06] = 'REL_HWHEEL',
-  [0x07] = 'REL_DIAL',
-  [0x08] = 'REL_WHEEL',
-  [0x09] = 'REL_MISC',
-  [0x0f] = 'REL_MAX',
-}
-
-Hid.event_codes[Hid.event_types_rev['EV_ABS']] = {
-  [0x00] = 'ABS_X',
-  [0x01] = 'ABS_Y',
-  [0x02] = 'ABS_Z',
-  [0x03] = 'ABS_RX',
-  [0x04] = 'ABS_RY',
-  [0x05] = 'ABS_RZ',
-  [0x06] = 'ABS_THROTTLE',
-  [0x07] = 'ABS_RUDDER',
-  [0x08] = 'ABS_WHEEL',
-  [0x09] = 'ABS_GAS',
-  [0x0a] = 'ABS_BRAKE',
-  [0x10] = 'ABS_HAT0X',
-  [0x11] = 'ABS_HAT0Y',
-  [0x12] = 'ABS_HAT1X',
-  [0x13] = 'ABS_HAT1Y',
-  [0x14] = 'ABS_HAT2X',
-  [0x15] = 'ABS_HAT2Y',
-  [0x16] = 'ABS_HAT3X',
-  [0x17] = 'ABS_HAT3Y',
-  [0x18] = 'ABS_PRESSURE',
-  [0x19] = 'ABS_DISTANCE',
-  [0x1a] = 'ABS_TILT_X',
-  [0x1b] = 'ABS_TILT_Y',
-  [0x1c] = 'ABS_TOOL_WIDTH',
-  [0x20] = 'ABS_VOLUME',
-  [0x28] = 'ABS_MISC',
-  [0x2f] = 'ABS_MT_SLOT',
-  [0x30] = 'ABS_MT_TOUCH_MAJOR',
-  [0x31] = 'ABS_MT_TOUCH_MINOR',
-  [0x32] = 'ABS_MT_WIDTH_MAJOR',
-  [0x33] = 'ABS_MT_WIDTH_MINOR',
-  [0x34] = 'ABS_MT_ORIENTATION',
-  [0x35] = 'ABS_MT_POSITION_X',
-  [0x36] = 'ABS_MT_POSITION_Y',
-  [0x37] = 'ABS_MT_TOOL_TYPE',
-  [0x38] = 'ABS_MT_BLOB_ID',
-  [0x39] = 'ABS_MT_TRACKING_ID',
-  [0x3a] = 'ABS_MT_PRESSURE',
-  [0x3b] = 'ABS_MT_DISTANCE',
-  [0x3c] = 'ABS_MT_TOOL_X',
-  [0x3d] = 'ABS_MT_TOOL_Y',
-  [0x3f] = 'ABS_MAX',
-}
-
-Hid.event_codes[Hid.event_types_rev['EV_SW']] = {
-  [0x00] = 'SW_LID',
-  [0x01] = 'SW_TABLET_MODE',
-  [0x02] = 'SW_HEADPHONE_INSERT',
-  [0x03] = 'SW_RFKILL_ALL',
-  --[SW_RFKILL_ALL] = 'SW_RADIO',
-  [0x04] = 'SW_MICROPHONE_INSERT',
-  [0x05] = 'SW_DOCK',
-  [0x06] = 'SW_LINEOUT_INSERT',
-  [0x07] = 'SW_JACK_PHYSICAL_INSERT',
-  [0x08] = 'SW_VIDEOOUT_INSERT',
-  [0x09] = 'SW_CAMERA_LENS_COVER',
-  [0x0a] = 'SW_KEYPAD_SLIDE',
-  [0x0b] = 'SW_FRONT_PROXIMITY',
-  [0x0c] = 'SW_ROTATE_LOCK',
-  [0x0d] = 'SW_LINEIN_INSERT',
-  [0x0e] = 'SW_MUTE_DEVICE',
-  [0x0f] = 'SW_PEN_INSERTED',
-  [0x0f] = 'SW_MAX',
-}
-
-Hid.event_codes[Hid.event_types_rev['EV_LED']] = {
-  [0x00] = 'LED_NUML',
-  [0x01] = 'LED_CAPSL',
-  [0x02] = 'LED_SCROLLL',
-  [0x03] = 'LED_COMPOSE',
-  [0x04] = 'LED_KANA',
-  [0x05] = 'LED_SLEEP',
-  [0x06] = 'LED_SUSPEND',
-  [0x07] = 'LED_MUTE',
-  [0x08] = 'LED_MISC',
-  [0x09] = 'LED_MAIL',
-  [0x0a] = 'LED_CHARGING',
-  [0x0f] = 'LED_MAX',
-}
-
-Hid.event_codes_rev = {}
-for t,tname in pairs(Hid.event_types) do
-  Hid.event_codes_rev[tname] = {}
-  -- print(tname)
-  for c,cname in pairs(Hid.event_codes[t]) do
-    -- print(c, cname)
-    Hid.event_codes_rev[tname][cname] = c
+    if device.port then
+      if Hid.vports[device.port].event then
+        Hid.vports[device.port].event(id, type, code, value)
+      end
+    end
+  else
+    error('no entry for hid '..id)
   end
 end
 

--- a/lua/core/hid_events.lua
+++ b/lua/core/hid_events.lua
@@ -1,0 +1,751 @@
+local hid_events = {}
+
+-- Event types
+
+hid_events.types = {}
+
+hid_events.types.EV_SYN = 0x00
+hid_events.types.EV_KEY = 0x01
+hid_events.types.EV_REL = 0x02
+hid_events.types.EV_ABS = 0x03
+hid_events.types.EV_MSC = 0x04
+hid_events.types.EV_SW = 0x05
+hid_events.types.EV_LED = 0x11
+hid_events.types.EV_SND = 0x12
+hid_events.types.EV_REP = 0x14
+hid_events.types.EV_FF = 0x15
+hid_events.types.EV_PWR = 0x16
+hid_events.types.EV_FF_STATUS = 0x17
+
+-- Input event codes
+
+hid_events.codes = {}
+
+-- Synchronization events.
+
+hid_events.codes.SYN_REPORT = 0
+hid_events.codes.SYN_CONFIG = 1
+hid_events.codes.SYN_MT_REPORT = 2
+hid_events.codes.SYN_DROPPED = 3
+
+-- Keys and buttons
+
+hid_events.codes.KEY_RESERVED = 0
+hid_events.codes.KEY_ESC = 1
+hid_events.codes.KEY_1 = 2
+hid_events.codes.KEY_2 = 3
+hid_events.codes.KEY_3 = 4
+hid_events.codes.KEY_4 = 5
+hid_events.codes.KEY_5 = 6
+hid_events.codes.KEY_6 = 7
+hid_events.codes.KEY_7 = 8
+hid_events.codes.KEY_8 = 9
+hid_events.codes.KEY_9 = 10
+hid_events.codes.KEY_0 = 11
+hid_events.codes.KEY_MINUS = 12
+hid_events.codes.KEY_EQUAL = 13
+hid_events.codes.KEY_BACKSPACE = 14
+hid_events.codes.KEY_TAB = 15
+hid_events.codes.KEY_Q = 16
+hid_events.codes.KEY_W = 17
+hid_events.codes.KEY_E = 18
+hid_events.codes.KEY_R = 19
+hid_events.codes.KEY_T = 20
+hid_events.codes.KEY_Y = 21
+hid_events.codes.KEY_U = 22
+hid_events.codes.KEY_I = 23
+hid_events.codes.KEY_O = 24
+hid_events.codes.KEY_P = 25
+hid_events.codes.KEY_LEFTBRACE = 26
+hid_events.codes.KEY_RIGHTBRACE = 27
+hid_events.codes.KEY_ENTER = 28
+hid_events.codes.KEY_LEFTCTRL = 29
+hid_events.codes.KEY_A = 30
+hid_events.codes.KEY_S = 31
+hid_events.codes.KEY_D = 32
+hid_events.codes.KEY_F = 33
+hid_events.codes.KEY_G = 34
+hid_events.codes.KEY_H = 35
+hid_events.codes.KEY_J = 36
+hid_events.codes.KEY_K = 37
+hid_events.codes.KEY_L = 38
+hid_events.codes.KEY_SEMICOLON = 39
+hid_events.codes.KEY_APOSTROPHE = 40
+hid_events.codes.KEY_GRAVE = 41
+hid_events.codes.KEY_LEFTSHIFT = 42
+hid_events.codes.KEY_BACKSLASH = 43
+hid_events.codes.KEY_Z = 44
+hid_events.codes.KEY_X = 45
+hid_events.codes.KEY_C = 46
+hid_events.codes.KEY_V = 47
+hid_events.codes.KEY_B = 48
+hid_events.codes.KEY_N = 49
+hid_events.codes.KEY_M = 50
+hid_events.codes.KEY_COMMA = 51
+hid_events.codes.KEY_DOT = 52
+hid_events.codes.KEY_SLASH = 53
+hid_events.codes.KEY_RIGHTSHIFT = 54
+hid_events.codes.KEY_KPASTERISK = 55
+hid_events.codes.KEY_LEFTALT = 56
+hid_events.codes.KEY_SPACE = 57
+hid_events.codes.KEY_CAPSLOCK = 58
+hid_events.codes.KEY_F1 = 59
+hid_events.codes.KEY_F2 = 60
+hid_events.codes.KEY_F3 = 61
+hid_events.codes.KEY_F4 = 62
+hid_events.codes.KEY_F5 = 63
+hid_events.codes.KEY_F6 = 64
+hid_events.codes.KEY_F7 = 65
+hid_events.codes.KEY_F8 = 66
+hid_events.codes.KEY_F9 = 67
+hid_events.codes.KEY_F10 = 68
+hid_events.codes.KEY_NUMLOCK = 69
+hid_events.codes.KEY_SCROLLLOCK = 70
+hid_events.codes.KEY_KP7 = 71
+hid_events.codes.KEY_KP8 = 72
+hid_events.codes.KEY_KP9 = 73
+hid_events.codes.KEY_KPMINUS = 74
+hid_events.codes.KEY_KP4 = 75
+hid_events.codes.KEY_KP5 = 76
+hid_events.codes.KEY_KP6 = 77
+hid_events.codes.KEY_KPPLUS = 78
+hid_events.codes.KEY_KP1 = 79
+hid_events.codes.KEY_KP2 = 80
+hid_events.codes.KEY_KP3 = 81
+hid_events.codes.KEY_KP0 = 82
+hid_events.codes.KEY_KPDOT = 83
+
+hid_events.codes.KEY_ZENKAKUHANKAKU = 85
+hid_events.codes.KEY_102ND = 86
+hid_events.codes.KEY_F11 = 87
+hid_events.codes.KEY_F12 = 88
+hid_events.codes.KEY_RO = 89
+hid_events.codes.KEY_KATAKANA = 90
+hid_events.codes.KEY_HIRAGANA = 91
+hid_events.codes.KEY_HENKAN = 92
+hid_events.codes.KEY_KATAKANAHIRAGANA = 93
+hid_events.codes.KEY_MUHENKAN = 94
+hid_events.codes.KEY_KPJPCOMMA = 95
+hid_events.codes.KEY_KPENTER = 96
+hid_events.codes.KEY_RIGHTCTRL = 97
+hid_events.codes.KEY_KPSLASH = 98
+hid_events.codes.KEY_SYSRQ = 99
+hid_events.codes.KEY_RIGHTALT = 100
+hid_events.codes.KEY_LINEFEED = 101
+hid_events.codes.KEY_HOME = 102
+hid_events.codes.KEY_UP = 103
+hid_events.codes.KEY_PAGEUP = 104
+hid_events.codes.KEY_LEFT = 105
+hid_events.codes.KEY_RIGHT = 106
+hid_events.codes.KEY_END = 107
+hid_events.codes.KEY_DOWN = 108
+hid_events.codes.KEY_PAGEDOWN = 109
+hid_events.codes.KEY_INSERT = 110
+hid_events.codes.KEY_DELETE = 111
+hid_events.codes.KEY_MACRO = 112
+hid_events.codes.KEY_MUTE = 113
+hid_events.codes.KEY_VOLUMEDOWN = 114
+hid_events.codes.KEY_VOLUMEUP = 115
+hid_events.codes.KEY_POWER = 116
+hid_events.codes.KEY_KPEQUAL = 117
+hid_events.codes.KEY_KPPLUSMINUS = 118
+hid_events.codes.KEY_PAUSE = 119
+hid_events.codes.KEY_SCALE = 120
+
+hid_events.codes.KEY_KPCOMMA = 121
+hid_events.codes.KEY_HANGEUL = 122
+hid_events.codes.KEY_HANGUEL = hid_events.codes.KEY_HANGEUL
+hid_events.codes.KEY_HANJA = 123
+hid_events.codes.KEY_YEN = 124
+hid_events.codes.KEY_LEFTMETA = 125
+hid_events.codes.KEY_RIGHTMETA = 126
+hid_events.codes.KEY_COMPOSE = 127
+
+hid_events.codes.KEY_STOP = 128
+hid_events.codes.KEY_AGAIN = 129
+hid_events.codes.KEY_PROPS = 130
+hid_events.codes.KEY_UNDO = 131
+hid_events.codes.KEY_FRONT = 132
+hid_events.codes.KEY_COPY = 133
+hid_events.codes.KEY_OPEN = 134
+hid_events.codes.KEY_PASTE = 135
+hid_events.codes.KEY_FIND = 136
+hid_events.codes.KEY_CUT = 137
+hid_events.codes.KEY_HELP = 138
+hid_events.codes.KEY_MENU = 139
+hid_events.codes.KEY_CALC = 140
+hid_events.codes.KEY_SETUP = 141
+hid_events.codes.KEY_SLEEP = 142
+hid_events.codes.KEY_WAKEUP = 143
+hid_events.codes.KEY_FILE = 144
+hid_events.codes.KEY_SENDFILE = 145
+hid_events.codes.KEY_DELETEFILE = 146
+hid_events.codes.KEY_XFER = 147
+hid_events.codes.KEY_PROG1 = 148
+hid_events.codes.KEY_PROG2 = 149
+hid_events.codes.KEY_WWW = 150
+hid_events.codes.KEY_MSDOS = 151
+hid_events.codes.KEY_COFFEE = 152
+hid_events.codes.KEY_SCREENLOCK = hid_events.codes.KEY_COFFEE
+hid_events.codes.KEY_ROTATE_DISPLAY = 153
+hid_events.codes.KEY_DIRECTION = hid_events.codes.KEY_ROTATE_DISPLAY
+hid_events.codes.KEY_CYCLEWINDOWS = 154
+hid_events.codes.KEY_MAIL = 155
+hid_events.codes.KEY_BOOKMARKS = 156
+hid_events.codes.KEY_COMPUTER = 157
+hid_events.codes.KEY_BACK = 158
+hid_events.codes.KEY_FORWARD = 159
+hid_events.codes.KEY_CLOSECD = 160
+hid_events.codes.KEY_EJECTCD = 161
+hid_events.codes.KEY_EJECTCLOSECD = 162
+hid_events.codes.KEY_NEXTSONG = 163
+hid_events.codes.KEY_PLAYPAUSE = 164
+hid_events.codes.KEY_PREVIOUSSONG = 165
+hid_events.codes.KEY_STOPCD = 166
+hid_events.codes.KEY_RECORD = 167
+hid_events.codes.KEY_REWIND = 168
+hid_events.codes.KEY_PHONE = 169
+hid_events.codes.KEY_ISO = 170
+hid_events.codes.KEY_CONFIG = 171
+hid_events.codes.KEY_HOMEPAGE = 172
+hid_events.codes.KEY_REFRESH = 173
+hid_events.codes.KEY_EXIT = 174
+hid_events.codes.KEY_MOVE = 175
+hid_events.codes.KEY_EDIT = 176
+hid_events.codes.KEY_SCROLLUP = 177
+hid_events.codes.KEY_SCROLLDOWN = 178
+hid_events.codes.KEY_KPLEFTPAREN = 179
+hid_events.codes.KEY_KPRIGHTPAREN = 180
+hid_events.codes.KEY_NEW = 181
+hid_events.codes.KEY_REDO = 182
+
+hid_events.codes.KEY_F13 = 183
+hid_events.codes.KEY_F14 = 184
+hid_events.codes.KEY_F15 = 185
+hid_events.codes.KEY_F16 = 186
+hid_events.codes.KEY_F17 = 187
+hid_events.codes.KEY_F18 = 188
+hid_events.codes.KEY_F19 = 189
+hid_events.codes.KEY_F20 = 190
+hid_events.codes.KEY_F21 = 191
+hid_events.codes.KEY_F22 = 192
+hid_events.codes.KEY_F23 = 193
+hid_events.codes.KEY_F24 = 194
+
+hid_events.codes.KEY_PLAYCD = 200
+hid_events.codes.KEY_PAUSECD = 201
+hid_events.codes.KEY_PROG3 = 202
+hid_events.codes.KEY_PROG4 = 203
+hid_events.codes.KEY_DASHBOARD = 204
+hid_events.codes.KEY_SUSPEND = 205
+hid_events.codes.KEY_CLOSE = 206
+hid_events.codes.KEY_PLAY = 207
+hid_events.codes.KEY_FASTFORWARD = 208
+hid_events.codes.KEY_BASSBOOST = 209
+hid_events.codes.KEY_PRINT = 210
+hid_events.codes.KEY_HP = 211
+hid_events.codes.KEY_CAMERA = 212
+hid_events.codes.KEY_SOUND = 213
+hid_events.codes.KEY_QUESTION = 214
+hid_events.codes.KEY_EMAIL = 215
+hid_events.codes.KEY_CHAT = 216
+hid_events.codes.KEY_SEARCH = 217
+hid_events.codes.KEY_CONNECT = 218
+hid_events.codes.KEY_FINANCE = 219
+hid_events.codes.KEY_SPORT = 220
+hid_events.codes.KEY_SHOP = 221
+hid_events.codes.KEY_ALTERASE = 222
+hid_events.codes.KEY_CANCEL = 223
+hid_events.codes.KEY_BRIGHTNESSDOWN = 224
+hid_events.codes.KEY_BRIGHTNESSUP = 225
+hid_events.codes.KEY_MEDIA = 226
+
+hid_events.codes.KEY_SWITCHVIDEOMODE = 227
+hid_events.codes.KEY_KBDILLUMTOGGLE = 228
+hid_events.codes.KEY_KBDILLUMDOWN = 229
+hid_events.codes.KEY_KBDILLUMUP = 230
+
+hid_events.codes.KEY_SEND = 231
+hid_events.codes.KEY_REPLY = 232
+hid_events.codes.KEY_FORWARDMAIL = 233
+hid_events.codes.KEY_SAVE = 234
+hid_events.codes.KEY_DOCUMENTS = 235
+
+hid_events.codes.KEY_BATTERY = 236
+
+hid_events.codes.KEY_BLUETOOTH = 237
+hid_events.codes.KEY_WLAN = 238
+hid_events.codes.KEY_UWB = 239
+
+hid_events.codes.KEY_UNKNOWN = 240
+
+hid_events.codes.KEY_VIDEO_NEXT = 241
+hid_events.codes.KEY_VIDEO_PREV = 242
+hid_events.codes.KEY_BRIGHTNESS_CYCLE = 243
+hid_events.codes.KEY_BRIGHTNESS_AUTO = 244
+hid_events.codes.KEY_BRIGHTNESS_ZERO = hid_events.codes.KEY_BRIGHTNESS_AUTO
+hid_events.codes.KEY_DISPLAY_OFF = 245
+
+hid_events.codes.KEY_WWAN = 246
+hid_events.codes.KEY_WIMAX = hid_events.codes.KEY_WWAN
+hid_events.codes.KEY_RFKILL = 247
+
+hid_events.codes.KEY_MICMUTE = 248
+
+hid_events.codes.BTN_MISC = 0x100
+hid_events.codes.BTN_0 = 0x100
+hid_events.codes.BTN_1 = 0x101
+hid_events.codes.BTN_2 = 0x102
+hid_events.codes.BTN_3 = 0x103
+hid_events.codes.BTN_4 = 0x104
+hid_events.codes.BTN_5 = 0x105
+hid_events.codes.BTN_6 = 0x106
+hid_events.codes.BTN_7 = 0x107
+hid_events.codes.BTN_8 = 0x108
+hid_events.codes.BTN_9 = 0x109
+
+hid_events.codes.BTN_MOUSE = 0x110
+hid_events.codes.BTN_LEFT = 0x110
+hid_events.codes.BTN_RIGHT = 0x111
+hid_events.codes.BTN_MIDDLE = 0x112
+hid_events.codes.BTN_SIDE = 0x113
+hid_events.codes.BTN_EXTRA = 0x114
+hid_events.codes.BTN_FORWARD = 0x115
+hid_events.codes.BTN_BACK = 0x116
+hid_events.codes.BTN_TASK = 0x117
+
+hid_events.codes.BTN_JOYSTICK = 0x120
+hid_events.codes.BTN_TRIGGER = 0x120
+hid_events.codes.BTN_THUMB = 0x121
+hid_events.codes.BTN_THUMB2 = 0x122
+hid_events.codes.BTN_TOP = 0x123
+hid_events.codes.BTN_TOP2 = 0x124
+hid_events.codes.BTN_PINKIE = 0x125
+hid_events.codes.BTN_BASE = 0x126
+hid_events.codes.BTN_BASE2 = 0x127
+hid_events.codes.BTN_BASE3 = 0x128
+hid_events.codes.BTN_BASE4 = 0x129
+hid_events.codes.BTN_BASE5 = 0x12a
+hid_events.codes.BTN_BASE6 = 0x12b
+hid_events.codes.BTN_DEAD = 0x12f
+
+hid_events.codes.BTN_GAMEPAD = 0x130
+hid_events.codes.BTN_SOUTH = 0x130
+hid_events.codes.BTN_A = hid_events.codes.BTN_SOUTH
+hid_events.codes.BTN_EAST = 0x131
+hid_events.codes.BTN_B = hid_events.codes.BTN_EAST
+hid_events.codes.BTN_C = 0x132
+hid_events.codes.BTN_NORTH = 0x133
+hid_events.codes.BTN_X = hid_events.codes.BTN_NORTH
+hid_events.codes.BTN_WEST = 0x134
+hid_events.codes.BTN_Y = hid_events.codes.BTN_WEST
+hid_events.codes.BTN_Z = 0x135
+hid_events.codes.BTN_TL = 0x136
+hid_events.codes.BTN_TR = 0x137
+hid_events.codes.BTN_TL2 = 0x138
+hid_events.codes.BTN_TR2 = 0x139
+hid_events.codes.BTN_SELECT = 0x13a
+hid_events.codes.BTN_START = 0x13b
+hid_events.codes.BTN_MODE = 0x13c
+hid_events.codes.BTN_THUMBL = 0x13d
+hid_events.codes.BTN_THUMBR = 0x13e
+
+hid_events.codes.BTN_DIGI = 0x140
+hid_events.codes.BTN_TOOL_PEN = 0x140
+hid_events.codes.BTN_TOOL_RUBBER = 0x141
+hid_events.codes.BTN_TOOL_BRUSH = 0x142
+hid_events.codes.BTN_TOOL_PENCIL = 0x143
+hid_events.codes.BTN_TOOL_AIRBRUSH = 0x144
+hid_events.codes.BTN_TOOL_FINGER = 0x145
+hid_events.codes.BTN_TOOL_MOUSE = 0x146
+hid_events.codes.BTN_TOOL_LENS = 0x147
+hid_events.codes.BTN_TOOL_QUINTTAP = 0x148
+hid_events.codes.BTN_STYLUS3 = 0x149
+hid_events.codes.BTN_TOUCH = 0x14a
+hid_events.codes.BTN_STYLUS = 0x14b
+hid_events.codes.BTN_STYLUS2 = 0x14c
+hid_events.codes.BTN_TOOL_DOUBLETAP = 0x14d
+hid_events.codes.BTN_TOOL_TRIPLETAP = 0x14e
+hid_events.codes.BTN_TOOL_QUADTAP = 0x14f
+
+hid_events.codes.BTN_WHEEL = 0x150
+hid_events.codes.BTN_GEAR_DOWN = 0x150
+hid_events.codes.BTN_GEAR_UP = 0x151
+
+hid_events.codes.KEY_OK = 0x160
+hid_events.codes.KEY_SELECT = 0x161
+hid_events.codes.KEY_GOTO = 0x162
+hid_events.codes.KEY_CLEAR = 0x163
+hid_events.codes.KEY_POWER2 = 0x164
+hid_events.codes.KEY_OPTION = 0x165
+hid_events.codes.KEY_INFO = 0x166
+hid_events.codes.KEY_TIME = 0x167
+hid_events.codes.KEY_VENDOR = 0x168
+hid_events.codes.KEY_ARCHIVE = 0x169
+hid_events.codes.KEY_PROGRAM = 0x16a
+hid_events.codes.KEY_CHANNEL = 0x16b
+hid_events.codes.KEY_FAVORITES = 0x16c
+hid_events.codes.KEY_EPG = 0x16d
+hid_events.codes.KEY_PVR = 0x16e
+hid_events.codes.KEY_MHP = 0x16f
+hid_events.codes.KEY_LANGUAGE = 0x170
+hid_events.codes.KEY_TITLE = 0x171
+hid_events.codes.KEY_SUBTITLE = 0x172
+hid_events.codes.KEY_ANGLE = 0x173
+hid_events.codes.KEY_ZOOM = 0x174
+hid_events.codes.KEY_MODE = 0x175
+hid_events.codes.KEY_KEYBOARD = 0x176
+hid_events.codes.KEY_SCREEN = 0x177
+hid_events.codes.KEY_PC = 0x178
+hid_events.codes.KEY_TV = 0x179
+hid_events.codes.KEY_TV2 = 0x17a
+hid_events.codes.KEY_VCR = 0x17b
+hid_events.codes.KEY_VCR2 = 0x17c
+hid_events.codes.KEY_SAT = 0x17d
+hid_events.codes.KEY_SAT2 = 0x17e
+hid_events.codes.KEY_CD = 0x17f
+hid_events.codes.KEY_TAPE = 0x180
+hid_events.codes.KEY_RADIO = 0x181
+hid_events.codes.KEY_TUNER = 0x182
+hid_events.codes.KEY_PLAYER = 0x183
+hid_events.codes.KEY_TEXT = 0x184
+hid_events.codes.KEY_DVD = 0x185
+hid_events.codes.KEY_AUX = 0x186
+hid_events.codes.KEY_MP3 = 0x187
+hid_events.codes.KEY_AUDIO = 0x188
+hid_events.codes.KEY_VIDEO = 0x189
+hid_events.codes.KEY_DIRECTORY = 0x18a
+hid_events.codes.KEY_LIST = 0x18b
+hid_events.codes.KEY_MEMO = 0x18c
+hid_events.codes.KEY_CALENDAR = 0x18d
+hid_events.codes.KEY_RED = 0x18e
+hid_events.codes.KEY_GREEN = 0x18f
+hid_events.codes.KEY_YELLOW = 0x190
+hid_events.codes.KEY_BLUE = 0x191
+hid_events.codes.KEY_CHANNELUP = 0x192
+hid_events.codes.KEY_CHANNELDOWN = 0x193
+hid_events.codes.KEY_FIRST = 0x194
+hid_events.codes.KEY_LAST = 0x195
+hid_events.codes.KEY_AB = 0x196
+hid_events.codes.KEY_NEXT = 0x197
+hid_events.codes.KEY_RESTART = 0x198
+hid_events.codes.KEY_SLOW = 0x199
+hid_events.codes.KEY_SHUFFLE = 0x19a
+hid_events.codes.KEY_BREAK = 0x19b
+hid_events.codes.KEY_PREVIOUS = 0x19c
+hid_events.codes.KEY_DIGITS = 0x19d
+hid_events.codes.KEY_TEEN = 0x19e
+hid_events.codes.KEY_TWEN = 0x19f
+hid_events.codes.KEY_VIDEOPHONE = 0x1a0
+hid_events.codes.KEY_GAMES = 0x1a1
+hid_events.codes.KEY_ZOOMIN = 0x1a2
+hid_events.codes.KEY_ZOOMOUT = 0x1a3
+hid_events.codes.KEY_ZOOMRESET = 0x1a4
+hid_events.codes.KEY_WORDPROCESSOR = 0x1a5
+hid_events.codes.KEY_EDITOR = 0x1a6
+hid_events.codes.KEY_SPREADSHEET = 0x1a7
+hid_events.codes.KEY_GRAPHICSEDITOR = 0x1a8
+hid_events.codes.KEY_PRESENTATION = 0x1a9
+hid_events.codes.KEY_DATABASE = 0x1aa
+hid_events.codes.KEY_NEWS = 0x1ab
+hid_events.codes.KEY_VOICEMAIL = 0x1ac
+hid_events.codes.KEY_ADDRESSBOOK = 0x1ad
+hid_events.codes.KEY_MESSENGER = 0x1ae
+hid_events.codes.KEY_DISPLAYTOGGLE = 0x1af
+hid_events.codes.KEY_BRIGHTNESS_TOGGLE = hid_events.codes.KEY_DISPLAYTOGGLE
+hid_events.codes.KEY_SPELLCHECK = 0x1b0
+hid_events.codes.KEY_LOGOFF = 0x1b1
+
+hid_events.codes.KEY_DOLLAR = 0x1b2
+hid_events.codes.KEY_EURO = 0x1b3
+
+hid_events.codes.KEY_FRAMEBACK = 0x1b4
+hid_events.codes.KEY_FRAMEFORWARD = 0x1b5
+hid_events.codes.KEY_CONTEXT_MENU = 0x1b6
+hid_events.codes.KEY_MEDIA_REPEAT = 0x1b7
+hid_events.codes.KEY_10CHANNELSUP = 0x1b8
+hid_events.codes.KEY_10CHANNELSDOWN = 0x1b9
+hid_events.codes.KEY_IMAGES = 0x1ba
+
+hid_events.codes.KEY_DEL_EOL = 0x1c0
+hid_events.codes.KEY_DEL_EOS = 0x1c1
+hid_events.codes.KEY_INS_LINE = 0x1c2
+hid_events.codes.KEY_DEL_LINE = 0x1c3
+
+hid_events.codes.KEY_FN = 0x1d0
+hid_events.codes.KEY_FN_ESC = 0x1d1
+hid_events.codes.KEY_FN_F1 = 0x1d2
+hid_events.codes.KEY_FN_F2 = 0x1d3
+hid_events.codes.KEY_FN_F3 = 0x1d4
+hid_events.codes.KEY_FN_F4 = 0x1d5
+hid_events.codes.KEY_FN_F5 = 0x1d6
+hid_events.codes.KEY_FN_F6 = 0x1d7
+hid_events.codes.KEY_FN_F7 = 0x1d8
+hid_events.codes.KEY_FN_F8 = 0x1d9
+hid_events.codes.KEY_FN_F9 = 0x1da
+hid_events.codes.KEY_FN_F10 = 0x1db
+hid_events.codes.KEY_FN_F11 = 0x1dc
+hid_events.codes.KEY_FN_F12 = 0x1dd
+hid_events.codes.KEY_FN_1 = 0x1de
+hid_events.codes.KEY_FN_2 = 0x1df
+hid_events.codes.KEY_FN_D = 0x1e0
+hid_events.codes.KEY_FN_E = 0x1e1
+hid_events.codes.KEY_FN_F = 0x1e2
+hid_events.codes.KEY_FN_S = 0x1e3
+hid_events.codes.KEY_FN_B = 0x1e4
+
+hid_events.codes.KEY_BRL_DOT1 = 0x1f1
+hid_events.codes.KEY_BRL_DOT2 = 0x1f2
+hid_events.codes.KEY_BRL_DOT3 = 0x1f3
+hid_events.codes.KEY_BRL_DOT4 = 0x1f4
+hid_events.codes.KEY_BRL_DOT5 = 0x1f5
+hid_events.codes.KEY_BRL_DOT6 = 0x1f6
+hid_events.codes.KEY_BRL_DOT7 = 0x1f7
+hid_events.codes.KEY_BRL_DOT8 = 0x1f8
+hid_events.codes.KEY_BRL_DOT9 = 0x1f9
+hid_events.codes.KEY_BRL_DOT10 = 0x1fa
+
+hid_events.codes.KEY_NUMERIC_0 = 0x200
+hid_events.codes.KEY_NUMERIC_1 = 0x201
+hid_events.codes.KEY_NUMERIC_2 = 0x202
+hid_events.codes.KEY_NUMERIC_3 = 0x203
+hid_events.codes.KEY_NUMERIC_4 = 0x204
+hid_events.codes.KEY_NUMERIC_5 = 0x205
+hid_events.codes.KEY_NUMERIC_6 = 0x206
+hid_events.codes.KEY_NUMERIC_7 = 0x207
+hid_events.codes.KEY_NUMERIC_8 = 0x208
+hid_events.codes.KEY_NUMERIC_9 = 0x209
+hid_events.codes.KEY_NUMERIC_STAR = 0x20a
+hid_events.codes.KEY_NUMERIC_POUND = 0x20b
+hid_events.codes.KEY_NUMERIC_A = 0x20c
+hid_events.codes.KEY_NUMERIC_B = 0x20d
+hid_events.codes.KEY_NUMERIC_C = 0x20e
+hid_events.codes.KEY_NUMERIC_D = 0x20f
+
+hid_events.codes.KEY_CAMERA_FOCUS = 0x210
+hid_events.codes.KEY_WPS_BUTTON = 0x211
+
+hid_events.codes.KEY_TOUCHPAD_TOGGLE = 0x212
+hid_events.codes.KEY_TOUCHPAD_ON = 0x213
+hid_events.codes.KEY_TOUCHPAD_OFF = 0x214
+
+hid_events.codes.KEY_CAMERA_ZOOMIN = 0x215
+hid_events.codes.KEY_CAMERA_ZOOMOUT = 0x216
+hid_events.codes.KEY_CAMERA_UP = 0x217
+hid_events.codes.KEY_CAMERA_DOWN = 0x218
+hid_events.codes.KEY_CAMERA_LEFT = 0x219
+hid_events.codes.KEY_CAMERA_RIGHT = 0x21a
+
+hid_events.codes.KEY_ATTENDANT_ON = 0x21b
+hid_events.codes.KEY_ATTENDANT_OFF = 0x21c
+hid_events.codes.KEY_ATTENDANT_TOGGLE = 0x21d
+hid_events.codes.KEY_LIGHTS_TOGGLE = 0x21e
+
+hid_events.codes.BTN_DPAD_UP = 0x220
+hid_events.codes.BTN_DPAD_DOWN = 0x221
+hid_events.codes.BTN_DPAD_LEFT = 0x222
+hid_events.codes.BTN_DPAD_RIGHT = 0x223
+
+hid_events.codes.KEY_ALS_TOGGLE = 0x230
+
+hid_events.codes.KEY_BUTTONCONFIG = 0x240
+hid_events.codes.KEY_TASKMANAGER = 0x241
+hid_events.codes.KEY_JOURNAL = 0x242
+hid_events.codes.KEY_CONTROLPANEL = 0x243
+hid_events.codes.KEY_APPSELECT = 0x244
+hid_events.codes.KEY_SCREENSAVER = 0x245
+hid_events.codes.KEY_VOICECOMMAND = 0x246
+hid_events.codes.KEY_ASSISTANT = 0x247
+
+hid_events.codes.KEY_BRIGHTNESS_MIN = 0x250
+hid_events.codes.KEY_BRIGHTNESS_MAX = 0x251
+
+hid_events.codes.KEY_KBDINPUTASSIST_PREV = 0x260
+hid_events.codes.KEY_KBDINPUTASSIST_NEXT = 0x261
+hid_events.codes.KEY_KBDINPUTASSIST_PREVGROUP = 0x262
+hid_events.codes.KEY_KBDINPUTASSIST_NEXTGROUP = 0x263
+hid_events.codes.KEY_KBDINPUTASSIST_ACCEPT = 0x264
+hid_events.codes.KEY_KBDINPUTASSIST_CANCEL = 0x265
+
+hid_events.codes.KEY_RIGHT_UP = 0x266
+hid_events.codes.KEY_RIGHT_DOWN = 0x267
+hid_events.codes.KEY_LEFT_UP = 0x268
+hid_events.codes.KEY_LEFT_DOWN = 0x269
+
+hid_events.codes.KEY_ROOT_MENU = 0x26a
+hid_events.codes.KEY_MEDIA_TOP_MENU = 0x26b
+hid_events.codes.KEY_NUMERIC_11 = 0x26c
+hid_events.codes.KEY_NUMERIC_12 = 0x26d
+
+hid_events.codes.KEY_AUDIO_DESC = 0x26e
+hid_events.codes.KEY_3D_MODE = 0x26f
+hid_events.codes.KEY_NEXT_FAVORITE = 0x270
+hid_events.codes.KEY_STOP_RECORD = 0x271
+hid_events.codes.KEY_PAUSE_RECORD = 0x272
+hid_events.codes.KEY_VOD = 0x273
+hid_events.codes.KEY_UNMUTE = 0x274
+hid_events.codes.KEY_FASTREVERSE = 0x275
+hid_events.codes.KEY_SLOWREVERSE = 0x276
+
+hid_events.codes.KEY_DATA = 0x277
+hid_events.codes.KEY_ONSCREEN_KEYBOARD = 0x278
+
+hid_events.codes.BTN_TRIGGER_HAPPY = 0x2c0
+hid_events.codes.BTN_TRIGGER_HAPPY1 = 0x2c0
+hid_events.codes.BTN_TRIGGER_HAPPY2 = 0x2c1
+hid_events.codes.BTN_TRIGGER_HAPPY3 = 0x2c2
+hid_events.codes.BTN_TRIGGER_HAPPY4 = 0x2c3
+hid_events.codes.BTN_TRIGGER_HAPPY5 = 0x2c4
+hid_events.codes.BTN_TRIGGER_HAPPY6 = 0x2c5
+hid_events.codes.BTN_TRIGGER_HAPPY7 = 0x2c6
+hid_events.codes.BTN_TRIGGER_HAPPY8 = 0x2c7
+hid_events.codes.BTN_TRIGGER_HAPPY9 = 0x2c8
+hid_events.codes.BTN_TRIGGER_HAPPY10 = 0x2c9
+hid_events.codes.BTN_TRIGGER_HAPPY11 = 0x2ca
+hid_events.codes.BTN_TRIGGER_HAPPY12 = 0x2cb
+hid_events.codes.BTN_TRIGGER_HAPPY13 = 0x2cc
+hid_events.codes.BTN_TRIGGER_HAPPY14 = 0x2cd
+hid_events.codes.BTN_TRIGGER_HAPPY15 = 0x2ce
+hid_events.codes.BTN_TRIGGER_HAPPY16 = 0x2cf
+hid_events.codes.BTN_TRIGGER_HAPPY17 = 0x2d0
+hid_events.codes.BTN_TRIGGER_HAPPY18 = 0x2d1
+hid_events.codes.BTN_TRIGGER_HAPPY19 = 0x2d2
+hid_events.codes.BTN_TRIGGER_HAPPY20 = 0x2d3
+hid_events.codes.BTN_TRIGGER_HAPPY21 = 0x2d4
+hid_events.codes.BTN_TRIGGER_HAPPY22 = 0x2d5
+hid_events.codes.BTN_TRIGGER_HAPPY23 = 0x2d6
+hid_events.codes.BTN_TRIGGER_HAPPY24 = 0x2d7
+hid_events.codes.BTN_TRIGGER_HAPPY25 = 0x2d8
+hid_events.codes.BTN_TRIGGER_HAPPY26 = 0x2d9
+hid_events.codes.BTN_TRIGGER_HAPPY27 = 0x2da
+hid_events.codes.BTN_TRIGGER_HAPPY28 = 0x2db
+hid_events.codes.BTN_TRIGGER_HAPPY29 = 0x2dc
+hid_events.codes.BTN_TRIGGER_HAPPY30 = 0x2dd
+hid_events.codes.BTN_TRIGGER_HAPPY31 = 0x2de
+hid_events.codes.BTN_TRIGGER_HAPPY32 = 0x2df
+hid_events.codes.BTN_TRIGGER_HAPPY33 = 0x2e0
+hid_events.codes.BTN_TRIGGER_HAPPY34 = 0x2e1
+hid_events.codes.BTN_TRIGGER_HAPPY35 = 0x2e2
+hid_events.codes.BTN_TRIGGER_HAPPY36 = 0x2e3
+hid_events.codes.BTN_TRIGGER_HAPPY37 = 0x2e4
+hid_events.codes.BTN_TRIGGER_HAPPY38 = 0x2e5
+hid_events.codes.BTN_TRIGGER_HAPPY39 = 0x2e6
+hid_events.codes.BTN_TRIGGER_HAPPY40 = 0x2e7
+
+hid_events.codes.KEY_MIN_INTERESTING = hid_events.codes.KEY_MUTE
+
+-- Relative axes
+
+hid_events.codes.REL_X = 0x00
+hid_events.codes.REL_Y = 0x01
+hid_events.codes.REL_Z = 0x02
+hid_events.codes.REL_RX = 0x03
+hid_events.codes.REL_RY = 0x04
+hid_events.codes.REL_RZ = 0x05
+hid_events.codes.REL_HWHEEL = 0x06
+hid_events.codes.REL_DIAL = 0x07
+hid_events.codes.REL_WHEEL = 0x08
+hid_events.codes.REL_MISC = 0x09
+
+-- Absolute axes
+
+hid_events.codes.ABS_X = 0x00
+hid_events.codes.ABS_Y = 0x01
+hid_events.codes.ABS_Z = 0x02
+hid_events.codes.ABS_RX = 0x03
+hid_events.codes.ABS_RY = 0x04
+hid_events.codes.ABS_RZ = 0x05
+hid_events.codes.ABS_THROTTLE = 0x06
+hid_events.codes.ABS_RUDDER = 0x07
+hid_events.codes.ABS_WHEEL = 0x08
+hid_events.codes.ABS_GAS = 0x09
+hid_events.codes.ABS_BRAKE = 0x0a
+hid_events.codes.ABS_HAT0X = 0x10
+hid_events.codes.ABS_HAT0Y = 0x11
+hid_events.codes.ABS_HAT1X = 0x12
+hid_events.codes.ABS_HAT1Y = 0x13
+hid_events.codes.ABS_HAT2X = 0x14
+hid_events.codes.ABS_HAT2Y = 0x15
+hid_events.codes.ABS_HAT3X = 0x16
+hid_events.codes.ABS_HAT3Y = 0x17
+hid_events.codes.ABS_PRESSURE = 0x18
+hid_events.codes.ABS_DISTANCE = 0x19
+hid_events.codes.ABS_TILT_X = 0x1a
+hid_events.codes.ABS_TILT_Y = 0x1b
+hid_events.codes.ABS_TOOL_WIDTH = 0x1c
+
+hid_events.codes.ABS_VOLUME = 0x20
+
+hid_events.codes.ABS_MISC = 0x28
+
+hid_events.codes.ABS_MT_SLOT = 0x2f
+hid_events.codes.ABS_MT_TOUCH_MAJOR = 0x30
+hid_events.codes.ABS_MT_TOUCH_MINOR = 0x31
+hid_events.codes.ABS_MT_WIDTH_MAJOR = 0x32
+hid_events.codes.ABS_MT_WIDTH_MINOR = 0x33
+hid_events.codes.ABS_MT_ORIENTATION = 0x34
+hid_events.codes.ABS_MT_POSITION_X = 0x35
+hid_events.codes.ABS_MT_POSITION_Y = 0x36
+hid_events.codes.ABS_MT_TOOL_TYPE = 0x37
+hid_events.codes.ABS_MT_BLOB_ID = 0x38
+hid_events.codes.ABS_MT_TRACKING_ID = 0x39
+hid_events.codes.ABS_MT_PRESSURE = 0x3a
+hid_events.codes.ABS_MT_DISTANCE = 0x3b
+hid_events.codes.ABS_MT_TOOL_X = 0x3c
+hid_events.codes.ABS_MT_TOOL_Y = 0x3d
+
+-- Switch events
+
+hid_events.codes.SW_LID = 0x00
+hid_events.codes.SW_TABLET_MODE = 0x01
+hid_events.codes.SW_HEADPHONE_INSERT = 0x02
+hid_events.codes.SW_RFKILL_ALL = 0x03
+hid_events.codes.SW_RADIO = hid_events.codes.SW_RFKILL_ALL
+hid_events.codes.SW_MICROPHONE_INSERT = 0x04
+hid_events.codes.SW_DOCK = 0x05
+hid_events.codes.SW_LINEOUT_INSERT = 0x06
+hid_events.codes.SW_JACK_PHYSICAL_INSERT = 0x07
+hid_events.codes.SW_VIDEOOUT_INSERT = 0x08
+hid_events.codes.SW_CAMERA_LENS_COVER = 0x09
+hid_events.codes.SW_KEYPAD_SLIDE = 0x0a
+hid_events.codes.SW_FRONT_PROXIMITY = 0x0b
+hid_events.codes.SW_ROTATE_LOCK = 0x0c
+hid_events.codes.SW_LINEIN_INSERT = 0x0d
+hid_events.codes.SW_MUTE_DEVICE = 0x0e
+hid_events.codes.SW_PEN_INSERTED = 0x0f
+
+-- Misc events
+
+hid_events.codes.MSC_SERIAL = 0x00
+hid_events.codes.MSC_PULSELED = 0x01
+hid_events.codes.MSC_GESTURE = 0x02
+hid_events.codes.MSC_RAW = 0x03
+hid_events.codes.MSC_SCAN = 0x04
+hid_events.codes.MSC_TIMESTAMP = 0x05
+
+-- LEDs
+
+hid_events.codes.LED_NUML = 0x00
+hid_events.codes.LED_CAPSL = 0x01
+hid_events.codes.LED_SCROLLL = 0x02
+hid_events.codes.LED_COMPOSE = 0x03
+hid_events.codes.LED_KANA = 0x04
+hid_events.codes.LED_SLEEP = 0x05
+hid_events.codes.LED_SUSPEND = 0x06
+hid_events.codes.LED_MUTE = 0x07
+hid_events.codes.LED_MISC = 0x08
+hid_events.codes.LED_MAIL = 0x09
+hid_events.codes.LED_CHARGING = 0x0a
+
+-- Autorepeat values
+
+hid_events.codes.REP_DELAY = 0x00
+hid_events.codes.REP_PERIOD = 0x01
+
+-- Sounds
+
+hid_events.codes.SND_CLICK = 0x00
+hid_events.codes.SND_BELL = 0x01
+hid_events.codes.SND_TONE = 0x02
+
+return hid_events

--- a/lua/core/menu.lua
+++ b/lua/core/menu.lua
@@ -816,8 +816,8 @@ function m.devices.refresh()
   for _,i in pairs(grid.list) do
     table.insert(m.devices.options.grid,i)
   end
-  for _,i in pairs(arc.list) do
-    table.insert(m.devices.options.arc,i)
+  for _, device in pairs(arc.devices) do
+    table.insert(m.devices.options.arc, device.name)
   end
 end
 

--- a/lua/core/menu.lua
+++ b/lua/core/menu.lua
@@ -860,7 +860,7 @@ m.key[pDEVICES] = function(n,z)
         midi.vport[m.devices.setpos].name = s
         midi.update_devices()
       elseif m.devices.section == "grid" then
-        grid.vport[m.devices.setpos].name = s
+        grid.vports[m.devices.setpos].name = s
         grid.update_devices()
       elseif m.devices.section == "arc" then
         arc.vports[m.devices.setpos].name = s
@@ -896,7 +896,7 @@ m.redraw[pDEVICES] = function()
       if m.devices.section == "midi" then
         screen.text(i .. ". " .. midi.vport[i].name)
       elseif m.devices.section == "grid" then
-        screen.text(i .. ". " .. grid.vport[i].name)
+        screen.text(i .. ". " .. grid.vports[i].name)
       elseif m.devices.section == "arc" then
         screen.text(i .. ". " .. arc.vports[i].name)
       end

--- a/lua/core/menu.lua
+++ b/lua/core/menu.lua
@@ -857,7 +857,7 @@ m.key[pDEVICES] = function(n,z)
     elseif n==3 and z==1 then
       local s = m.devices.options[m.devices.section][m.devices.pos]
       if m.devices.section == "midi" then
-        midi.vport[m.devices.setpos].name = s
+        midi.vports[m.devices.setpos].name = s
         midi.update_devices()
       elseif m.devices.section == "grid" then
         grid.vports[m.devices.setpos].name = s
@@ -894,7 +894,7 @@ m.redraw[pDEVICES] = function()
       screen.text(string.upper(m.devices.list[i]) .. " >")
     elseif m.devices.mode == "list" then
       if m.devices.section == "midi" then
-        screen.text(i .. ". " .. midi.vport[i].name)
+        screen.text(i .. ". " .. midi.vports[i].name)
       elseif m.devices.section == "grid" then
         screen.text(i .. ". " .. grid.vports[i].name)
       elseif m.devices.section == "arc" then

--- a/lua/core/menu.lua
+++ b/lua/core/menu.lua
@@ -863,7 +863,7 @@ m.key[pDEVICES] = function(n,z)
         grid.vport[m.devices.setpos].name = s
         grid.update_devices()
       elseif m.devices.section == "arc" then
-        arc.vport[m.devices.setpos].name = s
+        arc.vports[m.devices.setpos].name = s
         arc.update_devices()
       end
       m.devices.mode = "list"
@@ -898,7 +898,7 @@ m.redraw[pDEVICES] = function()
       elseif m.devices.section == "grid" then
         screen.text(i .. ". " .. grid.vport[i].name)
       elseif m.devices.section == "arc" then
-        screen.text(i .. ". " .. arc.vport[i].name)
+        screen.text(i .. ". " .. arc.vports[i].name)
       end
     elseif m.devices.mode == "select" then
       screen.text(m.devices.options[m.devices.section][i])

--- a/lua/core/menu.lua
+++ b/lua/core/menu.lua
@@ -801,23 +801,27 @@ m.deinit[pSYSTEM] = norns.none
 -- DEVICES
 m.devices = {}
 m.devices.pos = 1
-m.devices.list = {"midi", "grid", "arc"}
+m.devices.list = {"midi", "grid", "arc", "hid"}
 m.devices.len = #m.devices.list
 function m.devices.refresh()
   m.devices.options = {
     midi = {"none"},
     grid = {"none"},
     arc = {"none"},
+    hid = {"none"},
   }
   -- create midi list
-  for _,i in pairs(midi.list) do
-    table.insert(m.devices.options.midi,i)
+  for _, device in pairs(midi.devices) do
+    table.insert(m.devices.options.midi, device.name)
   end
-  for _,i in pairs(grid.list) do
-    table.insert(m.devices.options.grid,i)
+  for _, device in pairs(grid.devices) do
+    table.insert(m.devices.options.grid, device.name)
   end
   for _, device in pairs(arc.devices) do
     table.insert(m.devices.options.arc, device.name)
+  end
+  for _, device in pairs(hid.devices) do
+    table.insert(m.devices.options.hid, device.name)
   end
 end
 
@@ -865,6 +869,9 @@ m.key[pDEVICES] = function(n,z)
       elseif m.devices.section == "arc" then
         arc.vports[m.devices.setpos].name = s
         arc.update_devices()
+      elseif m.devices.section == "hid" then
+        hid.vports[m.devices.setpos].name = s
+        hid.update_devices()
       end
       m.devices.mode = "list"
       m.devices.len = 4
@@ -899,6 +906,8 @@ m.redraw[pDEVICES] = function()
         screen.text(i .. ". " .. grid.vports[i].name)
       elseif m.devices.section == "arc" then
         screen.text(i .. ". " .. arc.vports[i].name)
+      elseif m.devices.section == "hid" then
+        screen.text(i .. ". " .. hid.vports[i].name)
       end
     elseif m.devices.mode == "select" then
       screen.text(m.devices.options[m.devices.section][i])

--- a/lua/core/midi.lua
+++ b/lua/core/midi.lua
@@ -2,17 +2,13 @@
 -- @module midi
 -- @alias Midi
 
+local vport = require 'vport'
+
 local Midi = {}
 Midi.__index = Midi
 
 Midi.devices = {}
 Midi.vports = {}
-
-local function wrap_midi_method(method)
-  return function(self, ...)
-    if self.device then self.device[method](self.device, ...) end
-  end
-end
 
 for i=1,4 do
   Midi.vports[i] = {
@@ -22,18 +18,18 @@ for i=1,4 do
 
     send = function(self, ...) if self.device then self.device:send(...) end end,
 
-    note_on = wrap_midi_method('note_on'),
-    note_off = wrap_midi_method('note_off'),
-    cc = wrap_midi_method('cc'),
-    pitchbend = wrap_midi_method('pitchbend'),
-    key_pressure = wrap_midi_method('key_pressure'),
-    channel_pressure = wrap_midi_method('channel_pressure'),
-    start = wrap_midi_method('start'),
-    stop = wrap_midi_method('stop'),
-    continue = wrap_midi_method('continue'),
-    clock = wrap_midi_method('clock'),
-    song_position = wrap_midi_method('song_position'),
-    song_select = wrap_midi_method('song_select'),
+    note_on = vport.wrap_method('note_on'),
+    note_off = vport.wrap_method('note_off'),
+    cc = vport.wrap_method('cc'),
+    pitchbend = vport.wrap_method('pitchbend'),
+    key_pressure = vport.wrap_method('key_pressure'),
+    channel_pressure = vport.wrap_method('channel_pressure'),
+    start = vport.wrap_method('start'),
+    stop = vport.wrap_method('stop'),
+    continue = vport.wrap_method('continue'),
+    clock = vport.wrap_method('clock'),
+    song_position = vport.wrap_method('song_position'),
+    song_select = vport.wrap_method('song_select'),
   }
 end
 
@@ -45,7 +41,7 @@ function Midi.new(id, name, dev)
   local d = setmetatable({}, Midi)
 
   d.id = id
-  d.name = name
+  d.name = vport.get_unique_device_name(name, Midi.devices)
   d.dev = dev -- opaque pointer
   d.event = nil -- event callback
   d.remove = nil -- device unplug callback

--- a/lua/core/midi.lua
+++ b/lua/core/midi.lua
@@ -3,19 +3,39 @@
 -- @alias Midi
 
 local Midi = {}
+Midi.__index = Midi
+
 Midi.devices = {}
-Midi.list = {}
-Midi.vport = {}
+Midi.vports = {}
+
+local function wrap_midi_method(method)
+  return function(self, ...)
+    if self.device then self.device[method](self.device, ...) end
+  end
+end
+
 for i=1,4 do
-  Midi.vport[i] = {
+  Midi.vports[i] = {
     name = "none",
-    callbacks = {},
-    index = 0,
-    send = function() end,
-    attached = false
+    device = nil,
+    event = nil,
+
+    send = function(self, ...) if self.device then self.device:send(...) end end,
+
+    note_on = wrap_midi_method('note_on'),
+    note_off = wrap_midi_method('note_off'),
+    cc = wrap_midi_method('cc'),
+    pitchbend = wrap_midi_method('pitchbend'),
+    key_pressure = wrap_midi_method('key_pressure'),
+    channel_pressure = wrap_midi_method('channel_pressure'),
+    start = wrap_midi_method('start'),
+    stop = wrap_midi_method('stop'),
+    continue = wrap_midi_method('continue'),
+    clock = wrap_midi_method('clock'),
+    song_position = wrap_midi_method('song_position'),
+    song_select = wrap_midi_method('song_select'),
   }
 end
-Midi.__index = Midi
 
 --- constructor
 -- @tparam integer id : arbitrary numeric identifier
@@ -23,24 +43,23 @@ Midi.__index = Midi
 -- @tparam userdata dev : opaque pointer to device
 function Midi.new(id, name, dev)
   local d = setmetatable({}, Midi)
+
   d.id = id
-  -- append duplicate device names
-  --while tab.contains(Midi.list,name) do
-    --name = name .. "+"
-  --end
   d.name = name
   d.dev = dev -- opaque pointer
   d.event = nil -- event callback
   d.remove = nil -- device unplug callback
-  d.ports = {} -- list of virtual ports this device is attached to
+  d.port = nil
 
   -- autofill next postiion
   local connected = {}
-  for i=1,4 do table.insert(connected, Midi.vport[i].name) end
+  for i=1,4 do
+    table.insert(connected, Midi.vports[i].name)
+  end
   if not tab.contains(connected, name) then
     for i=1,4 do
-      if Midi.vport[i].name == "none" then
-        Midi.vport[i].name = name
+      if Midi.vports[i].name == "none" then
+        Midi.vports[i].name = d.name
         break
       end
     end
@@ -61,110 +80,77 @@ function Midi.remove(dev) end
 
 --- call add() for currently available devices
 -- when scripts are restarted
-function Midi.reconnect()
-  for id,dev in pairs(Midi.devices) do
-    if Midi.add ~= nil then Midi.add(dev) end
-  end
-end
+function Midi.reconnect() end
 
 --- send midi event to device
 -- @param array
 function Midi:send(data)
   if data.type then
-    --print("msg")
     local d = Midi.to_data(data)
-    if d then midi_send(self.dev, d) end
+    midi_send(self.dev, d)
   else
-    --print("data")
     midi_send(self.dev, data)
   end
 end
 
+function Midi:note_on(note, vel, ch)
+  self:send{type="note_on", note=note, vel=vel, ch=ch or 1}
+end
+
+function Midi:note_off(note, vel, ch)
+  self:send{type="note_off", note=note, vel=vel or 100, ch=ch or 1}
+end
+
+function Midi:cc(cc, val, ch)
+  self:send{type="cc", cc=cc, val=val, ch=ch or 1}
+end
+
+function Midi:pitchbend(val, ch)
+  self:send{type="pitchbend", val=val, ch=ch or 1}
+end
+
+function Midi:key_pressure(note, val, ch)
+  self:send{type="key_pressure", note=note, val=val, ch=ch or 1}
+end
+
+function Midi:channel_pressure(val, ch)
+  self:send{type="channel_pressure", val=val, ch=ch or 1}
+end
+
+function Midi:start()
+  self:send{type="start"}
+end
+
+function Midi:stop()
+  self:send{type="stop"}
+end
+
+function Midi:continue()
+  self:send{type="continue"}
+end
+
+function Midi:clock()
+  self:send{type="clock"}
+end
+
+function Midi:song_position(lsb, msb)
+  self:send{type="song_position", lsb=lsb, msb=msb}
+end
+
+function Midi:song_select(val)
+  self:send{type="song_select", val=val}
+end
 
 --- create device, returns object with handler and send
 function Midi.connect(n)
   local n = n or 1
-  if n>4 then n=4 end
-
-  Midi.vport[n].index = Midi.vport[n].index + 1
-
-  local d = {
-    index = Midi.vport[n].index,
-    port = n,
-    event = function(data)
-        print("midi input")
-      end,
-    attached = function() return Midi.vport[n].attached end,
-    send = function(data) Midi.vport[n].send(data) end,
-    disconnect = function(self)
-        self.send = function() print("not connected") end
-        Midi.vport[self.port].callbacks[self.index] = nil
-        self.index = nil
-        self.port = nil
-      end,
-    reconnect = function(self, p)
-        p = p or 1
-        if self.index then
-          Midi.vport[self.port].callbacks[self.index] = nil
-        end
-        self.send = function(data) Midi.vport[p].send(data) end
-        self.attached = function() return Midi.vport[p].attached end
-        Midi.vport[p].index = Midi.vport[p].index + 1
-        self.index = Midi.vport[p].index
-        self.port = p
-        Midi.vport[p].callbacks[self.index] = function(data) self.event(data) end
-      end
-  }
-
-  Midi.vport[n].callbacks[d.index] = function(data) d.event(data) end
-
-  -- midi send helper functions
-  d.note_on = function(note, vel, ch)
-      d.send{type="note_on", note=note, vel=vel, ch=ch or 1}
-    end
-  d.note_off = function(note, vel, ch)
-      d.send{type="note_off", note=note, vel=vel or 100, ch=ch or 1}
-    end
-  d.cc = function(cc, val, ch)
-      d.send{type="cc", cc=cc, val=val, ch=ch or 1}
-    end
-  d.pitchbend = function(val, ch)
-      d.send{type="pitchbend", val=val, ch=ch or 1}
-    end
-  d.key_pressure = function(note, val, ch)
-      d.send{type="key_pressure", note=note, val=val, ch=ch or 1}
-    end
-  d.channel_pressure = function(val, ch)
-      d.send{type="channel_pressure", val=val, ch=ch or 1}
-    end
-  d.start = function()
-      d.send{type="start"}
-    end
-  d.stop = function()
-      d.send{type="stop"}
-    end
-  d.continue = function()
-     d.send{type="continue"}
-      --d.send{0xfb}
-    end
-  d.clock = function()
-      d.send{type="clock"}
-    end
-  d.song_position = function(lsb, msb)
-      d.send{type="song_position", lsb=lsb, msb=msb}
-    end
-  d.song_select = function(val)
-      d.send{type="song_select", val=val}
-    end
-
-  return d
+  return Midi.vports[n]
 end
 
 --- clear handlers
 function Midi.cleanup()
   for i=1,4 do
-    Midi.vport[i].callbacks = {}
-    Midi.vport[i].index = 0
+    Midi.vports[i].event = nil
   end
 end
 
@@ -215,7 +201,9 @@ local to_data = {
 function Midi.to_data(msg)
   if msg.type then
     return to_data[msg.type](msg)
-  else return nil end
+  else
+    error('failed to serialize midi message')
+  end
 end
 
 --- convert data (midi bytes) to msg
@@ -228,7 +216,7 @@ function Midi.to_msg(data)
       vel = data[3],
       ch = data[1] - 0x90 + 1
     }
-    if data[3] > 0 then 
+    if data[3] > 0 then
       msg.type = "note_on"
     elseif data[3] == 0 then -- if velocity is zero then send note off
       msg.type = "note_off"
@@ -289,13 +277,13 @@ function Midi.to_msg(data)
         type = "song_position",
         lsb = data[2],
         msb = data[3]
-    }    
+    }
   -- song select
   elseif data[1] == 0xf3 then
     msg = {
         type = "song_select",
         val = data[2]
-    }    
+    }
   -- active sensing (should probably ignore)
   elseif data[1] == 0xfe then
       -- do nothing
@@ -310,31 +298,26 @@ end
 
 
 function Midi.update_devices()
-  -- build list of available devices
-  Midi.list = {}
+  -- reset vports for existing devices
   for _,device in pairs(Midi.devices) do
-    table.insert(Midi.list, device.name)
-    device.ports = {}
+    device.port = nil
   end
+
   -- connect available devices to vports
   for i=1,4 do
-    Midi.vport[i].attached = false
-    Midi.vport[i].send = function(data) end
-    for _,device in pairs(Midi.devices) do
-      if device.name == Midi.vport[i].name then
-        Midi.vport[i].send = function(data) device:send(data) end
-        Midi.vport[i].attached = true
-        table.insert(device.ports, i)
+    Midi.vports[i].device = nil
+
+    for _, device in pairs(Midi.devices) do
+      if device.name == Midi.vports[i].name then
+        Midi.vports[i].device = device
+        device.port = i
       end
     end
   end
 end
 
---- norns functions
-
 --- add a device
 norns.midi.add = function(id, name, dev)
-  print("midi added:", name)
   local d = Midi.new(id, name, dev)
   Midi.devices[id] = d
   Midi.update_devices()
@@ -344,7 +327,6 @@ end
 --- remove a device
 norns.midi.remove = function(id)
   if Midi.devices[id] then
-  print("midi removed:", Midi.devices[id].name)
     if Midi.devices[id].remove then
       Midi.devices[id].remove()
     end
@@ -355,21 +337,20 @@ end
 
 --- handle a midi event
 norns.midi.event = function(id, data)
-  -- iterate through port table
-
   local d = Midi.devices[id]
+
   if d ~= nil then
     if d.event ~= nil then
       d.event(data)
     end
 
-    for _,n in pairs(d.ports) do
-      for _,event in pairs(Midi.vport[n].callbacks) do
-        --print("vport " .. n)
-        event(data)
-      end
+    if d.port and Midi.vports[d.port].event then
+      Midi.vports[d.port].event(data)
     end
+  else
+    error('no entry for midi '..id)
   end
+
   -- hack = send all midi to menu for param-cc-map
   norns.menu_midi_event(data)
 end

--- a/lua/core/norns.lua
+++ b/lua/core/norns.lua
@@ -95,8 +95,8 @@ end
 -- hid callbacks
 norns.hid = {}
 --- HID or other input device added
-norns.hid.add = function(id, serial, name, types, codes)
-   -- print("norns.input.add ", id, serial, name, types, codes)
+norns.hid.add = function(id, name, types, codes, dev)
+   -- print("norns.input.add ", id, name, types, codes, dev)
 end
 norns.hid.event = function(id, ev_type, ev_code, value)
    -- print("norns.input.event ", id, ev_type, ev_code, value)

--- a/lua/core/script.lua
+++ b/lua/core/script.lua
@@ -74,6 +74,7 @@ Script.init = function()
   grid.reconnect()
   midi.reconnect()
   arc.reconnect()
+  hid.reconnect()
 end
 
 --- load a script from the /scripts folder

--- a/lua/core/state.lua
+++ b/lua/core/state.lua
@@ -81,7 +81,7 @@ state.save_state = function()
     io.write("grid.vport[" .. i .. "].name = '" .. grid.vport[i].name .. "'\n")
   end
   for i=1,4 do
-    io.write("arc.vport[" .. i .. "].name = '" .. arc.vport[i].name .. "'\n")
+    io.write("arc.vports[" .. i .. "].name = '" .. arc.vports[i].name .. "'\n")
   end
   io.close(fd)
 end

--- a/lua/core/state.lua
+++ b/lua/core/state.lua
@@ -27,6 +27,7 @@ state.resume = function()
   midi.update_devices()
   grid.update_devices()
   arc.update_devices()
+  hid.update_devices()
 
   -- only resume the script if we shut down cleanly
   if state.clean_shutdown and state.script ~= '' then
@@ -82,6 +83,9 @@ state.save_state = function()
   end
   for i=1,4 do
     io.write("arc.vports[" .. i .. "].name = '" .. arc.vports[i].name .. "'\n")
+  end
+  for i=1,4 do
+    io.write("hid.vports[" .. i .. "].name = '" .. hid.vports[i].name .. "'\n")
   end
   io.close(fd)
 end

--- a/lua/core/state.lua
+++ b/lua/core/state.lua
@@ -78,7 +78,7 @@ state.save_state = function()
     io.write("midi.vport[" .. i .. "].name = '" .. midi.vport[i].name .. "'\n")
   end
   for i=1,4 do
-    io.write("grid.vport[" .. i .. "].name = '" .. grid.vport[i].name .. "'\n")
+    io.write("grid.vports[" .. i .. "].name = '" .. grid.vports[i].name .. "'\n")
   end
   for i=1,4 do
     io.write("arc.vports[" .. i .. "].name = '" .. arc.vports[i].name .. "'\n")

--- a/lua/core/state.lua
+++ b/lua/core/state.lua
@@ -75,7 +75,7 @@ state.save_state = function()
   io.write("norns.state.path = '" .. state.path .. "'\n")
   io.write("norns.state.data = '" .. state.data .. "'\n")
   for i=1,4 do
-    io.write("midi.vport[" .. i .. "].name = '" .. midi.vport[i].name .. "'\n")
+    io.write("midi.vports[" .. i .. "].name = '" .. midi.vports[i].name .. "'\n")
   end
   for i=1,4 do
     io.write("grid.vports[" .. i .. "].name = '" .. grid.vports[i].name .. "'\n")

--- a/lua/core/vport.lua
+++ b/lua/core/vport.lua
@@ -1,0 +1,27 @@
+local vport = {}
+
+function vport.wrap_method(method)
+  return function(self, ...)
+    if self.device then self.device[method](self.device, ...) end
+  end
+end
+
+function vport.get_unique_device_name(name, devices)
+  local names = {}
+
+  for _, device in pairs(devices) do
+    names[device.name] = true
+  end
+
+  local result = name
+  local suffix = 2
+
+  while names[result] ~= nil do
+    result = name.." "..suffix
+    suffix = suffix + 1
+  end
+
+  return result
+end
+
+return vport

--- a/lua/user/lib/gridbuf.lua
+++ b/lua/user/lib/gridbuf.lua
@@ -78,7 +78,7 @@ function Buffer:render(grid)
   -- TODO: use map when it's available
   for row = 1, self.height do
     for col = 1, self.width do
-      grid.led(col, row, self.grid[row][col])
+      grid:led(col, row, self.grid[row][col])
     end
   end
 end

--- a/matron/src/device/device.c
+++ b/matron/src/device/device.c
@@ -33,7 +33,7 @@ union dev *dev_new(device_t type, const char *path, const char *name) {
         };
         break;
     case DEV_TYPE_HID:
-        if (dev_hid_init(d, false) < 0) {
+        if (dev_hid_init(d) < 0) {
             goto err_init;
         }
         break;

--- a/matron/src/device/device_hid.c
+++ b/matron/src/device/device_hid.c
@@ -28,41 +28,22 @@ static void add_types(struct dev_hid *d) {
 
 static void add_codes(struct dev_hid *d) {
     struct libevdev *dev = d->dev;
-    d->num_codes = calloc( d->num_types, sizeof(int) );
-    d->codes = calloc( d->num_types, sizeof(dev_code_t *) );
-    for(int i = 0; i < d->num_types; i++) {
+    d->num_codes = calloc(d->num_types, sizeof(int));
+    d->codes = calloc(d->num_types, sizeof(dev_code_t *));
+    for (int i = 0; i < d->num_types; i++) {
         int max_codes, num_codes = 0;
         uint16_t *codes;
         int type = d->types[i];
         max_codes = libevdev_event_type_get_max(type);
-        // printf("%s: %d\n", libevdev_event_type_get_name(type), libevdev_event_type_get_max(type));
-        /*
-        switch(type) {
-        case EV_KEY:
-            max_codes = KEY_MAX;
-            break;
-        case EV_REL:
-            max_codes = REL_MAX;
-            break;
-        case EV_ABS:
-            max_codes = ABS_MAX;
-            break;
-        case EV_LED:
-            max_codes = LED_MAX;
-            break;
-        default:
-            max_codes = 0;
-        }*/
-        
-        codes = calloc( max_codes, sizeof(dev_code_t) );
-		if (max_codes > 0 ){
-        for(int code = 0; code < max_codes; code++) {
-            if( libevdev_has_event_code(dev, type, code) ) {
+        codes = calloc(max_codes, sizeof(dev_code_t));
+
+        for (int code = 0; code < max_codes; code++) {
+            if (libevdev_has_event_code(dev, type, code)) {
                 codes[num_codes++] = code;
             }
         }
-        }
-        codes = realloc( codes, num_codes * sizeof(dev_code_t) );
+
+        codes = realloc(codes, num_codes * sizeof(dev_code_t));
         d->num_codes[i] = num_codes;
         d->codes[i] = codes;
     }
@@ -155,9 +136,8 @@ void *dev_hid_start(void *self) {
 
 void dev_hid_deinit(void *self) {
     struct dev_hid *di = (struct dev_hid *)self;
-    //libevdev_free(di->dev);
     for(int i = 0; i < di->num_types; i++) {
-        TEST_NULL_AND_FREE(di->codes[i]); 
+        TEST_NULL_AND_FREE(di->codes[i]);
     }
     TEST_NULL_AND_FREE(di->codes);
     TEST_NULL_AND_FREE(di->num_codes);

--- a/matron/src/device/device_hid.c
+++ b/matron/src/device/device_hid.c
@@ -49,22 +49,7 @@ static void add_codes(struct dev_hid *d) {
     }
 }
 
-static void dev_hid_print(struct dev_hid *d) {
-    printf("%s\n", d->base.name);
-    for(int i = 0; i < d->num_types; i++) {
-        printf( "  %d : %d (%s) : \n",
-                i,
-                d->types[i],
-                libevdev_event_type_get_name(d->types[i]) );
-        for(int j = 0; j < d->num_codes[i]; j++) {
-            printf( "      %d : %d (%s)\n",
-                    j, d->codes[i][j],
-                    libevdev_event_code_get_name(d->types[i], d->codes[i][j]) );
-        }
-    }
-}
-
-int dev_hid_init(void *self, bool print) {
+int dev_hid_init(void *self) {
     struct dev_hid *d = (struct dev_hid *)self;
     struct dev_common *base = (struct dev_common *)self;
     struct libevdev *dev = NULL;
@@ -90,10 +75,9 @@ int dev_hid_init(void *self, bool print) {
     d->vid = libevdev_get_id_vendor(dev);
     d->pid = libevdev_get_id_product(dev);
 
-    if(print ) { dev_hid_print(d); }
-
-    base->start =  &dev_hid_start;
+    base->start = &dev_hid_start;
     base->deinit = &dev_hid_deinit;
+
     return 0;
 }
 

--- a/matron/src/device/device_hid.c
+++ b/matron/src/device/device_hid.c
@@ -34,6 +34,9 @@ static void add_codes(struct dev_hid *d) {
         int max_codes, num_codes = 0;
         uint16_t *codes;
         int type = d->types[i];
+        max_codes = libevdev_event_type_get_max(type);
+        // printf("%s: %d\n", libevdev_event_type_get_name(type), libevdev_event_type_get_max(type));
+        /*
         switch(type) {
         case EV_KEY:
             max_codes = KEY_MAX;
@@ -49,13 +52,15 @@ static void add_codes(struct dev_hid *d) {
             break;
         default:
             max_codes = 0;
-        }
+        }*/
+        
         codes = calloc( max_codes, sizeof(dev_code_t) );
-
+		if (max_codes > 0 ){
         for(int code = 0; code < max_codes; code++) {
             if( libevdev_has_event_code(dev, type, code) ) {
                 codes[num_codes++] = code;
             }
+        }
         }
         codes = realloc( codes, num_codes * sizeof(dev_code_t) );
         d->num_codes[i] = num_codes;
@@ -150,8 +155,9 @@ void *dev_hid_start(void *self) {
 
 void dev_hid_deinit(void *self) {
     struct dev_hid *di = (struct dev_hid *)self;
+    //libevdev_free(di->dev);
     for(int i = 0; i < di->num_types; i++) {
-        TEST_NULL_AND_FREE(di->codes[i]);
+        TEST_NULL_AND_FREE(di->codes[i]); 
     }
     TEST_NULL_AND_FREE(di->codes);
     TEST_NULL_AND_FREE(di->num_codes);

--- a/matron/src/device/device_hid.h
+++ b/matron/src/device/device_hid.h
@@ -26,6 +26,6 @@ struct dev_hid {
     dev_code_t **codes;
 };
 
-extern int dev_hid_init(void *self, bool print);
+extern int dev_hid_init(void *self);
 extern void *dev_hid_start(void *self);
 extern void dev_hid_deinit(void *self);

--- a/matron/src/device/device_list.c
+++ b/matron/src/device/device_list.c
@@ -115,7 +115,7 @@ void dev_list_remove(device_t type, const char *node) {
     }
     event_post(ev);
 
-    if(dq.head == dn) { dq.head = NULL; }
+    if(dq.head == dn) { dq.head = dn->next; }
     if(dq.tail == dn) { dq.tail = dn->prev; }
     remque(dn);
     dq.size--;

--- a/matron/src/weaver.c
+++ b/matron/src/weaver.c
@@ -1428,7 +1428,9 @@ void w_handle_hid_add(void *p) {
     }
     lua_rawseti(lvm, -2, i + 1);
   }
-  l_report(lvm, l_docall(lvm, 4, 0));
+
+  lua_pushlightuserdata(lvm, dev);
+  l_report(lvm, l_docall(lvm, 5, 0));
 }
 
 void w_handle_hid_remove(int id) {


### PR DESCRIPTION
input/output API changes:

- use colon syntax when sending data to peripheral devices (`g:led`, not `g.led`)
- use dot syntax for now when assigning callbacks (`g.key = function(x, y, s) ... end`)
- `grid.event` has been renamed to `grid.key`

hid usage example:
```
local point_x = 0
local point_y = 0

h = hid.connect(2)

hid.event = function(type, code, value)
  if type == hid.types.EV_REL then
    if code == hid.codes.REL_X then
      point_x = point_x + value
    elseif code == hid.codes.REL_Y then
      point_y = point_y + value
    end

    print(point_x, point_y)
  end
end
```