### PR TITLE
crow asl execute syntax

### DIFF
--- a/lua/core/crow.lua
+++ b/lua/core/crow.lua
@@ -75,7 +75,6 @@ function output.new(x)
   o._slew = 0
   o.query = function() crow.send("get_out("..o.n..")") end
   o.receive = function(v) print("crow output receive: "..o.n.." "..v) end
-  o.execute = function() crow.send("output["..o.n.."]()") end
   setmetatable(o,output)
   return o
 end
@@ -99,6 +98,11 @@ output.__index = function(self, i)
     return self._slew
   end
 end
+
+output.__call = function(self)
+  crow.send("output["..self.n.."]()")
+end
+
 
 
 setmetatable(output, output)

--- a/lua/core/crow.lua
+++ b/lua/core/crow.lua
@@ -75,6 +75,8 @@ function output.new(x)
   o._slew = 0
   o.query = function() crow.send("get_out("..o.n..")") end
   o.receive = function(v) print("crow output receive: "..o.n.." "..v) end
+  -- WILL BE DEPRECATED in 2.3.0
+  o.execute = function() crow.send("output["..o.n.."]()") end
   setmetatable(o,output)
   return o
 end


### PR DESCRIPTION
match syntax with native crow

`output[1].execute` is now `output[1]()`