### PR TITLE
param remove

### DIFF
--- a/lua/core/paramset.lua
+++ b/lua/core/paramset.lua
@@ -121,7 +121,28 @@ end
 function ParamSet:print()
   print("paramset ["..self.name.."]")
   for k,v in pairs(self.params) do
-    print(k.." "..v.name.." = "..v:string())
+    local name = v.name or 'unnamed' -- e.g., separators
+    print(k.." "..name.." = "..v:string())
+  end
+end
+
+local function get_index(t, val)
+  for index, v in ipairs (t) do
+      if (v == val) then
+        return index
+      end
+  end
+  return nil
+end
+
+-- remove.
+function ParamSet:remove(id)
+  local param = self:lookup_param(id)
+  local index = get_index(self.params, param)
+  if (index) then
+    self.count = self.count - 1
+    self.lookup[id] = nil
+    table.remove(self.params, index)
   end
 end
 
@@ -210,7 +231,7 @@ function ParamSet:write(filename)
   print("pset >> write: "..filename)
   local fd = io.open(filename, "w+")
   io.output(fd)
-  for k,param in pairs(self.params) do
+  for _,param in pairs(self.params) do
     if param.id and param.t ~= self.tTRIGGER then
       io.write(string.format("%s: %s\n", quote(param.id), param:get()))
     end
@@ -267,7 +288,7 @@ end
 
 --- bang all params.
 function ParamSet:bang()
-  for k,v in pairs(self.params) do
+  for _,v in pairs(self.params) do
     if v.t ~= self.tTRIGGER then
       v:bang()
     end


### PR DESCRIPTION
this *almost* works but inexplicably falls over for some but not all param ids...

```
params:print()
paramset [arcadia]
1 enc3 = timbre
2 shape = 0.0 
3 timbre = 0.5 
4 sub = 0.0 
5 noise = 0.0 
6 stereo width = 0.5 
7 pitch lag = 0.0 
8 filter gain = 0.0 
9 cut = 8.0 
10 cut env amt = 0.0 
11 cut attack = 0.05 
12 cut sustain = 0.9 
13 cut release = 1.0 
14 level = 0.15 
15 amp attack = 0.05 
16 amp decay = 0.1 
17 amp sustain = 0.9 
18 amp release = 1.0 
19 unnamed = ---
20 output = crow ii JF
<ok>
params:remove('enc3')
lua: /home/we/norns/lua/core/paramset.lua:219: invalid paramset index: enc3
stack traceback:
	[C]: in function 'error'
	/home/we/norns/lua/core/paramset.lua:219: in function 'core/paramset.lookup_param'
	/home/we/norns/lua/core/paramset.lua:142: in function 'core/paramset.remove'
	(...tail calls...)
```

😬 

but then:

```
params:remove('level')
<ok>
```

or maybe i'm going about this in entirely the wrong way?

/cc @tehn 