### PR TITLE
Fix paths used for audio/fourwaves

### DIFF
--- a/lua/core/audio.lua
+++ b/lua/core/audio.lua
@@ -218,8 +218,8 @@ end
 
 function Audio.file_info(path)
   -- dur, ch, rate
-  print("file_info: " .. dust_dir .. path)
-  return sound_file_inspect(dust_dir .. path)
+  print("file_info: " .. path)
+  return sound_file_inspect(path)
 end
 
 

--- a/lua/softcut/fourwaves.lua
+++ b/lua/softcut/fourwaves.lua
@@ -15,7 +15,7 @@ local function new_voice()
     if x < voices[i] then
       x = voices[i]
       n = i
-    end 
+    end
     voices[i] = voices[i]+1
   end
   voices[n] = 0;
@@ -26,12 +26,12 @@ end
 local sc = {}
 
 function sc.init(file)
-  file = file or "audio/common/waves/01.wav"
+  file = file or _path.audio.."common/waves/01.wav"
   local ch, dur, sr = audio.file_info(file)
   d = dur/sr
 
   print("fourwaves: loading "..file)
-  softcut.buffer_read_mono(dust_dir..file,0,1,d,0,0)
+  softcut.buffer_read_mono(file,0,1,d,0,0)
   print("fourwaves: dur "..d)
 
   audio.level_cut(1.0)


### PR DESCRIPTION
This fixes the fourwaves errors as mentioned in #765 

Tbh I'm not entirely sure this is the correct fix. I think the fix to `Audio.file_info` is correct in that it should work with any audio file, be it stored in `dust/audio` or within a script's own `audio` directory.

The fix to fourwaves feels wrong, with it depending on non-local audio. Shouldn't that sample just be in a `data` directory within the `lua/softcut` directory? Not sure if that makes sense?
I think the underlying question is: What is `fourwaves.lua` exactly? It's not an engine and not a script. Should it be a lib inside `fourwaves-test`? :thinking: 

Fixes #765 