### PR TITLE
norns.menu.toggle() function added

### DIFF
--- a/lua/core/menu.lua
+++ b/lua/core/menu.lua
@@ -94,6 +94,7 @@ end
 norns.menu.get_enc = function() return menu.penc end
 norns.menu.get_key = function() return menu.key end
 norns.menu.get_redraw = function() return menu.redraw end
+norns.menu.toggle = function(status) menu.set_mode(status) end
 
 norns.scripterror = function(msg)
   local msg = msg;


### PR DESCRIPTION
Currently there is no way of calling menu from script (eg. for entering menu from keyboard).