### PR TITLE
flip pan

### DIFF
--- a/crone/src/Bus.h
+++ b/crone/src/Bus.h
@@ -196,8 +196,8 @@ namespace  crone {
                 x = a.buf[0][fr];
                 l = level.update();
                 c = pan.update();
-                buf[0][fr] += x*l*c;
-                buf[1][fr] += x*l*(1.f-c);
+                buf[1][fr] += x*l*c;
+                buf[0][fr] += x*l*(1.f-c);
             }
         }
 
@@ -212,8 +212,8 @@ namespace  crone {
                 l = level.update();
                 c = pan.update();
                 c *= (float)M_PI_2;
-                buf[0][fr] += x*l * sinf(c);
-                buf[1][fr] += x*l * cosf(c);
+                buf[1][fr] += x*l * sinf(c);
+                buf[0][fr] += x*l * cosf(c);
             }
         }
 


### PR DESCRIPTION
fixes #817 

flipped the pan. so now 1=R, 0=L.

could also change this to bipolar if that's desired.