### PR TITLE
Fix clip before tape write

### DIFF
--- a/crone/src/SoftCutClient.cpp
+++ b/crone/src/SoftCutClient.cpp
@@ -71,21 +71,15 @@ void crone::SoftCutClient::handleCommand(Commands::CommandPacket *p) {
     switch (p->id) {
         //-- softcut routing
         case Commands::Id::SET_ENABLED_CUT:
-            //std::cout << "softcut: setting enabled: voice "
-                      //<< p->idx_0 << ": " << (p->value > 0) << std::endl;
             enabled[p->idx_0] = p->value > 0.f;
             break;
         case Commands::Id::SET_LEVEL_CUT:
-            //std::cout << "softcut: setting voice output level "
-                      //<< p->idx_0 << ": " << p->value << std::endl;
             outLevel[p->idx_0].setTarget(p->value);
             break;;
         case Commands::Id::SET_PAN_CUT:
             outPan[p->idx_0].setTarget((p->value/2)+0.5); // map -1,1 to 0,1
             break;
         case Commands::Id::SET_LEVEL_IN_CUT:
-            //std::cout << "softcut: setting voice input level "
-                      //<< p->idx_0 << ": " << p->idx_1 << ": " << p->value << std::endl;
             inLevel[p->idx_0][p->idx_1].setTarget(p->value);
             break;
         case Commands::Id::SET_LEVEL_CUT_CUT:

--- a/crone/src/Tape.h
+++ b/crone/src/Tape.h
@@ -181,13 +181,7 @@ namespace crone {
                     // while we're interleaving, also apply envelope
                     float amp = SfStream::getEnvSample();
                     for (int ch = 0; ch < NumChannels; ++ch) {
-                        float x = src[ch][fr] * amp;
-// FIXME: some form of clipping is necessary before fixed-point encoding.
-// this hardclipper is neither optimally implemented, nor sonically ideal,
-// but it is better than nothing.
-                        x = x > 1.f ? 1.f : x;
-                        x = x < -1.f ? -1.f : x;
-                        *dst++ = x;
+                        *dst++ = src[ch][fr] * amp;
                    }
                 }
                 jack_ringbuffer_write(rb, (const char *) pushBuf, bytesToPush);
@@ -302,6 +296,9 @@ namespace crone {
                     std::cerr << "cannot open sndfile" << path << " for output (" << errstr << ")" << std::endl;
                     return false;
                 }
+
+                // enable clipping during float->int conversion
+                sf_command(this->file, SFC_SET_CLIPPING, NULL, SF_TRUE);
 
                 this->maxFrames = maxFrames;
                 jack_ringbuffer_reset(this->ringBuf.get());


### PR DESCRIPTION
added hardclipper in tape writer class. 

out-of-range values were wrapping when encoded to fixed point. (seems like pretty bad behavior from libsndfile, but w/e.)

could probably implement the hardclipper more efficiently, without conditionals, but this will get it done.