### PR TITLE
set name in engine.load

### DIFF
--- a/lua/core/engine.lua
+++ b/lua/core/engine.lua
@@ -85,6 +85,7 @@ Engine.load = function(name, callback)
     end
   else norns.init_done(true)
   end
+  Engine.name = name
   load_engine(name)
 end
 


### PR DESCRIPTION
Simply added  ` Engine.name = name` to `Engine.load`

Works ok with engine switching script (modified from [here](https://github.com/neauoire/tutorial/blob/master/A_engine.lua)). Not sure if this impacts anything else as @catfact [mentions here](https://llllllll.co/t/norns-development/14073/334) 
