### PR TITLE
make matron retry for 10s to grab gpios on boot

### DIFF
--- a/matron/src/hardware/gpio.c
+++ b/matron/src/hardware/gpio.c
@@ -18,8 +18,8 @@
 #include "events.h"
 
 
-int fd;
-pthread_t p;
+int key_fd;
+pthread_t key_p;
 
 int enc_fd[3];
 pthread_t enc_p[3];
@@ -29,51 +29,55 @@ void *enc_check(void *);
 
 // extern def
 
-void gpio_init() {
-    fd = open("/dev/input/by-path/platform-keys-event", O_RDONLY); // Keys
-    if(fd > 0) {
-        if(ioctl(fd, EVIOCGRAB, 1) == 0) {
-            ioctl(fd, EVIOCGRAB, (void*)0);
-        }
-        else {
-            fprintf(stderr, "ERROR (keys) grab fail\n");
-        }
-
-        if(pthread_create(&p, NULL, key_check, 0) ) {
-            fprintf(stderr, "ERROR (keys) pthread error\n");
-        } 
-    }
-    else {
-        fprintf(stderr, "ERROR (keys) fail!!\n");
-    }
-
-    enc_fd[0] = open("/dev/input/by-path/platform-soc:knob1-event", O_RDONLY);
-    enc_fd[1] = open("/dev/input/by-path/platform-soc:knob2-event", O_RDONLY);
-    enc_fd[2] = open("/dev/input/by-path/platform-soc:knob3-event", O_RDONLY);
-    if(enc_fd[0] > 0) {
-        for(int i = 0; i< 3; i++) {
-
-            if(ioctl(enc_fd[i], EVIOCGRAB, 1) == 0) {
-                ioctl(enc_fd[i], EVIOCGRAB, (void*)0);
+static int open_and_grab (const char *pathname, int flags) {
+    int i=0;
+    int fd;
+    while (i < 200) {
+        fd = open(pathname, flags);
+        if(fd > 0) {
+            if(ioctl(fd, EVIOCGRAB, 1) == 0) {
+                ioctl(fd, EVIOCGRAB, (void*)0);
+                return fd;
             }
             else {
-                fprintf(stderr, "ERROR (enc) grab fail\n");
+                fprintf(stderr, "WARN GPIO ioctl fail (%s, attempt %d)\n", pathname, i);
+                close(fd);
             }
-    
-            int *arg = malloc(sizeof(int));
-            *arg = i; 
-            if(pthread_create(&enc_p[i], NULL, enc_check, arg) ) {
-                fprintf(stderr, "ERROR (enc) pthread error\n");
-            } 
+        }
+        else {
+            fprintf(stderr, "WARN GPIO open fail (%s, attempt %d)\n", pathname, i);
+        }
+        i++;
+        usleep(50000); // 50ms sleep * 200 = 10s fail after 10s
+    };
+    return fd;
+}
+
+void gpio_init() {
+    key_fd = open_and_grab("/dev/input/by-path/platform-keys-event", O_RDONLY); // Keys
+    if(key_fd > 0) {
+        if(pthread_create(&key_p, NULL, key_check, 0) ) {
+            fprintf(stderr, "ERROR (keys) pthread error\n");
         }
     }
-    else {
-        fprintf(stderr, "ERROR (enc) didn't work\n");
-    } 
+
+    char *enc_filenames[3] = {"/dev/input/by-path/platform-soc:knob1-event",
+                              "/dev/input/by-path/platform-soc:knob2-event",
+                              "/dev/input/by-path/platform-soc:knob3-event"};
+    for(int i=0; i < 3; i++) {
+        enc_fd[i] = open_and_grab(enc_filenames[i], O_RDONLY);
+        if(enc_fd[i] > 0) {
+            int *arg = malloc(sizeof(int));
+            *arg = i;
+            if(pthread_create(&enc_p[i], NULL, enc_check, arg) ) {
+                fprintf(stderr, "ERROR (enc%d) pthread error\n",i);
+            }
+	}
+    }
 }
 
 void gpio_deinit() {
-    pthread_cancel(p);
+    pthread_cancel(key_p);
     pthread_cancel(enc_p[0]);
     pthread_cancel(enc_p[1]);
     pthread_cancel(enc_p[2]);
@@ -124,7 +128,7 @@ void *key_check(void *x) {
     struct input_event event[64];
 
     while(1) {
-        rd = read(fd, event, sizeof(struct input_event) * 64);
+        rd = read(key_fd, event, sizeof(struct input_event) * 64);
         if(rd < (int) sizeof(struct input_event)) {
             fprintf(stderr, "ERROR (key) read error\n");
         }


### PR DESCRIPTION
Set out to implement GPIO retries, ended up with quite a big change.  Tested all keys and encoders work properly after this change. It fixes my problem that norns wasn't booting into matron correctly without mucking up the init scripts with ugly fingers-crossed pauses.

I see the following lines in output from journalctl -u norns-matron:


-- Logs begin at Sun 2019-03-17 21:36:27 +07, end at Sun 2019-03-17 21:44:17 +07. --
Mar 17 21:36:35 norns systemd[1]: Started norns-matron.service.
Mar 17 21:36:36 norns matron[322]: *** WARNING *** The program 'matron' uses the Apple Bonjour compatibility layer of Avahi.
Mar 17 21:36:36 norns matron[322]: *** WARNING *** Please fix your application to use the native API of Avahi!
Mar 17 21:36:36 norns matron[322]: *** WARNING *** For more information see <http://0pointer.de/avahi-compat?s=libdns_sd&e=matron>
Mar 17 21:36:42 norns ws-wrapper[316]: attempting to bind socket at url ws://*:5555
Mar 17 21:36:42 norns ws-wrapper[316]: WARN GPIO open fail (/dev/input/by-path/platform-keys-event, attempt 0)
Mar 17 21:36:42 norns ws-wrapper[316]: WARN GPIO open fail (/dev/input/by-path/platform-keys-event, attempt 1)
Mar 17 21:36:42 norns ws-wrapper[316]: WARN GPIO open fail (/dev/input/by-path/platform-soc:knob1-event, attempt 0)
Mar 17 21:36:42 norns ws-wrapper[316]: WARN GPIO open fail (/dev/input/by-path/platform-soc:knob1-event, attempt 1)
Mar 17 21:36:42 norns ws-wrapper[316]: WARN GPIO open fail (/dev/input/by-path/platform-soc:knob1-event, attempt 2)
Mar 17 21:36:42 norns ws-wrapper[316]: WARN GPIO open fail (/dev/input/by-path/platform-soc:knob1-event, attempt 3)
Mar 17 21:36:42 norns ws-wrapper[316]: WARN GPIO open fail (/dev/input/by-path/platform-soc:knob1-event, attempt 4)
Mar 17 21:36:42 norns ws-wrapper[316]: *** WARNING *** The program 'matron' uses the Apple Bonjour compatibility layer of Avahi.
