### PR TITLE
include() path change

### DIFF
--- a/lua/core/startup.lua
+++ b/lua/core/startup.lua
@@ -33,7 +33,7 @@ require 'core/menu'
 
 -- global include function
 function include(file)
-  return dofile(norns.state.path .. file .. '.lua')
+  return dofile(_path.code .. file .. '.lua')
 end
 
 

--- a/lua/core/wifi.lua
+++ b/lua/core/wifi.lua
@@ -188,7 +188,10 @@ function Wifi.off()
 end
 
 function Wifi.hotspot()
-  Wifi.on(HOTSPOT)
+  print("activating hotspot")
+  Wifi.ensure_radio_is_on()
+  os.execute("nmcli c delete Hotspot")
+  os.execute("nmcli dev wifi hotspot ifname wlan0 ssid norns password 22222222")
 end
 
 function Wifi.on(connection)


### PR DESCRIPTION
many apologies for the breakage!

`include(file)` now includes from `dust/code` (and appends `.lua`)

previously was including from current folder (ie `dust/code/awake`) which made cross-folder sharing difficult (ie for engine libs)