### PR TITLE
don't hang for ages waiting for gpio unless on norns hardware

### DIFF
--- a/matron/src/main.c
+++ b/matron/src/main.c
@@ -52,7 +52,13 @@ int main(int argc, char **argv) {
     screen_init();
 
     metros_init();
+
+#ifdef __arm__
+    // gpio_init() hangs for too long when cross-compiling norns
+    // desktop for dev - just disable on x86 for now
     gpio_init();
+#endif
+
     battery_init();
     stat_init();
     i2c_init();


### PR DESCRIPTION
@artfwo pointed out my GPIO patch breaks desktop builds.  I think the best thing for now is to simply disable GPIO init when cross-compiling for x86 desktop (unless someone gets round to https://github.com/monome/norns/issues/732)

This is a bit of a hack but does fix the pressing issue (and I briefly tested it works for both platforms). Not quite sure what would be a better way to approach this?  I looked around for some global header where we could put in a more explicitly named preprocessor macro (eg #define DESKTOP_CROSSCOMPILE) but appears there is no project-wide header file for matron.