### PR TITLE
framebuffer select argument

### DIFF
--- a/matron/src/args.c
+++ b/matron/src/args.c
@@ -9,24 +9,32 @@ struct args {
     char loc_port[ARG_BUF_SIZE];
     char ext_port[ARG_BUF_SIZE];
     char crone_port[ARG_BUF_SIZE];
+    char framebuffer[ARG_BUF_SIZE];
 };
 
 static struct args a = {
     .loc_port = "8888",
-    .crone_port = "9999",
     .ext_port = "57120",
+    .crone_port = "9999",
+    .framebuffer = "/dev/fb0",
 };
 
 int args_parse(int argc, char **argv)
 {
     int opt;
-    while( ( opt = getopt(argc, argv, "e:l:c:") ) != -1 ) {
+    while( ( opt = getopt(argc, argv, "e:l:c:f:") ) != -1 ) {
         switch(opt) {
         case 'l':
             strncpy(a.loc_port, optarg, ARG_BUF_SIZE-1);
             break;
         case 'e':
             strncpy(a.ext_port, optarg, ARG_BUF_SIZE-1);
+            break;
+	case 'c':
+            strncpy(a.crone_port, optarg, ARG_BUF_SIZE-1);
+            break;
+	case 'f':
+            strncpy(a.framebuffer, optarg, ARG_BUF_SIZE-1);
             break;
         default:
             ;;
@@ -46,3 +54,8 @@ const char *args_ext_port(void) {
 const char *args_crone_port(void) {
     return a.crone_port;
 }
+
+const char *args_framebuffer(void) {
+    return a.framebuffer;
+}
+

--- a/matron/src/args.h
+++ b/matron/src/args.h
@@ -6,3 +6,4 @@ extern const char *args_local_port(void);
 extern const char *args_ext_port(void);
 extern const char *args_crone_port(void);
 extern const char *args_monome_path(void);
+extern const char *args_framebuffer(void);

--- a/matron/src/hardware/screen.c
+++ b/matron/src/hardware/screen.c
@@ -15,6 +15,8 @@
 #include <cairo.h>
 #include <cairo-ft.h>
 
+#include "args.h"
+
 // skip this if you don't want every screen module call to perform null checks
 #ifndef CHECK_CR
 #define CHECK_CR if (cr == NULL) {return; }
@@ -65,15 +67,12 @@ void cairo_linuxfb_surface_destroy(void *device)
 }
 
 /* Create a cairo surface using the specified framebuffer */
-cairo_surface_t *cairo_linuxfb_surface_create(const char *fb_name)
+cairo_surface_t *cairo_linuxfb_surface_create()
 {
     cairo_linuxfb_device_t *device;
     cairo_surface_t *surface;
 
-    /* Use fb0 if no fram buffer is specified */
-    if (fb_name == NULL) {
-        fb_name = "/dev/fb0";
-    }
+    const char* fb_name = args_framebuffer();
 
     device = malloc( sizeof(*device) );
     if (!device) {
@@ -155,7 +154,7 @@ void screen_display_png(const char *filename, double x, double y){
 
 
 void screen_init(void) {
-    surfacefb = cairo_linuxfb_surface_create("/dev/fb0");
+    surfacefb = cairo_linuxfb_surface_create();
     if(surfacefb == NULL) { return; }
     crfb = cairo_create(surfacefb);
 


### PR DESCRIPTION
added `matron` argument for specifying path to framebuffer used by cairo

defaults to `/dev/fb0`

change it like so:

`matron -f/dev/fb1`

have only tested on norns to make sure nothing is broken. @okyeron (or anyone else requiring this feature) - would be great to get feedback before we merge

addresses issue #749 