### PR TITLE
fix crow detection

### DIFF
--- a/lua/core/crow.lua
+++ b/lua/core/crow.lua
@@ -75,7 +75,6 @@ function output.new(x)
   o._slew = 0
   o.query = function() crow.send("get_out("..o.n..")") end
   o.receive = function(v) print("crow output receive: "..o.n.." "..v) end
-  o.execute = function() crow.send("output["..o.n.."]()") end
   setmetatable(o,output)
   return o
 end
@@ -99,6 +98,11 @@ output.__index = function(self, i)
     return self._slew
   end
 end
+
+output.__call = function(self)
+  crow.send("output["..self.n.."]()")
+end
+
 
 
 setmetatable(output, output)

--- a/lua/core/crow.lua
+++ b/lua/core/crow.lua
@@ -75,6 +75,7 @@ function output.new(x)
   o._slew = 0
   o.query = function() crow.send("get_out("..o.n..")") end
   o.receive = function(v) print("crow output receive: "..o.n.." "..v) end
+  o.execute = function() crow.send("output["..o.n.."]()") end
   setmetatable(o,output)
   return o
 end
@@ -98,11 +99,6 @@ output.__index = function(self, i)
     return self._slew
   end
 end
-
-output.__call = function(self)
-  crow.send("output["..self.n.."]()")
-end
-
 
 
 setmetatable(output, output)


### PR DESCRIPTION
crow detection previously failed if input streams were on (flooding serial input so the `^^id` is lost)