### PR TITLE
fix gcc new -Wstringop-truncation warning

### DIFF
--- a/matron/src/args.c
+++ b/matron/src/args.c
@@ -21,10 +21,10 @@ int args_parse(int argc, char **argv)
     while( ( opt = getopt(argc, argv, "r:l:m:") ) != -1 ) {
         switch(opt) {
         case 'l':
-            strncpy(a.loc_port, optarg, ARG_BUF_SIZE);
+            strncpy(a.loc_port, optarg, ARG_BUF_SIZE-1);
             break;
         case 'r':
-            strncpy(a.rem_port, optarg, ARG_BUF_SIZE);
+            strncpy(a.rem_port, optarg, ARG_BUF_SIZE-1);
             break;
         default:
             ;;


### PR DESCRIPTION
gcc 8.2.1 throws a warning here, which is blocking the build on my machine...

I guess the reason for this is as follows: max string length in N bytes (as per strncpy) is N-1 because the terminating '0' char at the end doesn't count as part of the string.  This snippet shows the problem:

https://gist.github.com/ranch-verdin/f8d26395a7d5cf89cc60f8cbd4262aa1

The warning actually only shows when you use -O3, which looks to me like a gcc bug!  (minimal test case exhibits a bug with or without -O3)