### PR TITLE
SC remove abstractions includepath

### DIFF
--- a/sc/norns-config.sc
+++ b/sc/norns-config.sc
@@ -11,7 +11,6 @@ Norns {
 
   *initClass {
     Norns.addIncludePath(Platform.userHomeDir ++ "/norns/sc/core");
-    Norns.addIncludePath(Platform.userHomeDir ++ "/norns/sc/abstractions");
     Norns.addIncludePath(Platform.userHomeDir ++ "/norns/sc/engines");
     Norns.addIncludePath(Platform.userHomeDir ++ "/norns/sc/ugens");
     Norns.addIncludePath(Platform.userHomeDir ++ "/dust");


### PR DESCRIPTION
This was the only warning I ran into when running the included/default scripts
```
Mar 22 00:44:45 norns ws-wrapper[351]: WARNING: Could not open directory: '/home/we/norns/sc/abstractions'
```