### PR TITLE
Don't fire triggers when calling bang() on ParamSet

### DIFF
--- a/lua/paramset.lua
+++ b/lua/paramset.lua
@@ -254,7 +254,9 @@ end
 --- bang all params
 function ParamSet:bang()
   for k,v in pairs(self.params) do
-    v:bang()
+    if v.t ~= self.tTRIGGER then
+      v:bang()
+    end
   end
 end
 


### PR DESCRIPTION
Tiny improvement to how trigger params are handled - skips calling bang() on triggers when bang() is called on all params. Think this makes more sense.