### PR TITLE
change default logarithmic ramp time from 1ms -> 50ms

### DIFF
--- a/crone/src/Utilities.h
+++ b/crone/src/Utilities.h
@@ -145,7 +145,7 @@ namespace crone {
         float x0;
         float y0;
     public:
-        explicit LogRamp(float sr=48000, float t=0.001) : sampleRate(sr), b(1.f), x0(0.f), y0(0.f) {
+        explicit LogRamp(float sr=48000, float t=0.05) : sampleRate(sr), b(1.f), x0(0.f), y0(0.f) {
             sampleRate = sr;
             time = t;
             setTime(t);


### PR DESCRIPTION
tiny change to increase default convergence time for log smoothers, from 1ms to 50ms. 

motivation: issue #750 

note that this effects everything that uses `LogRamp` - softcut rate, &c. there are explicit OSC commands to change smoothing time for mix levels, softcut levels, &c - but this is probably a better starting place.