### PR TITLE
docs: fixes audio.level_monitor() ldoc

### DIFF
--- a/lua/core/audio.lua
+++ b/lua/core/audio.lua
@@ -26,7 +26,7 @@ Audio.level_eng = function(level)
   _norns.level_ext(level)
 end
 
--- set monitor level for *both* input channels.
+--- set monitor level for *both* input channels.
 -- @param level in [0, 1]
 Audio.level_monitor = function(level)
   _norns.level_monitor(level)


### PR DESCRIPTION
Since ldoc only parses comments beginning with 3 hyphens, `level_monitor` wasn't showing up in norns docs. Currently, the only way to discover this function is to read the source.