### PR TITLE
revert data folder

### DIFF
--- a/lua/core/config.lua
+++ b/lua/core/config.lua
@@ -10,7 +10,7 @@ local core = norns..'/core/?.lua;'
 local params = norns..'/core/params/?.lua;'
 local lib = norns..'/lib/?.lua;'
 local softcut = norns..'/softcut/?.lua;'
-local dust = home..'/dust/?.lua;'
+local dust = home..'/dust/scripts/?.lua;'
 
 package.path = sys..core..params..lib..softcut..dust..package.path
 -- print('package.path: ' .. package.path)
@@ -18,4 +18,6 @@ package.path = sys..core..params..lib..softcut..dust..package.path
 _path = {}
 _path.home = home
 _path.dust = home..'/dust/'
-_path.audio = home..'/audio/'
+_path.scripts = _path.dust..'scripts/'
+_path.audio = _path.dust..'audio/'
+_path.data = _path.dust..'data/'

--- a/lua/core/config.lua
+++ b/lua/core/config.lua
@@ -10,7 +10,7 @@ local core = norns..'/core/?.lua;'
 local params = norns..'/core/params/?.lua;'
 local lib = norns..'/lib/?.lua;'
 local softcut = norns..'/softcut/?.lua;'
-local dust = home..'/dust/scripts/?.lua;'
+local dust = home..'/dust/code/?.lua;'
 
 package.path = sys..core..params..lib..softcut..dust..package.path
 -- print('package.path: ' .. package.path)
@@ -18,6 +18,6 @@ package.path = sys..core..params..lib..softcut..dust..package.path
 _path = {}
 _path.home = home
 _path.dust = home..'/dust/'
-_path.scripts = _path.dust..'scripts/'
+_path.code = _path.dust..'code/'
 _path.audio = _path.dust..'audio/'
 _path.data = _path.dust..'data/'

--- a/lua/core/menu.lua
+++ b/lua/core/menu.lua
@@ -349,7 +349,7 @@ local function build_select_tree(root,dir)
       else
         n = p
       end
-      n = string.gsub(n,_path.scripts,'')
+      n = string.gsub(n,_path.code,'')
       n = string.sub(n,0,-2)
       table.insert(m.sel.list,{name=n,file=file,path=p})
     end
@@ -358,7 +358,7 @@ end
 
 m.init[pSELECT] = function()
   m.sel.list = {}
-  build_select_tree(_path.scripts,"")
+  build_select_tree(_path.code,"")
   --for k,v in pairs(m.sel.list) do
     --print(k, v.name, v.file, v.path)
   --end

--- a/lua/core/menu.lua
+++ b/lua/core/menu.lua
@@ -349,7 +349,7 @@ local function build_select_tree(root,dir)
       else
         n = p
       end
-      n = string.gsub(n,_path.dust,'')
+      n = string.gsub(n,_path.scripts,'')
       n = string.sub(n,0,-2)
       table.insert(m.sel.list,{name=n,file=file,path=p})
     end
@@ -358,7 +358,7 @@ end
 
 m.init[pSELECT] = function()
   m.sel.list = {}
-  build_select_tree(_path.dust,"")
+  build_select_tree(_path.scripts,"")
   --for k,v in pairs(m.sel.list) do
     --print(k, v.name, v.file, v.path)
   --end
@@ -492,7 +492,7 @@ m.key[pPARAMS] = function(n,z)
     if not m.params.midimap then
       if params.count > 0 then
         if params:t(m.params.pos+1) == params.tFILE then
-          fileselect.enter(_path.home, m.params.newfile)
+          fileselect.enter(_path.dust, m.params.newfile)
         elseif params:t(m.params.pos+1) == params.tTRIGGER then
           params:set(m.params.pos+1)
           m.params.triggered[m.params.pos+1] = 2
@@ -1045,7 +1045,7 @@ m.key[pAUDIO] = function(n,z)
     menu.set_page(pSYSTEM)
   elseif n==3 and z==1 then
     if mix:t(m.audio.pos+1) == mix.tFILE then
-      fileselect.enter(_path.home, m.audio.newfile)
+      fileselect.enter(_path.dust, m.audio.newfile)
     end
   end
 end
@@ -1402,7 +1402,7 @@ m.key[pTAPE] = function(n,z)
       if m.tape.rec.sel == TAPE_REC_ARM then
         tape_diskfree()
         m.tape.rec.file = string.format("%04d",norns.state.tape) .. ".wav"
-        audio.tape_record_open(_path.audio.."/tape/"..m.tape.rec.file)
+        audio.tape_record_open(_path.audio.."tape/"..m.tape.rec.file)
         m.tape.rec.sel = TAPE_REC_START
         m.tape.rec.pos_tick = 0
         tape_rec_counter.time = 0.25

--- a/lua/core/paramset.lua
+++ b/lua/core/paramset.lua
@@ -201,6 +201,11 @@ function ParamSet:init()
   if util.file_exists(norns.state.data) == false then
     print("pset >> initializing data folder")
     util.make_dir(norns.state.data)
+    local project_data = norns.state.path .. 'data/'
+    if util.file_exists(project_data) then
+      print("pset >> copying default project data")
+      os.execute("cp " .. project_data .. norns.state.shortname .. "*.* " .. norns.state.data)
+    end
   end
 end
 
@@ -233,6 +238,7 @@ end
 function ParamSet:read(filename)
   filename = filename or 0
   if type(filename) == "number" then
+    self.init()
     local n = filename
     filename = norns.state.data .. norns.state.shortname
     if n > 0 then

--- a/lua/core/paramset.lua
+++ b/lua/core/paramset.lua
@@ -195,21 +195,11 @@ function ParamSet:lookup_param(index)
   end
 end
 
---- init local psets.
--- make data dir if needed.
-function ParamSet:init()
-  if util.file_exists(norns.state.data) == false then
-    print("pset >> initializing data folder")
-    util.make_dir(norns.state.data)
-  end
-end
-
 --- write to disk.
 -- @param filename absolute path or use number instead to write to local data folder
 function ParamSet:write(filename)
   filename = filename or 0
   if type(filename) == "number" then
-    self.init()
     local n = filename
     filename = norns.state.data .. norns.state.shortname
     if n > 0 then
@@ -233,7 +223,6 @@ end
 function ParamSet:read(filename)
   filename = filename or 0
   if type(filename) == "number" then
-    self.init()
     local n = filename
     filename = norns.state.data .. norns.state.shortname
     if n > 0 then

--- a/lua/core/paramset.lua
+++ b/lua/core/paramset.lua
@@ -201,11 +201,6 @@ function ParamSet:init()
   if util.file_exists(norns.state.data) == false then
     print("pset >> initializing data folder")
     util.make_dir(norns.state.data)
-    local project_data = norns.state.path .. 'data/'
-    if util.file_exists(project_data) then
-      print("pset >> copying default project data")
-      os.execute("cp " .. project_data .. norns.state.shortname .. "*.* " .. norns.state.data)
-    end
   end
 end
 

--- a/lua/core/script.lua
+++ b/lua/core/script.lua
@@ -132,6 +132,11 @@ Script.load = function(filename)
     norns.state.path = path .. '/'
     norns.state.data = _path.data .. name .. '/'
 
+    if util.file_exists(norns.state.data) == false then
+      print("### initializing data folder")
+      util.make_dir(norns.state.data)
+    end
+
     local status = norns.try(function() dofile(filename) end, "load fail") -- do the new script
     if status == true then
       norns.state.save() -- remember this script for next launch

--- a/lua/core/script.lua
+++ b/lua/core/script.lua
@@ -127,10 +127,10 @@ Script.load = function(filename)
     Script.clear() -- clear script variables and functions
 
     norns.state.script = filename
-    norns.state.path = path .. '/'
-    norns.state.data = path .. '/data/'
     norns.state.name = name
     norns.state.shortname = norns.state.name:match( "([^/]+)$" )
+    norns.state.path = path .. '/'
+    norns.state.data = _path.data .. name .. '/'
 
     local status = norns.try(function() dofile(filename) end, "load fail") -- do the new script
     if status == true then

--- a/lua/core/state.lua
+++ b/lua/core/state.lua
@@ -4,8 +4,8 @@
 state = {}
 state.tape = 0
 state.script = ''
-state.path = _path["dust"]
-state.data = _path["dust"]
+state.path = _path.scripts
+state.data = _path.data
 state.name = ''
 state.shortname = ''
 state.clean_shutdown = false
@@ -13,14 +13,14 @@ state.clean_shutdown = false
 --- read state.lua and set parameters back to stored vals.
 state.resume = function()
   -- restore mix state
-  mix:read(_path["dust"].."system.pset")
+  mix:read(_path.data.."system.pset")
   mix:bang()
 
   -- restore state object
-  local f = io.open(_path["dust"]..'system.state')
+  local f = io.open(_path.data..'system.state')
   if f ~= nil then
     io.close(f)
-    dofile(_path["dust"]..'system.state')
+    dofile(_path.data..'system.state')
   end
 
   -- update vports
@@ -48,8 +48,8 @@ state.resume = function()
     state.script=''
     state.name = 'none'
     state.shortname = 'none'
-    state.path = _path["dust"]
-    state.data = _path["dust"]
+    state.path = _path.scripts
+    state.data = _path.data
     norns.scripterror("NO SCRIPT")
   end
 end
@@ -61,11 +61,11 @@ state.save = function()
 end
 
 state.save_mix = function()
-  mix:write(_path["dust"].."system.pset")
+  mix:write(_path.data.."system.pset")
 end
 
 state.save_state = function()
-  local fd=io.open(_path["dust"] .. "system.state","w+")
+  local fd=io.open(_path.data .. "system.state","w+")
   io.output(fd)
   io.write("-- norns system state\n")
   io.write("norns.state.clean_shutdown = " .. (state.clean_shutdown and "true" or "false") .. "\n")

--- a/lua/core/state.lua
+++ b/lua/core/state.lua
@@ -4,7 +4,7 @@
 state = {}
 state.tape = 0
 state.script = ''
-state.path = _path.scripts
+state.path = _path.code
 state.data = _path.data
 state.name = ''
 state.shortname = ''
@@ -48,7 +48,7 @@ state.resume = function()
     state.script=''
     state.name = 'none'
     state.shortname = 'none'
-    state.path = _path.scripts
+    state.path = _path.code
     state.data = _path.data
     norns.scripterror("NO SCRIPT")
   end

--- a/lua/core/state.lua
+++ b/lua/core/state.lua
@@ -1,7 +1,7 @@
 --- State
 -- @module state
 
-state = {}
+local state = {}
 state.tape = 0
 state.script = ''
 state.path = _path.code


### PR DESCRIPTION
this PR reverts the `dust` structure to 190303

```
dust/
  audio/    -- all user audio
  data/      -- user pset/pmap data, gets tree'd same as script folder
  code/    -- user scripts/projects/etc. (includes 'we'/etc)
```

example script folder

```
mlr/
  mlr.lua    -- main version, shows up as MLR
  mod.lua   -- alt version, shows up as MLR/MOD
  data/
    mlr.pset    -- default pset. script is responsible for copying it/etc
    other.data   -- whatever other data
  lib/
    sub-mlr-lib.lua  -- arbitrary lib, imported via require 'mlr/lib/sub-mlr-lib'
    some-engine.sc   --- engine file
    some-engine.lua   --- engine lib, require 'mlr/lib/some-engine'
```


i'd like to bundle this in to a new beta installer soon so people don't sit with the botched 190314 for long. but please let me know if there are outstanding concerns that need immediate attention. i understand that there are some long-term v3 proposals on the table re non-sc-engines, but right now let's focus on v2.