### PR TITLE
report duplicates, improve missing include warning

### DIFF
--- a/lua/core/menu.lua
+++ b/lua/core/menu.lua
@@ -281,9 +281,8 @@ m.redraw[pHOME] = function()
     screen.move(0,15)
     screen.level(15)
     local line = string.upper(norns.state.name)
-    --if(menu.scripterror and state.script ~= '') then
     if(menu.scripterror and menu.errormsg ~= 'NO SCRIPT') then
-      line = line .. " (error: " .. menu.errormsg .. ")"
+      line = "error: " .. menu.errormsg
     end
     screen.text(line)
   else

--- a/lua/core/startup.lua
+++ b/lua/core/startup.lua
@@ -69,7 +69,7 @@ norns.startup_status.timeout = function()
     print("DUPLICATE ENGINES:\n" .. results)
     norns.scripterror("DUPLICATE ENGINES")
   else
-    norns.scripterror("SUPERCOLLODER FAIL")
+    norns.scripterror("SUPERCOLLIDER FAIL")
   end
 end
 

--- a/lua/core/startup.lua
+++ b/lua/core/startup.lua
@@ -69,7 +69,7 @@ norns.startup_status.timeout = function()
     print("DUPLICATE ENGINES:\n" .. results)
     norns.scripterror("DUPLICATE ENGINES")
   else
-    norns.scripterror("AUDIO ERROR")
+    norns.scripterror("SUPERCOLLODER FAIL")
   end
 end
 

--- a/lua/core/startup.lua
+++ b/lua/core/startup.lua
@@ -37,9 +37,12 @@ function include(file)
   if util.file_exists(here) then 
     print("including "..here)
     return dofile(here)
-  else
+  elseif util.file_exists(there) then
     print("including "..there)
     return dofile(there)
+  else
+    print("### MISSING INCLUDE: "..file)
+    error("MISSING INCLUDE: "..file,2)
   end
 end
 

--- a/lua/core/startup.lua
+++ b/lua/core/startup.lua
@@ -58,9 +58,16 @@ norns.startup_status.ok = function()
 end
 
 norns.startup_status.timeout = function()
-  print("norns.startup_status.timeout")
   norns.script.clear()
-  norns.scripterror("AUDIO ENGINE")
+  print("norns.startup_status.timeout")
+  local cmd="find ~/dust -name *.sc -type f -printf '%p %f\n' | sort -k2 | uniq -f1 --all-repeated=separate"
+  local results = util.os_capture(cmd,true)
+  if results ~= "" then
+    print("DUPLICATE ENGINES:\n" .. results)
+    norns.scripterror("DUPLICATE ENGINES")
+  else
+    norns.scripterror("AUDIO ERROR")
+  end
 end
 
 -- initial screen state


### PR DESCRIPTION
instead of AUDIO ENGINE error, now we see DUPLICATE ENGINES and then the duplicates are printed out in maiden.

fixes #864