### PR TITLE
change include() path

### DIFF
--- a/lua/core/startup.lua
+++ b/lua/core/startup.lua
@@ -33,7 +33,7 @@ require 'core/menu'
 
 -- global include function
 function include(file)
-  return dofile(norns.state.path .. file .. '.lua')
+  return dofile(_path.code .. file .. '.lua')
 end
 
 


### PR DESCRIPTION
many apologies for the breakage!

`include(file)` now includes from `dust/code` (and appends `.lua`)

previously was including from current folder (ie `dust/code/awake`) which made cross-folder sharing difficult (ie for engine libs)