### PR TITLE
Fix one obvious leak and one not-so-obvious one

### DIFF
--- a/matron/src/events.c
+++ b/matron/src/events.c
@@ -122,6 +122,7 @@ void event_data_free(union event_data *ev) {
         free(ev->poll_wave.data);
         break;
     }
+    free(ev);
 }
 
 // add an event to the q and signal if necessary

--- a/matron/src/weaver.c
+++ b/matron/src/weaver.c
@@ -1280,7 +1280,7 @@ int _send_command(lua_State *l) {
     case 'f':
       if (lua_isnumber(l, i)) {
 	f = lua_tonumber(l, i);
-	lo_message_add_double(msg, f);
+	lo_message_add_float(msg, (float)f);
       } else {
 	lo_message_free(msg);
 	return luaL_error(l, "failed double type check");
@@ -1297,7 +1297,7 @@ int _send_command(lua_State *l) {
   }
 
   o_send_command(cmd, msg);
-  free(msg);
+  lo_message_free(msg);
   lua_settop(l, 0);
   return 0;
 }


### PR DESCRIPTION
So I learned to use valgrind today, what a brilliant tool!

Think the change to events.c is just a garden variety forgot-to-free (I had a good ferret around to look where else the main event data structure might be freed, couldn't find anything)

The change to weaver.c is a bit more subtle - looks to me like lo_message_add_double leaks.  We can report this upstream separately with a minimal testcase but I'm happy to simply change to lo_message_add_float.

For evidence these are genuine leaks see valgrind before and after the changes - I can produce a third dump showing that the weaver.c change makes a difference if it seems far-fetched...

before:
https://gist.github.com/ranch-verdin/a403453ee4d8ef177e79eabe6798f6e7

after:
https://gist.github.com/ranch-verdin/d35eb7c7f709e5918ab937c0751afb30