### PR TITLE
Crone osx picked

### DIFF
--- a/crone/CMakeLists.txt
+++ b/crone/CMakeLists.txt
@@ -4,10 +4,6 @@ project(crone VERSION 1.0.0)
 
 set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
 
-# debug..
-# set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -O0")
-
-# release
 set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O2")
 
 set (SRC src/main.cpp
@@ -35,11 +31,24 @@ add_executable(crone ${SRC})
 
 include_directories(./faust)
 
-target_link_libraries(crone lo)
-target_link_libraries(crone jack)
-target_link_libraries(crone pthread)
-target_link_libraries(crone asound)
-target_link_libraries(crone sndfile)
+if(UNIX)
+    if(APPLE)
+        find_library(lo_lib liblo.dylib REQUIRED)
+        find_library(sndfile_lib libsndfile.a REQUIRED)
+        find_library(jack_lib libjack.dylib REQUIRED)
+        target_link_libraries(crone ${lo_lib} ${sndfile_lib} ${jack_lib})
+        include_directories(/usr/local/include)
+    else()
+        target_link_libraries(crone lo)
+        target_link_libraries(crone jack)
+        target_link_libraries(crone pthread)
+        target_link_libraries(crone asound)
+        target_link_libraries(crone sndfile)
+    endif()
+else()
+    # nope
+endif()
+
 
 set_target_properties(crone PROPERTIES
 CXX_STANDARD 14

--- a/crone/readme-macos.md
+++ b/crone/readme-macos.md
@@ -1,0 +1,17 @@
+` crone` can now be built and run as a native JACK client application on mac OS. this has been tested on Mojave (10.14.2).
+
+ note that there are a number of warnings when building with clang. these are pretty trivial (of the "unused variable" variety, from the Faust stack) and shouldn't cause any harm.
+
+## requirements
+-  JACK 2.0 server, 
+http://jackaudio.org/downloads/
+ 
+- i'm not actually sure if that installs development 
+
+- `boost` and `liblo`, from homebrew
+
+- `libsndfile`. with the homebrew version, i had difficulty linking ogg/vorbis/FLAC support, so ended up compiling this from source:
+  - clone from here: https://github.com/erikd/libsndfile 
+  - build and install using cmake with `-DENABLE_EXTERNAL_LIBS=OFF`
+  
+  


### PR DESCRIPTION
re-do of #707. allows hacking on `crone` if you're stuck with macOS.