### PR TITLE
move wifi-init

### DIFF
--- a/lua/core/startup.lua
+++ b/lua/core/startup.lua
@@ -26,8 +26,6 @@ controlspec = require 'core/controlspec'
 paramset = require 'core/paramset'
 params = paramset.new()
 
-wifi.init()
-
 
 -- load menu
 require 'core/menu'
@@ -55,7 +53,8 @@ norns.startup_status.ok = function()
   _norns.poll_start_vu()
   -- report engines
   report_engines()
-  
+  wifi.init()
+ 
 end
 
 norns.startup_status.timeout = function()
@@ -70,3 +69,5 @@ s_save()
 print("start_audio(): ")
 -- start the process of syncing with crone boot
 start_audio()
+
+


### PR DESCRIPTION
per #788 this moves `wifi.init()` into the `norns.startup_status.ok` callback function - at which point `wifi.state` gets set properly and the norns screen does not display `-` for IP address after reboot.