### PR TITLE
softcut phase offset

### DIFF
--- a/crone/osc-methods.txt
+++ b/crone/osc-methods.txt
@@ -1,5 +1,5 @@
 
-osc methods: 
+osc methods:
  /hello []
  /goodbye []
  /quit []
@@ -70,6 +70,7 @@ osc methods:
  /softcut/buffer/clear_region [ff]
  /softcut/buffer/clear_region_channel [iff]
  /set/param/cut/phase_quant [if]
+ /set/param/cut/phase_offset [if]
  /poll/start/cut/phase []
  /poll/stop/cut/phase []
  /tape/record/open [s]
@@ -79,4 +80,4 @@ osc methods:
  /tape/play/start []
  /tape/play/stop []
  /set/level/tape [f]
- 
+

--- a/crone/src/OscInterface.cpp
+++ b/crone/src/OscInterface.cpp
@@ -105,7 +105,7 @@ void OscInterface::addServerMethod(const char* path, const char* format, Handler
                                     (void) types;
                                     (void) msg;
                                     auto pm = static_cast<OscMethod*>(data);
-                                    std::cerr << "osc rx: " << path << std::endl;
+                                    //std::cerr << "osc rx: " << path << std::endl;
                                     pm->handler(argv, argc);
                                     return 0;
                                 }, &(methods[numMethods]));

--- a/crone/src/OscInterface.cpp
+++ b/crone/src/OscInterface.cpp
@@ -636,6 +636,11 @@ void OscInterface::addServerMethods() {
         softCutClient->setPhaseQuant(argv[0]->i, argv[1]->f);
     });
 
+    addServerMethod("/set/param/cut/phase_offset", "if", [](lo_arg **argv, int argc) {
+        if (argc<2) { return; }
+        softCutClient->setPhaseOffset(argv[0]->i, argv[1]->f);
+    });
+
     addServerMethod("/poll/start/cut/phase", "", [](lo_arg **argv, int argc) {
         (void)argv; (void)argc;
         phasePoll->start();

--- a/crone/src/SoftCutClient.h
+++ b/crone/src/SoftCutClient.h
@@ -81,6 +81,9 @@ namespace crone {
         void setPhaseQuant(int i, softcut::phase_t q) {
             cut.setPhaseQuant(i, q);
         }
+        void setPhaseOffset(int i, float sec) {
+            cut.setPhaseOffset(i, sec);
+        }
 
         int getNumVoices() const { return NumVoices; }
 

--- a/crone/src/softcut/SoftCut.h
+++ b/crone/src/softcut/SoftCut.h
@@ -165,6 +165,10 @@ namespace softcut {
             scv[i].setPhaseQuant(q);
         }
 
+        void setPhaseOffset(int i, float sec) {
+            scv[i].setPhaseOffset(sec);
+        }
+
         bool getRecFlag(int i) {
             return scv[i].getRecFlag();
         }

--- a/crone/src/softcut/SoftCutVoice.cpp
+++ b/crone/src/softcut/SoftCutVoice.cpp
@@ -188,7 +188,7 @@ void SoftCutVoice::updateQuantPhase() {
     if (phaseQuant == 0) {
         quantPhase = sch.getActivePhase() / sampleRate;
     } else {
-        quantPhase = std::floor( (sch.getActivePhase() + phaseOffset) /
+        quantPhase = std::floor( (sch.getActivePhase() + (phaseOffset * sampleRate)) /
             (sampleRate *phaseQuant)) * phaseQuant;
     }
 }

--- a/crone/src/softcut/SoftCutVoice.cpp
+++ b/crone/src/softcut/SoftCutVoice.cpp
@@ -176,7 +176,7 @@ void SoftCutVoice::setPhaseQuant(float x) {
 }
 
 void SoftCutVoice::setPhaseOffset(float x) {
-    phaseOffset = x;
+    phaseOffset = x * sampleRate;
 }
 
 
@@ -188,7 +188,7 @@ void SoftCutVoice::updateQuantPhase() {
     if (phaseQuant == 0) {
         quantPhase = sch.getActivePhase() / sampleRate;
     } else {
-        quantPhase = std::floor( (sch.getActivePhase() + (phaseOffset * sampleRate)) /
+        quantPhase = std::floor( (sch.getActivePhase() + phaseOffset) /
             (sampleRate *phaseQuant)) * phaseQuant;
     }
 }

--- a/crone/src/softcut/SoftCutVoice.cpp
+++ b/crone/src/softcut/SoftCutVoice.cpp
@@ -175,6 +175,10 @@ void SoftCutVoice::setPhaseQuant(float x) {
     phaseQuant = x;
 }
 
+void SoftCutVoice::setPhaseOffset(float x) {
+    phaseOffset = x;
+}
+
 
 phase_t SoftCutVoice::getQuantPhase() {
     return quantPhase;
@@ -184,7 +188,8 @@ void SoftCutVoice::updateQuantPhase() {
     if (phaseQuant == 0) {
         quantPhase = sch.getActivePhase() / sampleRate;
     } else {
-        quantPhase = std::floor(sch.getActivePhase() / (sampleRate *phaseQuant)) * phaseQuant;
+        quantPhase = std::floor( (sch.getActivePhase() + phaseOffset) /
+            (sampleRate *phaseQuant)) * phaseQuant;
     }
 }
 

--- a/crone/src/softcut/SoftCutVoice.h
+++ b/crone/src/softcut/SoftCutVoice.h
@@ -49,6 +49,7 @@ namespace softcut {
         void setLevelSlewTime(float d);
         void setRateSlewTime(float d);
         void setPhaseQuant(float x);
+        void setPhaseOffset(float x);
 
         phase_t getQuantPhase();
 
@@ -85,6 +86,8 @@ namespace softcut {
         float svfDryLevel = 1.0;
         // phase quantization unit, should be in [0,1]
         phase_t phaseQuant;
+        // phase offset in sec
+        float phaseOffset = 0;
         // quantized phase
         std::atomic<phase_t> quantPhase;
 

--- a/lua/core/softcut.lua
+++ b/lua/core/softcut.lua
@@ -101,6 +101,8 @@ SC.rate_slew_time = function(voice,value) _norns.cut_param("rate_slew_time",voic
 
 --- set phase poll quantization
 SC.phase_quant = function(voice,value) _norns.cut_param("phase_quant",voice,value) end
+--- set phase poll offset
+SC.phase_offset = function(voice,value) _norns.cut_param("phase_offset",voice,value) end
 --- start phase poll
 SC.poll_start_phase = function() _norns.poll_start_cut_phase() end
 --- stop phase poll

--- a/lua/core/softcut.lua
+++ b/lua/core/softcut.lua
@@ -182,6 +182,8 @@ function SC.reset()
     SC.filter_br(i,0)
     SC.level_slew_time(i,0.001)
     SC.rate_slew_time(i,0.001)
+    SC.phase_quant(i,1)
+    SC.phase_offset(i,0)
   end
   SC.buffer_clear()
 end


### PR DESCRIPTION
function to add offset to the phase quantization calc.

helpful for loops that don't start at position 0 (or a nice multiple thereof), needed for mlr

(also commented out osc packet prints)