### PR TITLE
add crone boot flag

### DIFF
--- a/sc/core/Crone.sc
+++ b/sc/core/Crone.sc
@@ -1,7 +1,7 @@
 // the Crone, a singleton class
 // it receives OSC from *matron* and manages the current CroneEngine
 Crone {
-	classvar <>autostart = true;
+	classvar <>bootOnInit = true;
 	// the audio server
 	classvar <>server;
 	// current CroneEngine subclass instance
@@ -25,23 +25,23 @@ Crone {
 
 	*initClass {
 		StartUp.add { // defer until after sclang init
-			if (Crone.autostart) {
-				croneAddr = NetAddr("127.0.0.1", 9999);
+			croneAddr = NetAddr("127.0.0.1", 9999);
 
-				postln("\n-------------------------------------------------");
-				postln(" Crone startup");
-				postln("");
-				postln(" OSC rx port: " ++ NetAddr.langPort);
-				postln(" OSC tx port: " ++ txPort);
-				postln(" server port: " ++ serverPort);
-				postln(" server port: " ++ croneAddr.port);
-				postln("--------------------------------------------------\n");
+			postln("\n-------------------------------------------------");
+			postln(" Crone startup");
+			postln("");
+			postln(" OSC rx port: " ++ NetAddr.langPort);
+			postln(" OSC tx port: " ++ txPort);
+			postln(" server port: " ++ serverPort);
+			postln(" server port: " ++ croneAddr.port);
+			postln("--------------------------------------------------\n");
 
-				remoteAddr = NetAddr("127.0.0.1", txPort);
+			remoteAddr = NetAddr("127.0.0.1", txPort);
 
-				"SC_JACK_DEFAULT_INPUTS".setenv("");
-				"SC_JACK_DEFAULT_OUTPUTS".setenv("");
+			"SC_JACK_DEFAULT_INPUTS".setenv("");
+			"SC_JACK_DEFAULT_OUTPUTS".setenv("");
 
+			if (Crone.bootOnInit) {
 				Crone.startBoot;
 			}
 		}

--- a/sc/core/Crone.sc
+++ b/sc/core/Crone.sc
@@ -1,6 +1,7 @@
 // the Crone, a singleton class
 // it receives OSC from *matron* and manages the current CroneEngine
 Crone {
+	classvar <>autostart = true;
 	// the audio server
 	classvar <>server;
 	// current CroneEngine subclass instance
@@ -24,24 +25,25 @@ Crone {
 
 	*initClass {
 		StartUp.add { // defer until after sclang init
+			if (Crone.autostart) {
+				croneAddr = NetAddr("127.0.0.1", 9999);
 
-			croneAddr = NetAddr("127.0.0.1", 9999);
+				postln("\n-------------------------------------------------");
+				postln(" Crone startup");
+				postln("");
+				postln(" OSC rx port: " ++ NetAddr.langPort);
+				postln(" OSC tx port: " ++ txPort);
+				postln(" server port: " ++ serverPort);
+				postln(" server port: " ++ croneAddr.port);
+				postln("--------------------------------------------------\n");
 
-			postln("\n-------------------------------------------------");
-			postln(" Crone startup");
-			postln("");
-			postln(" OSC rx port: " ++ NetAddr.langPort);
-			postln(" OSC tx port: " ++ txPort);
-			postln(" server port: " ++ serverPort);
-			postln(" server port: " ++ croneAddr.port);
-			postln("--------------------------------------------------\n");
+				remoteAddr = NetAddr("127.0.0.1", txPort);
 
-			remoteAddr = NetAddr("127.0.0.1", txPort);
+				"SC_JACK_DEFAULT_INPUTS".setenv("");
+				"SC_JACK_DEFAULT_OUTPUTS".setenv("");
 
-			"SC_JACK_DEFAULT_INPUTS".setenv("");
-			"SC_JACK_DEFAULT_OUTPUTS".setenv("");
-
-			Crone.startBoot;
+				Crone.startBoot;
+			}
 		}
 	}
 

--- a/sc/core/Crone.sc
+++ b/sc/core/Crone.sc
@@ -25,6 +25,7 @@ Crone {
 
 	*initClass {
 		StartUp.add { // defer until after sclang init
+
 			croneAddr = NetAddr("127.0.0.1", 9999);
 
 			postln("\n-------------------------------------------------");


### PR DESCRIPTION
i'm here just adding a flag that determines whether to boot on sclang init (the default is true which is normal norns behavior). this simplifies using Crone on desktop sc work in conjunction with non-Crone stuff.

Ie. if I do not want Crone to boot automatically I put this in my startup.scd file:

```
Crone.bootOnInit = false;
```
