### PR TITLE
Fix system cmd memleak

### DIFF
--- a/lua/core/menu.lua
+++ b/lua/core/menu.lua
@@ -362,7 +362,8 @@ end
 m.init[pSELECT] = function()
   m.sel.len = "scan" 
   m.sel.list = {}
-  norns.system_cmd('find ~/dust/code/ -name "*.lua" | sort', sort_select_tree)
+  -- weird command, but it is fast, recursive, skips hidden dirs, and sorts
+  norns.system_cmd('ls ~/dust/code/**/*.lua -1', sort_select_tree)
 end
 
 m.deinit[pSELECT] = norns.none

--- a/matron/src/system_cmd.c
+++ b/matron/src/system_cmd.c
@@ -28,7 +28,7 @@ void *run_cmd(void *);
 
 void system_cmd(char *cmd) {
     if (pthread_create(&p, NULL, run_cmd, cmd) ) {
-	fprintf(stderr, "system_cmd: error in pthread_create() \n");
+        fprintf(stderr, "system_cmd: error in pthread_create() \n");
     }
     // by default, a pthread is created in "joinable" state,
     // meaning it will retain its stack and other resources until joined.
@@ -38,23 +38,23 @@ void system_cmd(char *cmd) {
 }
 
 void *run_cmd(void *cmd) {
-  f = popen((char *)cmd, "r");
-  if(f == NULL) {
-    fprintf(stderr, "system_cmd: command failed\n");
-  } else {
-    capture[0]=0;
-    while (fgets(line, 254, f) != NULL) {
-      strcat(capture, line);
+    f = popen((char *)cmd, "r");
+    if(f == NULL) {
+        fprintf(stderr, "system_cmd: command failed\n");
+    } else {
+        capture[0]=0;
+        while (fgets(line, 254, f) != NULL) {
+            strcat(capture, line);
+        }
+        len = strlen(capture);
+        char *cap = malloc( (len + 1) * sizeof(char) );
+        strncpy(cap, capture, len);
+        cap[len] = '\0';
+        union event_data *ev = event_data_new(EVENT_SYSTEM_CMD);
+        ev->system_cmd.capture = cap;
+        event_post(ev);
+        //fprintf(stderr, "%s", capture);
+        pclose(f);
     }
-    len = strlen(capture);
-    char *cap = malloc( (len + 1) * sizeof(char) );
-    strncpy(cap, capture, len);
-    cap[len] = '\0';
-    union event_data *ev = event_data_new(EVENT_SYSTEM_CMD);
-    ev->system_cmd.capture = cap;
-    event_post(ev);
-    //fprintf(stderr, "%s", capture);
-    pclose(f);
-  }
-  return NULL;
+    return NULL;
 }

--- a/matron/src/system_cmd.c
+++ b/matron/src/system_cmd.c
@@ -27,9 +27,14 @@ void *run_cmd(void *);
 // extern def
 
 void system_cmd(char *cmd) {
-  if (pthread_create(&p, NULL, run_cmd, cmd) ) {
-    fprintf(stderr, "system_cmd: error creating thread\n");
-  }
+    if (pthread_create(&p, NULL, run_cmd, cmd) ) {
+	fprintf(stderr, "system_cmd: error in pthread_create() \n");
+    }
+    // by default, a pthread is created in "joinable" state,
+    // meaning it will retain its stack and other resources until joined.
+    // we need to detach the thread, either manually (as below)
+    // or by specificying the PTHREAD_CREATE_DETACHED attribute
+    pthread_detach(p);
 }
 
 void *run_cmd(void *cmd) {
@@ -39,7 +44,7 @@ void *run_cmd(void *cmd) {
   } else {
     capture[0]=0;
     while (fgets(line, 254, f) != NULL) {
-      strcat(capture,line);
+      strcat(capture, line);
     }
     len = strlen(capture);
     char *cap = malloc( (len + 1) * sizeof(char) );
@@ -51,6 +56,5 @@ void *run_cmd(void *cmd) {
     //fprintf(stderr, "%s", capture);
     pclose(f);
   }
-  pthread_cancel(p);
-  return 0;
+  return NULL;
 }


### PR DESCRIPTION
due to a subtlety of the pthreads API, the worker threads created in `system_cmd.c` were leaking _all the memory_ of the child processes they spawned. 

(the child process in latest version being a big ol' `find` that ate up a rather shocking 10MB a pop with a goodly number of scripts installed. [um, actually that's not quite right. it's mapped but unwired, or something.])

detaching the thread fixes this, it seems.

also uncrustified that file, because _someone_ has their vim set on 2space again. :)