### PR TITLE
Softcut equal power pan

### DIFF
--- a/crone/src/Bus.h
+++ b/crone/src/Bus.h
@@ -187,7 +187,7 @@ namespace  crone {
             }
         }
 
-        // mix from mono->stereo bus, with level and pan (equal power)
+        // mix from mono->stereo bus, with level and pan (linear)
         void panMixFrom(Bus<1, BlockSize> a, size_t numFrames, LogRamp &level, LogRamp& pan) {
             BOOST_ASSERT(numFrames < BlockSize);
             static_assert(NumChannels > 1, "using panMixFrom() on mono bus");

--- a/crone/src/SoftCutClient.cpp
+++ b/crone/src/SoftCutClient.cpp
@@ -62,7 +62,7 @@ void crone::SoftCutClient::mixInput(size_t numFrames) {
 void crone::SoftCutClient::mixOutput(size_t numFrames) {
     for (int v = 0; v < NumVoices; ++v) {
         if (cut.getPlayFlag(v)) {
-            mix.panMixFrom(output[v], numFrames, outLevel[v], outPan[v]);
+            mix.panMixEpFrom(output[v], numFrames, outLevel[v], outPan[v]);
         }
     }
 }


### PR DESCRIPTION
use equal power panning when mixing softcut voices to output bus.