### PR TITLE
initialize all softcut filters to fully dry, reasonable bandwidth

### DIFF
--- a/crone/src/softcut/SoftCutVoice.cpp
+++ b/crone/src/softcut/SoftCutVoice.cpp
@@ -21,16 +21,16 @@ void SoftCutVoice::reset() {
     svfPre.setHpMix(0.0);
     svfPre.setBpMix(0.0);
     svfPre.setBrMix(0.0);
-    svfPre.setRq(20.0);
+    svfPre.setRq(4.0);
     svfPre.setFc(svfPreFcBase);
     svfPreFcMod = 1.0;
-    svfPreDryLevel = 1.0;
+    svfPreDryLevel = 0.0;
 
     svfPost.setLpMix(0.0);
     svfPost.setHpMix(0.0);
     svfPost.setBpMix(0.0);
     svfPost.setBrMix(0.0);
-    svfPost.setRq(20.0);
+    svfPost.setRq(4.0);
     svfPost.setFc(12000);
     svfPostDryLevel = 1.0;
 


### PR DESCRIPTION
first of several small PRs around crone levels.

here, softcut reset was erroneously setting both lowpass and dry pre-filter routes to full volume. this halved the headroom for clipping at the buffer input.

solution taken here is to use only the dry route. this means rate->filter modulation will not be apparent without explicitly setting filter mode levels. but i think this is actually the right default - otherwise users are surprised by any phase shift or &c introduced by the filter even when fully open.

also, the default RQ value of 20 was a little silly.