### PR TITLE
warn and continue on nonexistent crone engine

### DIFF
--- a/sc/core/Crone.sc
+++ b/sc/core/Crone.sc
@@ -126,6 +126,10 @@ Crone {
 					this.reportPolls;
 				});
 			}
+		}, {
+		   postln("warning: didn't find engine: " ++ name.asString);
+		   this.reportCommands;
+		   this.reportPolls;
 		});
 	}
 


### PR DESCRIPTION
without this change, a misspelled or missing engine name causes the script to hang on "loading..." forever