### PR TITLE
add --supercollider-prefix config option

### DIFF
--- a/wscript
+++ b/wscript
@@ -13,6 +13,7 @@ def get_version_hash():
 def options(opt):
     opt.load('compiler_c compiler_cxx boost')
     opt.add_option('--desktop', action='store_true', default=False)
+    opt.add_option('--supercollider-prefix', action='store', default='/usr')
 
 def configure(conf):
     conf.load('compiler_c compiler_cxx boost')
@@ -45,17 +46,15 @@ def configure(conf):
         header_name='monome.h',
         uselib_store='LIBMONOME')
 
+    conf.env.SC_PREFIX = conf.options.supercollider_prefix
+
     conf.check_cxx(msg='Checking for supercollider',
         define_name='HAVE_SUPERCOLLIDER',
         mandatory=True,
         includes=[
-            '{}/include/SuperCollider/plugin_interface'.format(conf.env.PREFIX),
-            '{}/include/SuperCollider/common'.format(conf.env.PREFIX),
-            '/usr/include/SuperCollider/plugin_interface',
-            '/usr/include/SuperCollider/common',
-            '/usr/local/include/SuperCollider/plugin_interface',
-            '/usr/local/include/SuperCollider/common',
-            '/sc/external_libraries/nova-simd'
+            '{}/include/SuperCollider/plugin_interface'.format(conf.env.SC_PREFIX),
+            '{}/include/SuperCollider/common'.format(conf.env.SC_PREFIX),
+	    '{}/sc/external_libraries/nova-simd'.format(top)
         ],
         header_name='SC_PlugIn.h',
         uselib_store='SUPERCOLLIDER')


### PR DESCRIPTION
there is currently some include path hackery going on within the norns buildroot setup when it comes to checking for supercollider headers and building plugins. this additional configuration flag should allow the buildroot setup to be streamlined (allow the path to supercollider in the cross compilation environment to be passed in).

note that i've removed the absolute and partially redundant include paths for `/usr/local/include/SuperCollider...` and `/usr/include/SuperCollider` and replaced them with paths that start with and explict SC_PREFIX value

the default for `--supercollider-prefix` is `/usr` so things will still compile on the current norns device(s) and likely any Linux hosts with supercollider installed via a package. 

/cc @simonvanderveldt 