### PR TITLE
remove reconnect stub from input devices

### DIFF
--- a/lua/core/arc.lua
+++ b/lua/core/arc.lua
@@ -69,9 +69,6 @@ function Arc.add(dev)
   print("arc added:", dev.id, dev.name, dev.serial)
 end
 
---- scan device list and grab one, redefined later
-function Arc.reconnect() end
-
 --- static callback when any arc device is removed;
 -- user scripts can redefine
 -- @param dev : a Arc table

--- a/lua/core/arc.lua
+++ b/lua/core/arc.lua
@@ -146,6 +146,13 @@ function Arc.cleanup()
     Arc.vports[i].delta = nil
     Arc.vports[i].key = nil
   end
+
+  for _, dev in pairs(Arc.devices) do
+    dev:all(0)
+    dev:refresh()
+    dev.delta = nil
+    dev.key = nil
+  end
 end
 
 function Arc.update_devices()

--- a/lua/core/grid.lua
+++ b/lua/core/grid.lua
@@ -72,9 +72,6 @@ function Grid.add(dev)
   print("grid added:", dev.id, dev.name, dev.serial)
 end
 
---- scan device list and grab one, redefined later
-function Grid.reconnect() end
-
 --- static callback when any grid device is removed;
 -- user scripts can redefine
 -- @param dev : a Grid table

--- a/lua/core/grid.lua
+++ b/lua/core/grid.lua
@@ -114,6 +114,12 @@ function Grid.cleanup()
   for i=1,4 do
     Grid.vports[i].key = nil
   end
+
+  for _, dev in pairs(Grid.devices) do
+    dev:all(0)
+    dev:refresh()
+    dev.key = nil
+  end
 end
 
 function Grid.update_devices()

--- a/lua/core/hid.lua
+++ b/lua/core/hid.lua
@@ -84,6 +84,10 @@ function Hid.cleanup()
   for i=1,4 do
     Hid.vports[i].event = nil
   end
+
+  for _, dev in pairs(Hid.devices) do
+    dev.event = nil
+  end
 end
 
 function Hid.update_devices()

--- a/lua/core/hid.lua
+++ b/lua/core/hid.lua
@@ -66,9 +66,6 @@ function Hid.add(dev)
   print("hid added:", dev.id, dev.name)
 end
 
---- scan device list and grab one, redefined later
-function Hid.reconnect() end
-
 --- static callback when any hid device is removed;
 -- user scripts can redefine
 -- @param dev : a Hid table

--- a/lua/core/midi.lua
+++ b/lua/core/midi.lua
@@ -144,6 +144,10 @@ function Midi.cleanup()
   for i=1,4 do
     Midi.vports[i].event = nil
   end
+
+  for _, dev in pairs(Midi.devices) do
+    dev.event = nil
+  end
 end
 
 -- utility

--- a/lua/core/midi.lua
+++ b/lua/core/midi.lua
@@ -74,10 +74,6 @@ function Midi.add(dev) end
 -- @param dev : a Midi table
 function Midi.remove(dev) end
 
---- call add() for currently available devices
--- when scripts are restarted
-function Midi.reconnect() end
-
 --- send midi event to device
 -- @param array
 function Midi:send(data)

--- a/lua/core/script.lua
+++ b/lua/core/script.lua
@@ -18,25 +18,10 @@ Script.clear = function()
   key = norns.none
   enc = norns.none
 
-  -- clear, redirect, and reset grids
-  for _,dev in pairs(grid.devices) do
-    dev:all(0)
-    dev:refresh()
-    dev.key = norns.none
-  end
+  -- clear, redirect, and reset devices
   grid.cleanup()
-
-   -- clear, redirect, and reset arcs
-  for _, dev in pairs(arc.devices) do
-    dev:all(0)
-    dev:refresh()
-  end
   arc.cleanup()
-
-  -- clear, redirect, and reset midi
   midi.cleanup()
-
-  -- clear, redirect, and reset hid
   hid.cleanup()
 
   -- stop all timers

--- a/lua/core/script.lua
+++ b/lua/core/script.lua
@@ -71,10 +71,6 @@ Script.init = function()
   params.name = norns.state.shortname
   init()
   s_save()
-  grid.reconnect()
-  midi.reconnect()
-  arc.reconnect()
-  hid.reconnect()
 end
 
 --- load a script from the /scripts folder

--- a/lua/core/script.lua
+++ b/lua/core/script.lua
@@ -7,13 +7,17 @@ local Script = {}
 -- ie redirect draw, key, enc functions, stop timers, clear engine, etc
 Script.clear = function()
   print("# script clear")
+
   -- reset cleanup script
   cleanup = norns.none
+
   -- reset oled redraw
   redraw = norns.blank
+
   -- redirect inputs to nowhere
   key = norns.none
   enc = norns.none
+
   -- clear, redirect, and reset grids
   for _,dev in pairs(grid.devices) do
     dev:all(0)
@@ -21,47 +25,54 @@ Script.clear = function()
     dev.key = norns.none
   end
   grid.cleanup()
+
    -- clear, redirect, and reset arcs
   for _, dev in pairs(arc.devices) do
     dev:all(0)
     dev:refresh()
   end
   arc.cleanup()
-  --g = nil
-  -- reset gridkey callback
-  --gridkey = norns.none
-  -- reset midi callbacks
-  midi.add = norns.none
-  midi.remove = norns.none
-  for _,dev in pairs(midi.devices) do
-    dev.event = norns.none
-  end
+
+  -- clear, redirect, and reset midi
   midi.cleanup()
+
+  -- clear, redirect, and reset hid
+  hid.cleanup()
+
   -- stop all timers
   metro.free_all()
+
   -- stop all polls and clear callbacks
   poll.clear_all()
+
   -- clear engine
   engine.name = nil
   free_engine()
+
   -- clear init
   init = norns.none
+
   -- clear last run
   norns.state.script = ''
   norns.state.name = 'none'
   norns.state.shortname = 'none'
   norns.state.path = dust_dir
+
   -- clear params
   params:clear()
+
   -- reset PLAY mode screen settings
   local status = norns.menu.status()
   if status == true then s_restore() end
+
   screen.aa(0)
   screen.level(15)
   screen.line_width(1)
   screen.font_face(0)
   screen.font_size(8)
+
   if status == true then s_save() end
+
   -- ensure finalizers run before next script
   collectgarbage()
 end
@@ -152,7 +163,7 @@ Script.metadata = function(filename)
         table.insert(meta, string.sub(line,4,-1))
       else return meta end
     end
-    if #meta == 0 then 
+    if #meta == 0 then
       table.insert(meta, "no script information")
     end
   end


### PR DESCRIPTION
reconnect shouldn't be used with vports and its functionality is redundant for scripts that want to use devices directly, hence we can safely remove it.