### PR TITLE
WIP: fine parameter adjustment

### DIFF
--- a/lua/core/menu.lua
+++ b/lua/core/menu.lua
@@ -469,6 +469,7 @@ m.params.map = {}
 m.params.init_map = function()
   for i = 1,params.count do m.params.map[i] = -1 end
 end
+m.params.fine = false
 
 m.key[pPARAMS] = function(n,z)
   if menu.alt then
@@ -492,6 +493,7 @@ m.key[pPARAMS] = function(n,z)
     --menu.set_page(pHOME)
   elseif n==3 and z==1 then
     if not m.params.midimap then
+      m.params.fine = true
       if params.count > 0 then
         if params:t(m.params.pos+1) == params.tFILE then
           fileselect.enter(_path.dust, m.params.newfile)
@@ -503,6 +505,8 @@ m.key[pPARAMS] = function(n,z)
     else
       m.params.midilearn = not m.params.midilearn
     end
+  elseif n==3 and z==0 then
+    m.params.fine = false
   end
 end
 
@@ -549,7 +553,8 @@ m.enc[pPARAMS] = function(n,d)
     if m.params.pos ~= prev then menu.redraw() end
   elseif n==3 and params.count > 0 then
     if not m.params.midimap then
-      params:delta(m.params.pos+1,d)
+      local dx = m.params.fine and (d/20) or d
+      params:delta(m.params.pos+1,dx)
       menu.redraw()
     else
       m.params.map[m.params.pos+1] = util.clamp(m.params.map[m.params.pos+1]+d,-1,127)


### PR DESCRIPTION
when experimenting with softcut (playback rate) and at times with other scripts using the generic params menu i've found myself wanting a fine adjustment mode.

this change is a rather basic solve; if key 3 is held down, the delta value from enc 3 is somewhat arbitrarily divided by 20.

some downsides of this approach that i see:
- the fine divisor is arbitrary and results in floating point values being sent to `param:delta(...)`
- parameters may benefit from being able to define course vs fine steps (like octaves vs semitones)
- the fine adjust behavior is only exposed when interacting in the menu but a script would have to roll its own.

if there is general interest in exposing fine parameter control as part of the param abstraction then i'm inclined to close this and look at a general abstraction.