### PR TITLE
fix crash in engine report (strlen), report engines on startup

### DIFF
--- a/lua/core/startup.lua
+++ b/lua/core/startup.lua
@@ -53,6 +53,9 @@ norns.startup_status.ok = function()
   norns.state.resume()
   -- turn on VU
   _norns.poll_start_vu()
+  -- report engines
+  report_engines()
+  
 end
 
 norns.startup_status.timeout = function()

--- a/matron/src/oracle.c
+++ b/matron/src/oracle.c
@@ -362,7 +362,7 @@ void o_set_engine_name(int idx, const char *name) {
                 "refusing to allocate engine name %d; already exists",
                 idx);
     } else {
-        len = strlen(name);
+        len = strlen(name) + 1; // include null terminator
         engine_names[idx] = malloc(len);
         if ( engine_names[idx] == NULL ) {
             fprintf(stderr,
@@ -370,7 +370,7 @@ void o_set_engine_name(int idx, const char *name) {
                     idx,
                     name);
         } else {
-            strncpy(engine_names[idx], name, len + 1);
+            strncpy(engine_names[idx], name, len);
         }
     }
     o_unlock_descriptors();
@@ -709,7 +709,7 @@ int handle_engine_report_start(const char *path,
                                void *user_data)
 {
     assert(argc > 0);
-    // arg 1: count of engines
+    // arg 1: count of engines    
     o_clear_engine_names();
     o_set_num_desc(&num_engines, argv[0]->i);
     return 0;


### PR DESCRIPTION
fix a dang null-terminator bug that crashed matron sometimes on engine report.

also, report engines on startup, because why not

fixes issue #798 