### PR TITLE
encoder soft fix

### DIFF
--- a/matron/src/hardware/gpio.c
+++ b/matron/src/hardware/gpio.c
@@ -101,9 +101,9 @@ void *enc_check(void *x) {
           if(event[i].type) { // make sure it's not EV_SYN == 0
             now[i] = clock();
             diff = now[i] - prev[i];
-            fprintf(stderr, "%d\t%d\t%lu\n", n, event[i].value, diff);
+            //fprintf(stderr, "%d\t%d\t%lu\n", n, event[i].value, diff);
             prev[i] = now[i];
-            if(diff > 150) { // filter out glitches
+            if(diff > 100) { // filter out glitches
               if(dir[i] != event[i].value && diff > 500) { // only reverse direction if there is reasonable settling time
                 dir[i] = event[i].value;
               }

--- a/matron/src/hardware/gpio.c
+++ b/matron/src/hardware/gpio.c
@@ -13,6 +13,7 @@
 #include <stdlib.h>
 #include <pthread.h>
 #include <linux/input.h>
+#include <time.h>
 
 #include "events.h"
 
@@ -84,6 +85,11 @@ void *enc_check(void *x) {
     int rd;
     unsigned int i;
     struct input_event event[64];
+    int dir[3] = {1,1,1};
+    clock_t now[3];
+    clock_t prev[3];
+    clock_t diff;
+    prev[0] = prev[1] = prev[2] = clock();
 
     while(1) {
         rd = read(enc_fd[n], event, sizeof(struct input_event) * 64);
@@ -92,13 +98,21 @@ void *enc_check(void *x) {
         }
 
         for(i=0;i<rd/sizeof(struct input_event);i++) {
-            if(event[i].type) { // make sure it's not EV_SYN == 0
-                //fprintf(stderr, "enc%d = %d\n", n, event[i].value);
-                union event_data *ev = event_data_new(EVENT_ENC);
-                ev->enc.n = n + 1;
-                ev->enc.delta = event[i].value;
-                event_post(ev);
+          if(event[i].type) { // make sure it's not EV_SYN == 0
+            now[i] = clock();
+            diff = now[i] - prev[i];
+            fprintf(stderr, "%d\t%d\t%lu\n", n, event[i].value, diff);
+            prev[i] = now[i];
+            if(diff > 150) { // filter out glitches
+              if(dir[i] != event[i].value && diff > 500) { // only reverse direction if there is reasonable settling time
+                dir[i] = event[i].value;
+              }
+              union event_data *ev = event_data_new(EVENT_ENC);
+              ev->enc.n = n + 1;
+              ev->enc.delta = event[i].value;
+              event_post(ev);
             }
+          }
         }
     } 
 }


### PR DESCRIPTION
unfortunately discovered that the encoders might develop problems over time due to assembly method.

symptom: pulses are noisy, so the encoder overlay might translate them a bursts of values which may also flip direction.

this PR adds debouncing. it checks for faster-than-possible rotation ticks and for reversals of direction at physically-impossible rates. magic numbers determined by trial and error on hardware.

i welcome any suggestions on improving this algo. 