### PR TITLE
fix tape (2nd try)

### DIFF
--- a/crone/src/Tape.h
+++ b/crone/src/Tape.h
@@ -161,8 +161,8 @@ namespace crone {
                 size_t bytesToPush = numFrames * frameSize;
                 const size_t bytesAvailable = jack_ringbuffer_write_space(rb);
                 
-#if 0
                 if (bytesToPush > bytesAvailable) {
+#if 0
                     std::cerr << "Tape: writer overrun: " 
                               << bytesAvailable << " bytes available; " 
                               << bytesToPush << " bytes to push; "


### PR DESCRIPTION
issue #739 

re-wrote, doublechecked and cleaned up multithreading bits.

in particular, more correct signaling. tried lockless variant but simply didn't work. lock doesn't block audio thread.  

ringbuffer correctly reset on open

i can no longer reproduce the garbage fire meltdown on norns HW. there are still occasional overruns while writing - these will result in dropouts. no longer printing anything on overruns because we don't actually want to exacerbate glitches with I/O on audio thread.

time permitting, will come back to this with a clean test case and maybe ask for help from LAD community.