### PR TITLE
reset quant phase stuff in softcutvoice:reset

### DIFF
--- a/crone/src/softcut/SoftCut.h
+++ b/crone/src/softcut/SoftCut.h
@@ -36,9 +36,7 @@ namespace softcut {
 
         void reset() {
             for (int v = 0; v < numVoices; ++v) {
-		        scv[v].reset();
-                /* scv[v].phase_quant(i, 1); */
-                /* scv[v].phase_offset(i, 0); */
+		scv[v].reset();
             };
         }
 

--- a/crone/src/softcut/SoftCutVoice.cpp
+++ b/crone/src/softcut/SoftCutVoice.cpp
@@ -40,6 +40,9 @@ void SoftCutVoice::reset() {
     recFlag = false;
     playFlag = false;
 
+
+    setPhaseQuant(1);
+    setPhaseOffset(0);
     sch.init();
 
 }


### PR DESCRIPTION
should probably reset phase quantization and offset settings along with other softcut voice params.