### PR TITLE
lua/core/config.lua: Fix dust scripts package path

### DIFF
--- a/lua/core/config.lua
+++ b/lua/core/config.lua
@@ -10,7 +10,7 @@ local core = norns..'/core/?.lua;'
 local params = norns..'/core/params/?.lua;'
 local lib = norns..'/lib/?.lua;'
 local softcut = norns..'/softcut/?.lua;'
-local dust = home..'/dust/?.lua;'
+local dust = home..'/dust/scripts/?.lua;'
 
 package.path = sys..core..params..lib..softcut..dust..package.path
 -- print('package.path: ' .. package.path)


### PR DESCRIPTION
I think this is what it actually should be :roll_eyes: 
This way `require 'we/lib/<somelib>'` works :)