### PR TITLE
Cleanup device_crow

### DIFF
--- a/matron/src/device/device_crow.c
+++ b/matron/src/device/device_crow.c
@@ -38,7 +38,7 @@ int dev_crow_init(void *self) {
     d->newtio.c_cc[VTIME]=5;
     tcflush(d->fd, TCIFLUSH);
     tcsetattr(d->fd,TCSANOW,&d->newtio);
-    
+
     // check if modem is a crow
     char s[256];
     read(d->fd, s, 255); // clear buffer
@@ -48,8 +48,8 @@ int dev_crow_init(void *self) {
     //fprintf(stderr,"crow init> %i %s",len,s);
 
     if(strstr(s,"^^identity")==NULL) {
-      fprintf(stderr,">> ttyACM found, but not a crow\n");
-      return -1;
+        fprintf(stderr,">> ttyACM found, but not a crow\n");
+        return -1;
     }
 
     base->start = &dev_crow_start;
@@ -66,35 +66,35 @@ static void handle_event(void *dev, uint8_t id) {
 }
 
 void *dev_crow_start(void *self) {
-	struct dev_crow *di = (struct dev_crow *)self;
-  struct dev_common *base = (struct dev_common *)self;
+    struct dev_crow *di = (struct dev_crow *)self;
+    struct dev_common *base = (struct dev_common *)self;
 
-	uint8_t len;
+    uint8_t len;
 
-	while(1) {
-		len = read(di->fd, di->line, 255);
-		if(len > 0) {
-			di->line[len] = 0; // add null to end of string
-			if(len>1) {
-				//fprintf(stderr,"crow> %s", di->line);
-				handle_event(self, base->id);
-			}
-			len = 0;
-		}
-		usleep(1000); // 1ms
-	}
-	return NULL;
+    while(1) {
+        len = read(di->fd, di->line, 255);
+        if(len > 0) {
+            di->line[len] = 0; // add null to end of string
+            if(len>1) {
+                //fprintf(stderr,"crow> %s", di->line);
+                handle_event(self, base->id);
+            }
+            len = 0;
+        }
+        usleep(1000); // 1ms
+    }
+    return NULL;
 }
 
 void dev_crow_deinit(void *self) {
     struct dev_crow *di = (struct dev_crow *)self;
-  	tcsetattr(di->fd,TCSANOW,&di->oldtio);
+    tcsetattr(di->fd,TCSANOW,&di->oldtio);
 }
 
 void dev_crow_send(struct dev_crow *d, const char *line) {
-	char s[256];
-	strcpy(s,line);
-	strcat(s,"\n\0");
-	//fprintf(stderr,"crow_send: %s",line);
-  write(d->fd, s, strlen(s));
+    char s[256];
+    strcpy(s,line);
+    strcat(s,"\n\0");
+    //fprintf(stderr,"crow_send: %s",line);
+    write(d->fd, s, strlen(s));
 }

--- a/matron/src/device/device_crow.c
+++ b/matron/src/device/device_crow.c
@@ -12,6 +12,9 @@
 #include "device_crow.h"
 #include "events.h"
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-result"
+
 #define TEST_NULL_AND_FREE(p) if( (p) != NULL ) { free(p); } \
     else { fprintf(stderr, "error: double free in device_crow.c\n"); }
 
@@ -42,7 +45,7 @@ int dev_crow_init(void *self) {
     // check if modem is a crow
     char s[256];
     read(d->fd, s, 255); // clear buffer
-    write(d->fd,"^^i\n\0",5);
+    write(d->fd,"^^i\n\0",5);    
     usleep(1000);
     read(d->fd, s, 255);
     //fprintf(stderr,"crow init> %i %s",len,s);
@@ -98,3 +101,6 @@ void dev_crow_send(struct dev_crow *d, const char *line) {
     //fprintf(stderr,"crow_send: %s",line);
     write(d->fd, s, strlen(s));
 }
+
+
+#pragma GCC diagnostic pop

--- a/matron/src/weaver.c
+++ b/matron/src/weaver.c
@@ -40,6 +40,14 @@
 #include "clock.h"
 #include "clocks/clock_internal.h"
 
+
+// registered lua functions require the LVM state as a parameter.
+// but often we don't need it.
+// use pragma instead of casting to void as a workaround.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+
+
 //------
 //---- global lua state!
 lua_State *lvm;
@@ -1247,7 +1255,6 @@ int _send_command(lua_State *l) {
 }
 
 int _request_engine_report(lua_State *l) {
-  (void)l;
   o_request_engine_report();
   return 0;
 }
@@ -1925,25 +1932,21 @@ int _set_level_monitor(lua_State *l) {
 }
 
 int _set_monitor_mix_mono(lua_State *l) {
-  (void)l;
   o_set_monitor_mix_mono();
   return 0;
 }
 
 int _set_monitor_mix_stereo(lua_State *l) {
-  (void)l;
   o_set_monitor_mix_stereo();
   return 0;
 }
 
 int _set_audio_pitch_on(lua_State *l) {
-  (void)l;
   o_set_audio_pitch_on();
   return 0;
 }
 
 int _set_audio_pitch_off(lua_State *l) {
-  (void)l;
   o_set_audio_pitch_off();
   return 0;
 }
@@ -1965,13 +1968,11 @@ int _tape_rec_open(lua_State *l) {
 }
 
 int _tape_rec_start(lua_State *l) {
-  (void)l;
   o_tape_rec_start();
   return 0;
 }
 
 int _tape_rec_stop(lua_State *l) {
-  (void)l;
   o_tape_rec_stop();
   return 0;
 }
@@ -1985,37 +1986,31 @@ int _tape_play_open(lua_State *l) {
 }
 
 int _tape_play_start(lua_State *l) {
-  (void)l;
   o_tape_play_start();
   return 0;
 }
 
 int _tape_play_stop(lua_State *l) {
-  (void)l;
   o_tape_play_stop();
   return 0;
 }
 
 int _poll_start_vu(lua_State *l) {
-  (void)l;
   o_poll_start_vu();
   return 0;
 }
 
 int _poll_stop_vu(lua_State *l) {
-  (void)l;
   o_poll_stop_vu();
   return 0;
 }
 
 int _poll_start_cut_phase(lua_State *l) {
-  (void)l;
   o_poll_start_cut_phase();
   return 0;
 }
 
 int _poll_stop_cut_phase(lua_State *l) {
-  (void)l;
   o_poll_stop_cut_phase();
   return 0;
 }
@@ -2090,7 +2085,6 @@ int _set_pan_cut(lua_State *l) {
 }
 
 int _cut_buffer_clear(lua_State *l) {
-  (void)l;
   o_cut_buffer_clear();
   return 0;
 }
@@ -2161,7 +2155,6 @@ int _cut_buffer_write_stereo(lua_State *l) {
 }
 
 int _cut_reset(lua_State *l) {
-  (void)l;
   o_cut_reset();
   return 0;
 }
@@ -2208,13 +2201,11 @@ int _set_level_input_cut(lua_State *l) {
 
 // rev effects controls
 int _set_rev_on(lua_State *l) {
-  (void)l;
   o_set_rev_on();
   return 0;
 }
 
 int _set_rev_off(lua_State *l) {
-  (void)l;
   o_set_rev_off();
   return 0;
 }
@@ -2258,13 +2249,11 @@ int _set_rev_param(lua_State *l) {
 
 // comp effects controls
 int _set_comp_on(lua_State *l) {
-  (void)l;
   o_set_comp_on();
   return 0;
 }
 
 int _set_comp_off(lua_State *l) {
-  (void)l;
   o_set_comp_off();
   return 0;
 }
@@ -2285,13 +2274,11 @@ int _set_comp_param(lua_State *l) {
 }
 
 int _start_audio(lua_State *l) {
-  (void)l;  
   norns_hello_start();
   return 0;
 }
 
 int _restart_audio(lua_State *l) {
-  (void)l;
   o_restart_audio();
   norns_hello_start();
   return 0;
@@ -2315,4 +2302,4 @@ int _system_cmd(lua_State *l)
   return 0;
 }
 
-
+#pragma GCC diagnostic pop


### PR DESCRIPTION
`device_crow.c` was throwing unused-result errors.
suppressed with gcc pragma.

gave weaver.c same treatment while i was thinking about it, removing some `(void)l` clutter. 

also, device_crow.c was an unholy mix of 2-space and tabs. uncrustified.