### PR TITLE
include() checks two paths

### DIFF
--- a/lua/core/startup.lua
+++ b/lua/core/startup.lua
@@ -33,7 +33,15 @@ require 'core/menu'
 
 -- global include function
 function include(file)
-  return dofile(_path.code .. file .. '.lua')
+  local here = norns.state.path .. file .. '.lua'
+  local there = _path.code .. file .. '.lua'
+  if util.file_exists(here) then 
+    print("including "..here)
+    return dofile(here)
+  else
+    print("including "..there)
+    return dofile(there)
+  end
 end
 
 


### PR DESCRIPTION
for `include(filepath)`:

- first check local ie `dust/code/awake/(filepath).lua`
- second check root folder = `dust/code/(filepath).lua`

thanks @catfact 