### PR TITLE
add dummy engine; allows scripts to use polls w/o an engine

### DIFF
--- a/lua/core/script.lua
+++ b/lua/core/script.lua
@@ -157,8 +157,7 @@ Script.run = function()
     print("loading engine: " .. engine.name)
     engine.load(engine.name, Script.init)
   else
-    local status = norns.try(Script.init,"init")
-    norns.init_done(status)
+    engine.load("None", Script.init)
   end
 end
 

--- a/sc/core/CroneEngine.sc
+++ b/sc/core/CroneEngine.sc
@@ -81,3 +81,14 @@ CroneEngine {
 
 }
 
+
+// dummy engine
+Engine_None : CroneEngine {
+	*new { arg context, doneCallback;
+		^super.new(context, doneCallback);
+	}
+
+	alloc {}
+
+	free {}
+}


### PR DESCRIPTION
addresses issue #615 by simply adding an empty engine called `Engine_None`.

test script: `no_engine.lua` 
```
-- engine.name = nope
function init()
   local p_amp_l = poll.set('amp_in_l', function(amp_l) print("amp L: "..amp_l) end)
   local p_amp_r = poll.set('amp_in_r', function(amp_r) print("amp R: "..amp_l) end)
   p_amp_l:start()
   p_amp_r:start()
end
```