### PR TITLE
Add display png function

### DIFF
--- a/lua/core/screen.lua
+++ b/lua/core/screen.lua
@@ -199,6 +199,11 @@ s_circle = function(x, y, r)
   s_arc(x, y, r, 0, math.pi*2)
 end
 
+--- display png
+-- @param filename
+-- @param x x position
+-- @param y y position
+Screen.display_png = function(filename,x,y) s_display_png(filename,x,y) end
 
 
 return Screen

--- a/matron/src/hardware/screen.c
+++ b/matron/src/hardware/screen.c
@@ -32,6 +32,8 @@ static float c[16] =
 
 static cairo_surface_t *surface;
 static cairo_surface_t *surfacefb;
+static cairo_surface_t *image;
+
 static cairo_t *cr;
 static cairo_t *crfb;
 static cairo_font_face_t *ct[NUM_FONTS];
@@ -134,8 +136,26 @@ handle_allocate_error:
     return NULL;
 }
 
+void screen_display_png(const char *filename, double x, double y){
+	int img_w, img_h;
+	//fprintf(stderr, "loading: %s\n", filename);
+	
+	image = cairo_image_surface_create_from_png (filename);
+	if(image == NULL) { return; }
+	
+	img_w = cairo_image_surface_get_width (image);
+	img_h = cairo_image_surface_get_height (image);
+
+	cairo_set_source_surface (cr, image, x, y);
+	//cairo_paint (cr);
+	cairo_rectangle (cr, x, y, img_w, img_h);
+	cairo_fill (cr);
+	cairo_surface_destroy (image);
+}
+
+
 void screen_init(void) {
-    surfacefb = cairo_linuxfb_surface_create("/dev/fb0");
+    surfacefb = cairo_linuxfb_surface_create("/dev/fb1");
     if(surfacefb == NULL) { return; }
     crfb = cairo_create(surfacefb);
 
@@ -365,9 +385,12 @@ double *screen_extents(const char *s) {
     return text_xy;
 }
 
+
 extern void screen_export_png(const char *s) {
     CHECK_CR
     cairo_surface_write_to_png(surface, s);
 }
+
+
 #undef CHECK_CR
 #undef CHECK_CRR

--- a/matron/src/hardware/screen.c
+++ b/matron/src/hardware/screen.c
@@ -155,7 +155,7 @@ void screen_display_png(const char *filename, double x, double y){
 
 
 void screen_init(void) {
-    surfacefb = cairo_linuxfb_surface_create("/dev/fb1");
+    surfacefb = cairo_linuxfb_surface_create("/dev/fb0");
     if(surfacefb == NULL) { return; }
     crfb = cairo_create(surfacefb);
 

--- a/matron/src/hardware/screen.h
+++ b/matron/src/hardware/screen.h
@@ -41,4 +41,4 @@ extern void screen_clear(void);
 extern void screen_close_path(void);
 extern double *screen_extents(const char *s);
 extern void screen_export_png(const char *s);
-
+extern void screen_display_png(const char *filename, double x, double y);

--- a/matron/src/weaver.c
+++ b/matron/src/weaver.c
@@ -95,6 +95,7 @@ static int _screen_clear(lua_State *l);
 static int _screen_close(lua_State *l);
 static int _screen_extents(lua_State *l);
 static int _screen_export_png(lua_State *l);
+static int _screen_display_png(lua_State *l);
 //i2c
 static int _gain_hp(lua_State *l);
 //osc
@@ -314,6 +315,7 @@ void w_init(void) {
   lua_register(lvm, "s_close", &_screen_close);
   lua_register(lvm, "s_extents", &_screen_extents);
   lua_register(lvm, "s_export_png", &_screen_export_png);
+  lua_register(lvm, "s_display_png", &_screen_display_png);
 
   // analog output control
   lua_register(lvm, "gain_hp", &_gain_hp);
@@ -843,6 +845,24 @@ int _screen_export_png(lua_State *l) {
 
   const char *s = luaL_checkstring(l, 1);
   screen_export_png(s);
+  lua_settop(l, 0);
+  return 0;
+}
+
+/***
+ * screen: display_png
+ * @function s_display_png
+ * @tparam string filename
+ */
+int _screen_display_png(lua_State *l) {
+  if (lua_gettop(l) != 3) {
+    return luaL_error(l, "wrong number of arguments");
+  }
+
+  const char *s = luaL_checkstring(l, 1);
+  double x = luaL_checknumber(l, 2);
+  double y = luaL_checknumber(l, 3);
+  screen_display_png(s, x, y);
   lua_settop(l, 0);
   return 0;
 }


### PR DESCRIPTION
Cairo screen function to load png files to the display.

lua syntax: `screen.display_png(filename, x, y)`

@artfwo suggested this should probably be two functions (one for load and one for display). However I won't have time to get back to this for a few days so I thought I'd submit it now for basic functionality.