### PR TITLE
tape->cut and tape->reverb routing options

### DIFF
--- a/crone/osc-methods.txt
+++ b/crone/osc-methods.txt
@@ -80,4 +80,6 @@ osc methods:
  /tape/play/start []
  /tape/play/stop []
  /set/level/tape [f]
+ /set/level/tape_cut [f]
+ /set/level/tape_rev [f]
 

--- a/crone/src/Commands.h
+++ b/crone/src/Commands.h
@@ -51,6 +51,8 @@ namespace crone {
             SET_LEVEL_IN_CUT,
             SET_LEVEL_CUT_CUT,
             SET_LEVEL_TAPE,
+            SET_LEVEL_TAPE_AUX,
+            SET_LEVEL_TAPE_CUT,
 
             // params
             SET_CUT_REC_FLAG,

--- a/crone/src/MixerClient.cpp
+++ b/crone/src/MixerClient.cpp
@@ -44,8 +44,6 @@ void MixerClient::process(jack_nframes_t numFrames) {
         float *dst[2] = {static_cast<float*>(bus.tape.buf[0]), static_cast<float*>(bus.tape.buf[1])};
         tape.reader.process(dst, numFrames);
         bus.tape.applyGain(numFrames, smoothLevels.tape);
-        // FIXME: probably want other options for tape playback routing.
-        /// for now, just sum tape to insert bus
         bus.ins_in.addFrom(bus.tape, numFrames);
     }
 

--- a/crone/src/MixerClient.cpp
+++ b/crone/src/MixerClient.cpp
@@ -208,7 +208,7 @@ MixerClient::SmoothLevelList::SmoothLevelList() {
     cut.setTarget(1.f);
     monitor.setTarget(0.f);
     tape.setTarget(1.f);
-    adc_cut.setTarget(1.f);
+    adc_cut.setTarget(0.f);
     ext_cut.setTarget(0.f);
     tape_cut.setTarget(0.f);
     monitor_aux.setTarget(0.f);

--- a/crone/src/MixerClient.cpp
+++ b/crone/src/MixerClient.cpp
@@ -209,12 +209,14 @@ MixerClient::SmoothLevelList::SmoothLevelList() {
     ext.setTarget(1.f);
     cut.setTarget(1.f);
     monitor.setTarget(0.f);
-    cut_aux.setTarget(0.f);
-    ext_aux.setTarget(0.f);
-    tape_aux.setTarget(0.f);
+    tape.setTarget(1.f);
+    adc_cut.setTarget(1.f);
     ext_cut.setTarget(0.f);
     tape_cut.setTarget(0.f);
     monitor_aux.setTarget(0.f);
+    cut_aux.setTarget(0.f);
+    ext_aux.setTarget(0.f);
+    tape_aux.setTarget(0.f);
     aux.setTarget(0.f);
     ins_mix.setTarget(0.f);
 }
@@ -225,13 +227,16 @@ void MixerClient::SmoothLevelList::setSampleRate(float sr) {
     ext.setSampleRate(sr);
     cut.setSampleRate(sr);
     monitor.setSampleRate(sr);
+    tape.setSampleRate(sr);
+    adc_cut.setSampleRate(sr);
+    ext_cut.setSampleRate(sr);
+    tape_cut.setSampleRate(sr);
+    monitor_aux.setSampleRate(sr);
     cut_aux.setSampleRate(sr);
     ext_aux.setSampleRate(sr);
     tape_aux.setSampleRate(sr);
-    monitor_aux.setSampleRate(sr);
     aux.setSampleRate(sr);
-    ins_mix.setSampleRate(sr);    tape.setSampleRate(sr);
-
+    ins_mix.setSampleRate(sr);
 }
 
 MixerClient::StaticLevelList::StaticLevelList() {

--- a/crone/src/MixerClient.cpp
+++ b/crone/src/MixerClient.cpp
@@ -207,7 +207,7 @@ MixerClient::SmoothLevelList::SmoothLevelList() {
     ext.setTarget(1.f);
     cut.setTarget(1.f);
     monitor.setTarget(0.f);
-    tape.setTarget(1.f);
+    tape.setTarget(0.f);
     adc_cut.setTarget(0.f);
     ext_cut.setTarget(0.f);
     tape_cut.setTarget(0.f);

--- a/crone/src/MixerClient.h
+++ b/crone/src/MixerClient.h
@@ -75,18 +75,20 @@ namespace  crone {
             LogRamp ext;
             LogRamp cut;
             LogRamp monitor;
+            LogRamp tape;
             // softcut input levels
             LogRamp adc_cut;
             LogRamp ext_cut;
+            LogRamp tape_cut;
             // aux send levels
             LogRamp monitor_aux;
             LogRamp cut_aux;
             LogRamp ext_aux;
+            LogRamp tape_aux;
             // FX return / mix levels
             LogRamp aux;
             LogRamp ins_mix;
-            // tape playback level
-            LogRamp tape;
+
             SmoothLevelList();
             void setSampleRate(float sr);
         };

--- a/crone/src/OscInterface.cpp
+++ b/crone/src/OscInterface.cpp
@@ -305,7 +305,11 @@ void OscInterface::addServerMethods() {
     addServerMethod("/set/level/ext_cut", "f", [](lo_arg **argv, int argc) {
         if(argc<1) { return; }
         Commands::mixerCommands.post(Commands::Id::SET_LEVEL_EXT_CUT, argv[0]->f);
+    });
 
+    addServerMethod("/set/level/tape_cut", "f", [](lo_arg **argv, int argc) {
+        if(argc<1) { return; }
+        Commands::mixerCommands.post(Commands::Id::SET_LEVEL_TAPE_CUT, argv[0]->f);
     });
 
     addServerMethod("/set/level/cut_rev", "f", [](lo_arg **argv, int argc) {
@@ -690,6 +694,10 @@ void OscInterface::addServerMethods() {
         Commands::mixerCommands.post(Commands::Id::SET_LEVEL_TAPE, argv[0]->f);
     });
 
+    addServerMethod("/set/level/tape_rev", "f", [](lo_arg **argv, int argc) {
+        if (argc<1) { return; }
+        Commands::mixerCommands.post(Commands::Id::SET_LEVEL_TAPE_AUX, argv[0]->f);
+    });
 }
 
 void OscInterface::printServerMethods() {

--- a/lua/core/audio.lua
+++ b/lua/core/audio.lua
@@ -98,6 +98,12 @@ function Audio.level_eng_rev(val)
    _norns.level_ext_rev(val)
 end
 
+--- reverb TAPE level.
+-- @param val
+function Audio.level_tape_rev(val)
+   _norns.level_tape_rev(val)
+end
+
 --- reverb DAC level.
 -- @param val
 function Audio.level_rev_dac(val)
@@ -185,6 +191,12 @@ end
 -- @param value
 Audio.level_eng_cut = function(value)
   _norns.level_ext_cut(value)
+end
+
+--- softcut tape level.
+-- @param value
+Audio.level_tape_cut = function(value)
+  _norns.level_tape_cut(value)
 end
 
 --- softcut cut reverb level.

--- a/lua/core/mix.lua
+++ b/lua/core/mix.lua
@@ -65,6 +65,10 @@ mix:add_control("rev_monitor_input", "rev monitor input", cs_DB_LEVEL_MUTE)
 mix:set_action("rev_monitor_input",
   function(x) audio.level_monitor_rev(util.dbamp(x)) end)
 
+mix:add_control("rev_tape_input", "rev tape input", cs_DB_LEVEL_MUTE)
+mix:set_action("rev_tape_input",
+  function(x) audio.level_tape_rev(util.dbamp(x)) end)
+
 mix:add_control("rev_return_level", "rev return level", cs_DB_LEVEL)
 mix:set_action("rev_return_level",
   function(x) audio.level_rev_dac(util.dbamp(x)) end)

--- a/matron/src/oracle.c
+++ b/matron/src/oracle.c
@@ -508,6 +508,10 @@ void o_set_level_tape(float level) {
     lo_send(crone_addr, "/set/level/tape", "f", level);
 }
 
+void o_set_level_tape_rev(float level) {
+    lo_send(crone_addr, "/set/level/tape_rev", "f", level);
+}
+
 void o_tape_rec_open(char *file) {
     lo_send(crone_addr, "/tape/record/open", "s", file);
 }
@@ -544,6 +548,10 @@ void o_set_level_adc_cut(float value) {
 
 void o_set_level_ext_cut(float value) {
     lo_send(crone_addr, "/set/level/ext_cut", "f", value);
+}
+
+void o_set_level_tape_cut(float value) {
+    lo_send(crone_addr, "/set/level/tape_cut", "f", value);
 }
 
 void o_set_level_cut_rev(float value) {

--- a/matron/src/oracle.h
+++ b/matron/src/oracle.h
@@ -127,6 +127,7 @@ extern void o_tape_play_stop();
 //--- cut
 extern void o_set_level_adc_cut(float value);
 extern void o_set_level_ext_cut(float value);
+extern void o_set_level_tape_cut(float value);
 extern void o_set_level_cut_rev(float value);
 extern void o_set_level_cut_master(float value);
 extern void o_set_level_cut(int index, float value);
@@ -154,6 +155,7 @@ extern void o_set_rev_on();
 extern void o_set_rev_off();
 extern void o_set_level_monitor_rev(float value);
 extern void o_set_level_ext_rev(float value);
+extern void o_set_level_tape_rev(float value);
 extern void o_set_level_rev_dac(float value);
 extern void o_set_rev_param(const char* name, float value);
 

--- a/matron/src/weaver.c
+++ b/matron/src/weaver.c
@@ -155,6 +155,7 @@ static int _tape_play_stop(lua_State *l);
 // cut
 static int _set_level_adc_cut(lua_State *l);
 static int _set_level_ext_cut(lua_State *l);
+static int _set_level_tape_cut(lua_State *l);
 static int _set_level_cut_rev(lua_State *l);
 static int _set_level_cut_master(lua_State *l);
 static int _set_level_cut(lua_State *l);
@@ -179,6 +180,7 @@ static int _set_rev_on(lua_State *l);
 static int _set_rev_off(lua_State *l);
 static int _set_level_monitor_rev(lua_State *l);
 static int _set_level_ext_rev(lua_State *l);
+static int _set_level_tape_rev(lua_State *l);
 static int _set_level_rev_dac(lua_State *l);
 static int _set_rev_param(lua_State *l);
 
@@ -252,6 +254,7 @@ void w_init(void) {
   lua_register_norns("level_ext_rev", &_set_level_ext_rev);
   lua_register_norns("level_rev_dac", &_set_level_rev_dac);
   lua_register_norns("level_monitor_rev", &_set_level_monitor_rev);
+  lua_register_norns("level_tape_rev", &_set_level_tape_rev);
   lua_register_norns("comp_on", &_set_comp_on);
   lua_register_norns("comp_off", &_set_comp_off);
   lua_register_norns("comp_param", &_set_comp_param);
@@ -274,6 +277,7 @@ void w_init(void) {
   // cut
   lua_register_norns("level_adc_cut", &_set_level_adc_cut);
   lua_register_norns("level_ext_cut", &_set_level_ext_cut);
+  lua_register_norns("level_tape_cut", &_set_level_tape_cut);
   lua_register_norns("level_cut_rev", &_set_level_cut_rev);
   lua_register_norns("level_cut_master", &_set_level_cut_master);
   lua_register_norns("level_cut", &_set_level_cut);
@@ -2126,6 +2130,15 @@ int _set_level_ext_cut(lua_State *l) {
   return 0;
 }
 
+int _set_level_tape_cut(lua_State *l) {
+  if (lua_gettop(l) != 1) {
+    return luaL_error(l, "wrong number of arguments");
+  }
+  float val = (float) luaL_checknumber(l, 1);
+  o_set_level_tape_cut(val);
+  return 0;
+}
+
 int _set_level_cut_rev(lua_State *l) {
   if (lua_gettop(l) != 1) {
     return luaL_error(l, "wrong number of arguments");
@@ -2337,6 +2350,15 @@ int _set_level_ext_rev(lua_State *l) {
   }
   float val = (float) luaL_checknumber(l, 1);
   o_set_level_ext_rev(val);
+  return 0;
+}
+
+int _set_level_tape_rev(lua_State *l) {
+  if (lua_gettop(l) != 1) {
+    return luaL_error(l, "wrong number of arguments");
+  }
+  float val = (float) luaL_checknumber(l, 1);
+  o_set_level_tape_rev(val);
   return 0;
 }
 


### PR DESCRIPTION
So far this PR
* adds tape->cut and tape->aux level params to the crone mixer, initialized to 0 / -inf dB
* exposes tape->cut and tape->aux as OSC endpoints
* adds tape->cut and tape->aux methods to the Audio module in matron
* adds `rev tape input` menu param to `system > audio`

Tape to reverb works great. There's no direct UI exposure of the tape->cut parameter; I was able to test it by running `local audio = require('core\audio') audio.level_tape_cut(18.0)` in the maiden console. This is pretty fun, it ends up being a back door way of getting recorded material into mlr.

Making the tape->cut default to unity gain would make this step unnecessary, but that seems like a breaking change for people who want to play a backing track unaltered while sampling live input. Not sure if this should be a system level control or up to scripts to manage.

(as discussed here: https://llllllll.co/t/norns-help/14016/1406)