### PR TITLE
softcut buffer fixes

### DIFF
--- a/crone/src/OscInterface.cpp
+++ b/crone/src/OscInterface.cpp
@@ -555,6 +555,47 @@ void OscInterface::addServerMethods() {
     });
 
 
+    // FIXME: hrm, our system doesn't allow variable argument count. maybe need to make multiple methods
+    addServerMethod("/softcut/buffer/write_mono", "sffi", [](lo_arg **argv, int argc) {
+        float start = 0.f;
+        float dur = -1.f;
+        int chan=0;
+        if (argc < 1) {
+            std::cerr << "/softcut/buffer/write_mono requires at least one argument (file path)" << std::endl;
+            return;
+        }
+        if (argc > 1) {
+            start = argv[1]->f;
+        }
+        if (argc > 2) {
+            dur = argv[2]->f;
+        }
+        if (argc > 3) {
+            chan = argv[3]->i;
+        }
+        const char *str = &argv[0]->s;
+        softCutClient->writeBufferMono(str, start, dur, chan);
+    });
+
+    // FIXME: hrm, our system doesn't allow variable argument count. maybe need to make multiple methods
+    addServerMethod("/softcut/buffer/write_stereo", "sff", [](lo_arg **argv, int argc) {
+        float start = 0.f;
+        float dur = -1.f;
+        if (argc < 1) {
+            std::cerr << "/softcut/buffer/write_stereo requires at least one argument (file path)" << std::endl;
+            return;
+        }
+        if (argc > 1) {
+            start = argv[1]->f;
+        }
+        if (argc > 2) {
+            dur = argv[2]->f;
+        }
+        const char *str = &argv[0]->s;
+        softCutClient->writeBufferStereo(str, start, dur);
+    });
+
+
 
     addServerMethod("/softcut/buffer/clear", "", [](lo_arg **argv, int argc) {
         (void)argc;

--- a/crone/src/OscInterface.cpp
+++ b/crone/src/OscInterface.cpp
@@ -529,7 +529,7 @@ void OscInterface::addServerMethods() {
             chanDst= argv[5]->i;
         }
         const char *str = &argv[0]->s;
-        softCutClient->loadFileMono(str, startSrc, startDst, dur, chanSrc, chanDst);
+        softCutClient->readBufferMono(str, startSrc, startDst, dur, chanSrc, chanDst);
     });
 
     // FIXME: hrm, our system doesn't allow variable argument count. maybe need to make multiple methods
@@ -551,7 +551,7 @@ void OscInterface::addServerMethods() {
             dur = argv[3]->f;
         }
         const char *str = &argv[0]->s;
-        softCutClient->loadFileStereo(str, startSrc, startDst, dur);
+        softCutClient->readBufferStereo(str, startSrc, startDst, dur);
     });
 
 

--- a/crone/src/SoftCutClient.cpp
+++ b/crone/src/SoftCutClient.cpp
@@ -168,9 +168,14 @@ void crone::SoftCutClient::handleCommand(Commands::CommandPacket *p) {
 }
 
 void crone::SoftCutClient::clearBuffer(int bufIdx, float start, float dur) {
-    size_t frA =secToFrame(start);
+    size_t frA = secToFrame(start);
     clamp(frA, BufFrames-1);
-    size_t frB = frA + secToFrame(dur);
+    size_t frB;
+    if (dur < 0) {
+	frB = BufFrames;
+    } else {
+	frB = frA + secToFrame(dur);
+    }
     clamp(frB, BufFrames);
     for(size_t i=frA; i<frB; ++i) { buf[bufIdx][i] = 0.f; }
 }

--- a/crone/src/SoftCutClient.cpp
+++ b/crone/src/SoftCutClient.cpp
@@ -183,14 +183,15 @@ void crone::SoftCutClient::clearBuffer(int bufIdx, float start, float dur) {
 }
 
 
-/// FIXME: DRY this up
-void crone::SoftCutClient::loadFileMono(const std::string &path, float startTimeSrc, float startTimeDst, float dur,
-        int chanSrc, int chanDst) {
+///////////////////
+/// FIXME: DRY these all up
 
+void crone::SoftCutClient::readBufferMono(const std::string &path, float startTimeSrc, float startTimeDst, float dur,
+                                          int chanSrc, int chanDst) {
     SndfileHandle file(path);
 
     if (file.frames() < 1) {
-        std::cerr << "SoftCutClient::loadFileMono(): empty / missing file: " << path << std::endl;
+        std::cerr << "SoftCutClient::readBufferMono(): empty / missing file: " << path << std::endl;
         return;
     }
 
@@ -199,11 +200,6 @@ void crone::SoftCutClient::loadFileMono(const std::string &path, float startTime
 
     size_t frDst = secToFrame(startTimeDst);
     clamp(frDst, BufFrames-1);
-
-
-#if 0 // debug
-    std::cerr << "SoftCutClient::loadFileMono(): src frame (start) = " << frSrc << "; dst frame (start) = " << frDst << std::endl;
-#endif
 
     size_t frDur;
     if (dur < 0.f) {
@@ -226,23 +222,17 @@ void crone::SoftCutClient::loadFileMono(const std::string &path, float startTime
         buf[chanDst][frDst] = frBuf[chanSrc];
         ++frSrc;
         if (++frDst >= BufFrames) {
-            std::cerr << "SoftCutClient::loadFileMono(): exceeded buffer size; aborting" << std::endl;
+            std::cerr << "SoftCutClient::readBufferMono(): exceeded buffer size; aborting" << std::endl;
             return;
         }
     }
-
-#if 0 // debug
-    std::cerr << "SoftCutClient::loadFileMono(): src frame (end) = " << frSrc << "; dst frame (end ) = " << frDst << std::endl;
-#endif
 }
 
-/// FIXME: DRY this up
-void crone::SoftCutClient::loadFileStereo(const std::string &path, float startTimeSrc, float startTimeDst, float dur) {
+void crone::SoftCutClient::readBufferStereo(const std::string &path, float startTimeSrc, float startTimeDst, float dur) {
     SndfileHandle file(path);
-    // FIXME: bail here if fail to open
 
     if (file.frames() < 1) {
-        std::cerr << "SoftCutClient::loadFileStereo(): empty / missing file: " << path << std::endl;
+        std::cerr << "SoftCutClient::readBufferStereo(): empty / missing file: " << path << std::endl;
         return;
     }
 
@@ -251,11 +241,6 @@ void crone::SoftCutClient::loadFileStereo(const std::string &path, float startTi
 
     size_t frDst = secToFrame(startTimeDst);
     clamp(frDst, BufFrames-1);
-
-
-#if 0 // debug
-    std::cerr << "SoftCutClient::loadFileStereo(): src frame (start) = " << frSrc << "; dst frame (start) = " << frDst << std::endl;
-#endif
 
     size_t frDur;
     if (dur < 0.f) {
@@ -268,7 +253,7 @@ void crone::SoftCutClient::loadFileStereo(const std::string &path, float startTi
 
     auto numSrcChan = file.channels();
     if(numSrcChan<2) {
-        std::cerr << "SoftCutClient::loadFileStereo(): not enough channels in source; aborting" << std::endl;
+        std::cerr << "SoftCutClient::readBufferStereo(): not enough channels in source; aborting" << std::endl;
         return;
     }
     std::unique_ptr<float[]> frBuf(new float[numSrcChan]);
@@ -281,12 +266,40 @@ void crone::SoftCutClient::loadFileStereo(const std::string &path, float startTi
         buf[1][frDst] = frBuf[1];
         frSrc++;
         if (++frDst >= BufFrames) {
-            std::cerr << "SoftCutClient::loadFileStereo(): exceeded buffer size; aborting" << std::endl;
+            std::cerr << "SoftCutClient::readBufferStereo(): exceeded buffer size; aborting" << std::endl;
             return;
         }
     }
-
-#if 0 // debug
-    std::cerr << "SoftCutClient::loadFileStereo(): src frame (end) = " << frSrc << "; dst frame (end ) = " << frDst << std::endl;
-#endif
 }
+
+
+void crone::SoftCutClient::writeBufferMono(const std::string &path, float start = 0, float dur = -1, int chan = 0) {
+    SF_INFO sf_info;
+    SNDFILE *file;
+
+    if ((file = sf_open(path.c_str(), SFM_WRITE, &sf_info)) == NULL) {
+        char errstr[256];
+        sf_error_str(nullptr, errstr, sizeof(errstr) - 1);
+        std::cerr << "cannot open sndfile" << path << " for writing (" << errstr << ")" << std::endl;
+        return;
+    }
+
+    // TODO
+}
+
+
+void crone::SoftCutClient::writeBufferStereo(const std::string &path, float start = 0, float dur = -1) {
+    SF_INFO sf_info;
+    SNDFILE *file;
+
+    if ((file = sf_open(path.c_str(), SFM_WRITE, &sf_info)) == NULL) {
+        char errstr[256];
+        sf_error_str(nullptr, errstr, sizeof(errstr) - 1);
+        std::cerr << "cannot open sndfile" << path << " for writing (" << errstr << ")" << std::endl;
+        return;
+    }
+
+    // TODO
+}
+
+

--- a/crone/src/SoftCutClient.h
+++ b/crone/src/SoftCutClient.h
@@ -56,12 +56,15 @@ namespace crone {
         // these accessors can be called from other threads, so don't need to go through the commands queue
         //-- buffer manipulation
         //-- time parameters are in seconds
-        //-- negative 'dur' parameter reads/clears as much as possible.
-        void loadFileMono(const std::string &path, float startTimeSrc=0.f, float startTimeDst=0.f, float dur=-1.f,
-                                                int chanSrc=0, int chanDst=0);
-
-        void loadFileStereo(const std::string &path, float startTimeSrc=0.f, float startTimeDst=0.f, float dur=-1.f);
+        //-- negative 'dur' parameter reads/clears/writes as much as possible.
+        void readBufferMono(const std::string &path, float startTimeSrc = 0.f, float startTimeDst = 0.f,
+                            float dur = -1.f,
+                            int chanSrc = 0, int chanDst = 0);
+        void readBufferStereo(const std::string &path, float startTimeSrc = 0.f, float startTimeDst = 0.f,
+                              float dur = -1.f);
         void clearBuffer(int bufIdx, float startTime=0.f, float dur=-1);
+        void writeBufferMono(const std::string &path, float start, float dur, int chan);
+        void writeBufferStereo(const std::string &path, float start, float dur);
         // check if quantized phase has changed for a given voice
         // returns true
         bool checkVoiceQuantPhase(int i) {

--- a/matron/src/weaver.c
+++ b/matron/src/weaver.c
@@ -2102,9 +2102,10 @@ int _cut_buffer_clear_region_channel(lua_State *l) {
   if (lua_gettop(l) != 3) {
     return luaL_error(l, "wrong number of arguments");
   }
-  float start = (float) luaL_checknumber(l, 1);
-  float end = (float) luaL_checknumber(l, 2);
-  int ch = (int) luaL_checkinteger(l, 3) - 1;
+  
+  int ch = (int) luaL_checkinteger(l, 1) - 1;
+  float start = (float) luaL_checknumber(l, 2);
+  float end = (float) luaL_checknumber(l, 3);
   o_cut_buffer_clear_region_channel(start, end, ch);
   return 0;
 }


### PR DESCRIPTION
fixed a couple lua/OSC commands:

`/softcut/buffer/clear` : this was broken in `SoftCutClient`
`/softcut/buffer/clear_region_channel` : this was broken in `matron/weaver`

added:
-  `/softcut/buffer/write_mono [sffi]`; args: path, start (seconds), dur (seconds), channel (zero-based)

-  `/softcut/buffer/write_stereo [sff]`; args: path, start (seconds), dur (seconds)

for all the buffer functions, `dur=-1` means to read/write/clear the entire buffer. (or, read the entire file if that is shorter.) (there is an attempt in `OscInterface.cpp` to provide defaults for missing arguments, but it turns out `liblo` doesn't work this way and the handlers aren't called at all. so this should be cleaned up too.)

have **not** yet added lua/weaver glue for write commands, nor tested on norns HW (only on desktop `crone` with raw OSC.) 

(happy to add glue and test sometime next week, unless someone else can get to it first.)

also: 
- both read and write are unnecessarily slow (1 frame at a time.)
- it might be good to have `crone` send some OSC back to `matron` when these operations finish.