### PR TITLE
update start/stop to use systemctl

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -1,3 +1,4 @@
-cd "$(dirname "$0")"
-./crone.sh > /dev/null &
-./matron.sh > /dev/null &
+sudo systemctl start norns-jack.service
+sudo systemctl start norns-matron.service
+sudo systemctl start norns-crone.service
+

--- a/stop.sh
+++ b/stop.sh
@@ -1,4 +1,4 @@
-killall matron
-killall sclang
-killall scsynth
-killall crone
+sudo systemctl stop norns-jack.service
+sudo systemctl stop norns-matron.service
+sudo systemctl stop norns-crone.service
+


### PR DESCRIPTION
Could we update the start/stop scripts to use `systemctl` like this instead of using the manual `matron.sh/crone.sh` and `kill`?