### PR TITLE
add delta/key function nil check

### DIFF
--- a/lua/core/arc.lua
+++ b/lua/core/arc.lua
@@ -200,7 +200,9 @@ norns.arc.delta = function(id, n, delta)
     end
 
     if device.port then
-      Arc.vports[device.port].delta(n, delta)
+      if Arc.vports[device.port].delta then
+        Arc.vports[device.port].delta(n, delta)
+      end
     end
   else
     error('no entry for arc '..id)
@@ -216,7 +218,9 @@ norns.arc.key = function(id, n, s)
     end
 
     if device.port then
-      Arc.vports[device.port].key(n, s)
+      if Arc.vports[device.port].key then
+        Arc.vports[device.port].key(n, s)
+      end
     end
   else
     error('no entry for arc '..id)


### PR DESCRIPTION
otherwise a bunch of nil errors are thrown (trying to execute a nil function) when the functions are initially undefined. of course the user script should redefine them, but this will help avoid confusion.

we could alternatively define these functions as `function() end` instead of `nil`. there's a helper function `norns.none` that is a nil function, but this should really be renamed and moved (so probably not used)

similar fixes possibly needed with grid/midi/etc?