### PR TITLE
Remove redundant restarts

### DIFF
--- a/lua/core/menu.lua
+++ b/lua/core/menu.lua
@@ -1146,8 +1146,6 @@ elseif n==3 and z==1 then
     if pcall(cleanup) == false then print("cleanup failed") end
 
     os.execute("sudo systemctl restart norns-jack.service")
-    os.execute("sudo systemctl restart norns-crone.service")
-    os.execute("sudo systemctl restart norns-sclang.service")
     os.execute("sudo systemctl restart norns-matron.service")
   end
 end

--- a/lua/core/menu.lua
+++ b/lua/core/menu.lua
@@ -975,10 +975,10 @@ m.key[pWIFI] = function(n,z)
       listselect.enter(wifi.conn_list, m.wifi.connect)
     elseif m.wifi.pos == 3 then
       wifi.update()
-      listselect.enter(m.wifi.ssid_list, m.wifi.add) 
+      listselect.enter(m.wifi.ssid_list, m.wifi.add)
     elseif m.wifi.pos == 4 then
       wifi.update()
-      listselect.enter(wifi.conn_list, m.wifi.del) 
+      listselect.enter(wifi.conn_list, m.wifi.del)
     end
   end
 end
@@ -1393,7 +1393,7 @@ m.key[pTAPE] = function(n,z)
             tape_play_counter.time = 0.25
             tape_play_counter.event = function()
               m.tape.play.pos_tick = m.tape.play.pos_tick + 0.25
-              if m.tape.play.pos_tick > m.tape.play.length 
+              if m.tape.play.pos_tick > m.tape.play.length
                   and m.tape.play.status == TAPE_PLAY_PLAY then
                 print("tape is over!")
                 audio.tape_play_stop()
@@ -1532,5 +1532,3 @@ m.init[pTAPE] = function()
   tape_diskfree()
 end
 m.deinit[pTAPE] = norns.none
-
-


### PR DESCRIPTION
Service state changes before this change when executing `reset` via the menu:
```
Mar 08 23:52:03 norns systemd[1]: plymouth-read-write.service: Cannot add dependency job, ignoring: Unit plymouth-read-write.service is masked.
Mar 08 23:52:03 norns systemd[1]: plymouth-start.service: Cannot add dependency job, ignoring: Unit plymouth-start.service is masked.
Mar 08 23:52:03 norns systemd[1]: Stopped target norns.
Mar 08 23:52:03 norns systemd[1]: Stopping norns.
Mar 08 23:52:03 norns systemd[1]: Starting norns-init...
Mar 08 23:52:03 norns systemd[1]: Stopping norns-sclang.service...
Mar 08 23:52:03 norns systemd[1]: Stopping norns-crone.service...
Mar 08 23:52:03 norns systemd[1]: Started norns-init.
Mar 08 23:52:03 norns systemd[1]: Stopped norns-sclang.service.
Mar 08 23:52:03 norns systemd[1]: Stopped norns-crone.service.
Mar 08 23:52:03 norns systemd[1]: Stopping norns-jack.service...
Mar 08 23:52:03 norns systemd[1]: Stopped norns-jack.service.
Mar 08 23:52:03 norns systemd[1]: Starting norns-jack.service...
Mar 08 23:52:06 norns systemd[1]: Started norns-jack.service.
Mar 08 23:52:06 norns systemd[1]: Started norns-crone.service.
Mar 08 23:52:06 norns systemd[1]: Started norns-sclang.service.
Mar 08 23:52:06 norns systemd[1]: Reached target norns.
Mar 08 23:52:06 norns systemd[1]: plymouth-read-write.service: Cannot add dependency job, ignoring: Unit plymouth-read-write.service is masked.
Mar 08 23:52:06 norns systemd[1]: plymouth-start.service: Cannot add dependency job, ignoring: Unit plymouth-start.service is masked.
Mar 08 23:52:06 norns systemd[1]: Stopped target norns.
Mar 08 23:52:06 norns systemd[1]: Stopping norns.
Mar 08 23:52:06 norns systemd[1]: Stopping norns-crone.service...
Mar 08 23:52:06 norns systemd[1]: Starting norns-init...
Mar 08 23:52:06 norns systemd[1]: Stopped norns-crone.service.
Mar 08 23:52:06 norns systemd[1]: Started norns-crone.service.
Mar 08 23:52:06 norns systemd[1]: Started norns-init.
Mar 08 23:52:06 norns systemd[1]: Reached target norns.
Mar 08 23:52:06 norns systemd[1]: plymouth-read-write.service: Cannot add dependency job, ignoring: Unit plymouth-read-write.service is masked.
Mar 08 23:52:06 norns systemd[1]: plymouth-start.service: Cannot add dependency job, ignoring: Unit plymouth-start.service is masked.
Mar 08 23:52:06 norns systemd[1]: Stopped target norns.
Mar 08 23:52:06 norns systemd[1]: Stopping norns.
Mar 08 23:52:06 norns systemd[1]: Starting norns-init...
Mar 08 23:52:06 norns systemd[1]: Stopping norns-sclang.service...
Mar 08 23:52:06 norns systemd[1]: Stopped norns-sclang.service.
Mar 08 23:52:06 norns systemd[1]: Started norns-sclang.service.
Mar 08 23:52:06 norns systemd[1]: Started norns-init.
Mar 08 23:52:06 norns systemd[1]: Reached target norns.
Mar 08 23:52:06 norns systemd[1]: plymouth-read-write.service: Cannot add dependency job, ignoring: Unit plymouth-read-write.service is masked.
Mar 08 23:52:06 norns systemd[1]: plymouth-start.service: Cannot add dependency job, ignoring: Unit plymouth-start.service is masked.
Mar 08 23:52:06 norns systemd[1]: Stopped target norns.
Mar 08 23:52:06 norns systemd[1]: Stopping norns.
Mar 08 23:52:06 norns systemd[1]: Starting norns-init...
Mar 08 23:52:06 norns systemd[1]: Stopping norns-matron.service...
Mar 08 23:52:06 norns systemd[1]: Started norns-init.
Mar 08 23:52:06 norns systemd[1]: Stopped norns-matron.service.
Mar 08 23:52:06 norns systemd[1]: Started norns-matron.service.
Mar 08 23:52:06 norns systemd[1]: Reached target norns.
```

Service state changes after this change when executing `reset` via the menu:
```
Mar 08 23:48:32 norns systemd[1]: plymouth-read-write.service: Cannot add dependency job, ignoring: Unit plymouth-read-write.service is masked.
Mar 08 23:48:32 norns systemd[1]: plymouth-start.service: Cannot add dependency job, ignoring: Unit plymouth-start.service is masked.
Mar 08 23:48:32 norns systemd[1]: Stopped target norns.
Mar 08 23:48:32 norns systemd[1]: Stopping norns.
Mar 08 23:48:32 norns systemd[1]: Starting norns-init...
Mar 08 23:48:32 norns systemd[1]: Stopping norns-sclang.service...
Mar 08 23:48:32 norns systemd[1]: Stopping norns-crone.service...
Mar 08 23:48:32 norns systemd[1]: Started norns-init.
Mar 08 23:48:32 norns systemd[1]: Stopped norns-sclang.service.
Mar 08 23:48:32 norns systemd[1]: Stopped norns-crone.service.
Mar 08 23:48:32 norns systemd[1]: Stopping norns-jack.service...
Mar 08 23:48:32 norns systemd[1]: Stopped norns-jack.service.
Mar 08 23:48:32 norns systemd[1]: Starting norns-jack.service...
Mar 08 23:48:34 norns systemd[1]: Started norns-jack.service.
Mar 08 23:48:34 norns systemd[1]: Started norns-crone.service.
Mar 08 23:48:34 norns systemd[1]: Started norns-sclang.service.
Mar 08 23:48:34 norns systemd[1]: Reached target norns.
Mar 08 23:48:34 norns systemd[1]: plymouth-read-write.service: Cannot add dependency job, ignoring: Unit plymouth-read-write.service is masked.
Mar 08 23:48:34 norns systemd[1]: plymouth-start.service: Cannot add dependency job, ignoring: Unit plymouth-start.service is masked.
Mar 08 23:48:34 norns systemd[1]: Stopped target norns.
Mar 08 23:48:34 norns systemd[1]: Stopping norns.
Mar 08 23:48:34 norns systemd[1]: Starting norns-init...
Mar 08 23:48:34 norns systemd[1]: Stopping norns-matron.service...
Mar 08 23:48:34 norns systemd[1]: Started norns-init.
Mar 08 23:48:35 norns systemd[1]: Stopped norns-matron.service.
Mar 08 23:48:35 norns systemd[1]: Started norns-matron.service.
Mar 08 23:48:35 norns systemd[1]: Reached target norns.
```

And again some free whitespace fixes :P