### PR TITLE
dust data folders

### DIFF
--- a/lua/core/menu.lua
+++ b/lua/core/menu.lua
@@ -337,7 +337,7 @@ local function build_select_tree(root,dir)
 
   for _,v in pairs(c) do
     --print("---- " .. v)
-    if v == "data/" or v == "lib/" or v == "audio/" or v == 'lib/' then
+    if v == "data/" or v == "audio/" or v == 'lib/' then
       --print(".")
     elseif string.find(v,'/') then
       build_select_tree(p,v)
@@ -506,7 +506,7 @@ m.key[pPARAMS] = function(n,z)
     if not m.params.midimap then
       if params.count > 0 then
         if params:t(m.params.pos+1) == params.tFILE then
-          fileselect.enter(os.getenv("HOME").."/dust", m.params.newfile)
+          fileselect.enter(dust_dir, m.params.newfile)
         elseif params:t(m.params.pos+1) == params.tTRIGGER then
           params:set(m.params.pos+1)
           m.params.triggered[m.params.pos+1] = 2
@@ -536,10 +536,10 @@ m.enc[pPARAMS] = function(n,d)
         local path
         local f
         if m.params.n == 0 then
-          path = norns.state.path..'/data/'..norns.state.shortname..".pset"
+          path = norns.state.data .. norns.state.shortname..".pset"
           f=io.open(path,"r")
         else
-          path = norns.state.path..'/data/'..norns.state.shortname.."-"..string.format("%02d",m.params.n)..".pset"
+          path = norns.state.data .. norns.state.shortname.."-"..string.format("%02d",m.params.n)..".pset"
           f=io.open(path ,"r")
         end
         --print("pset: "..path)
@@ -714,7 +714,7 @@ function m.params.write_pmap(filename)
     io.close(fd)
   else
     print(">> creating subfolder")
-    os.execute("mkdir " .. dir)
+    util.make_dir(dir)
   end
 
   -- write file

--- a/lua/core/paramset.lua
+++ b/lua/core/paramset.lua
@@ -194,23 +194,28 @@ function ParamSet:lookup_param(index)
   end
 end
 
+--- init local psets
+-- make data dir if needed
+-- if psets are contained in project folder, copy them to local folder
+function ParamSet:init()
+  if norns.state.data ~= data_dir then
+    if util.file_exists(norns.state.data) == false then
+      print("pset >> initializing data folder")
+      util.make_dir(norns.state.data)
+      -- copy project contents
+    end
+  end
+end
+
 --- write to disk
 -- @param filename relative to data_dir
 function ParamSet:write(filename)
-  print("pset/write > " .. filename)
-  local dir = norns.state.path .. 'data'
+  self.init()
+  local dir = norns.state.data
   if filename == "system.pset" then dir = data_dir end -- hack for system.pset
-  -- check for subfolder
-  local fd = io.open(dir,"r")
-  if fd then
-    io.close(fd)
-  else
-    print(">> creating subfolder")
-    os.execute("mkdir " .. dir)
-  end
   -- write file
-  local file = dir..'/'..filename
-  print(">>>> "..file)
+  local file = dir .. filename
+  print("pset >> write: "..file)
   local fd = io.open(file, "w+")
   io.output(fd)
   for k,param in pairs(self.params) do
@@ -224,9 +229,11 @@ end
 --- read from disk
 -- @param filename relative to data_dir
 function ParamSet:read(filename)
-  local dir = norns.state.path .. 'data'
-  local file = dir .. '/' .. filename
-  print("pset/read > " .. file)
+  self.init()
+  local dir = norns.state.data
+  if filename == "system.pset" then dir = data_dir end -- hack for system.pset
+  local file = dir .. filename
+  print("pset >> read: " .. file)
   local fd = io.open(file, "r")
   if fd then
     io.close(fd)
@@ -251,7 +258,7 @@ function ParamSet:read(filename)
       end
     end
   else
-    print("paramset: "..filename.." not read.")
+    print("pset :: "..filename.." not read.")
   end
 end
 

--- a/lua/core/paramset.lua
+++ b/lua/core/paramset.lua
@@ -203,6 +203,11 @@ function ParamSet:init()
       print("pset >> initializing data folder")
       util.make_dir(norns.state.data)
       -- copy project contents
+      local project_data = norns.state.path .. 'data/'
+      if util.file_exists(project_data) then
+        print("pset >> copying default project data")
+        os.execute("cp " .. project_data .. "*.pset " .. norns.state.data)
+      end
     end
   end
 end

--- a/lua/core/script.lua
+++ b/lua/core/script.lua
@@ -84,6 +84,7 @@ Script.load = function(filename,name,path)
     name = norns.state.name
     shortname = norns.state.name:match("([^/]+)$")
     path = norns.state.path
+    data = norns.state.data
   end
 
   print("# script load: " .. filename)
@@ -114,6 +115,7 @@ Script.load = function(filename,name,path)
     if status == true then
       norns.state.script = filename
       norns.state.path = path
+      norns.state.data = data_dir .. name .. '/'
       norns.state.name = name
       norns.state.shortname = norns.state.name:match( "([^/]+)$" )
       norns.state.save() -- remember this script for next launch

--- a/lua/core/state.lua
+++ b/lua/core/state.lua
@@ -5,6 +5,7 @@ state = {}
 state.tape = 0
 state.script = ''
 state.path = dust_dir
+state.data = data_dir
 state.name = ''
 state.shortname = ''
 state.clean_shutdown = false
@@ -16,10 +17,10 @@ state.resume = function()
   mix:bang()
 
   -- restore state object
-  local f = io.open(dust_dir..'system.state')
+  local f = io.open(data_dir..'system.state')
   if f ~= nil then
     io.close(f)
-    dofile(dust_dir..'system.state')
+    dofile(data_dir..'system.state')
   end
 
   -- update vports
@@ -47,6 +48,7 @@ state.resume = function()
     state.name = 'none'
     state.shortname = 'none'
     state.path = dust_dir
+    state.data = data_dir
     norns.scripterror("NO SCRIPT")
   end
 end
@@ -62,7 +64,7 @@ state.save_mix = function()
 end
 
 state.save_state = function()
-  local fd=io.open(dust_dir .. "system.state","w+")
+  local fd=io.open(data_dir .. "system.state","w+")
   io.output(fd)
   io.write("-- norns system state\n")
   io.write("norns.state.clean_shutdown = " .. (state.clean_shutdown and "true" or "false") .. "\n")
@@ -71,6 +73,7 @@ state.save_state = function()
   io.write("norns.state.name = '" .. state.name .. "'\n")
   io.write("norns.state.shortname = '" .. state.shortname .. "'\n")
   io.write("norns.state.path = '" .. state.path .. "'\n")
+  io.write("norns.state.data = '" .. state.data .. "'\n")
   for i=1,4 do
     io.write("midi.vport[" .. i .. "].name = '" .. midi.vport[i].name .. "'\n")
   end

--- a/lua/user/lib/util.lua
+++ b/lua/user/lib/util.lua
@@ -31,6 +31,26 @@ util.scandir = function(directory)
   return t
 end
 
+--- check if file exists
+-- @param filepath
+-- @return true/false
+util.file_exists = function(name)
+  local f=io.open(name,"r")
+  if f~=nil then
+    io.close(f)
+    return true
+  else
+    return false
+  end
+end
+
+--- make directory (with parents as needed)
+-- @param path
+util.make_dir = function(path)
+  os.execute("mkdir -p " .. path)
+end
+
+
 --- execute os command, capture output
 -- @param cmd command
 -- @param raw raw output (omit for scrubbed)


### PR DESCRIPTION
- auto-create `dust/data/(script)` when needed
- auto-copy "preset data" `dust/script/data` to "local data" `dust/data/`

basically the new system distinguishes "project" data from "local" data. think of it as default presets. so a project (git repo usually) can include a bunch of default pset data that then gets copied to the local data folder on first run.

future: restore default pset function? (or just copy stuff with sftp)