### PR TITLE
change include function

### DIFF
--- a/lua/core/startup.lua
+++ b/lua/core/startup.lua
@@ -33,7 +33,7 @@ require 'core/menu'
 
 -- global include function
 function include(file)
-  return dofile(norns.state.path .. "lib/" .. file)
+  return dofile(norns.state.path .. file .. '.lua')
 end
 
 


### PR DESCRIPTION
instead of `require`

- relative path to current file (provided by `norns.state.path`) (not 
- `.lua` extension not required
