### PR TITLE
System cmd more cleanup

### DIFF
--- a/matron/src/system_cmd.c
+++ b/matron/src/system_cmd.c
@@ -14,19 +14,15 @@
 
 #include "events.h"
 
-#define CMD_BUFFER 8192
-
-static FILE *f;
-static pthread_t p;
-static char capture[CMD_BUFFER];
-static char line[255];
-static int len;
+static const size_t CMD_CAPTURE_BYTES = 8192 * 8;
+static const size_t CMD_LINE_BYTES = 1024;
 
 void *run_cmd(void *);
 
 // extern def
 
 void system_cmd(char *cmd) {
+    pthread_t p;
     if (pthread_create(&p, NULL, run_cmd, cmd) ) {
         fprintf(stderr, "system_cmd: error in pthread_create() \n");
     }
@@ -38,23 +34,44 @@ void system_cmd(char *cmd) {
 }
 
 void *run_cmd(void *cmd) {
-    f = popen((char *)cmd, "r");
-    if(f == NULL) {
+    const size_t CMD_LINE_CHARS = CMD_LINE_BYTES / sizeof(char);
+    
+    FILE *f = popen((char *)cmd, "r");
+    if (f == NULL) {
         fprintf(stderr, "system_cmd: command failed\n");
-    } else {
-        capture[0]=0;
-        while (fgets(line, 254, f) != NULL) {
-            strcat(capture, line);
-        }
-        len = strlen(capture);
-        char *cap = malloc( (len + 1) * sizeof(char) );
-        strncpy(cap, capture, len);
-        cap[len] = '\0';
-        union event_data *ev = event_data_new(EVENT_SYSTEM_CMD);
-        ev->system_cmd.capture = cap;
-        event_post(ev);
-        //fprintf(stderr, "%s", capture);
-        pclose(f);
+	return NULL;
     }
+	
+    char *capture = (char*)malloc(CMD_CAPTURE_BYTES);
+    char *line = (char*)malloc(CMD_LINE_BYTES);
+    size_t capacity = CMD_CAPTURE_BYTES - 1;
+    
+    do {
+	// "fgets() reads in at most one less than _size_ characters"
+	// so `line` is always null-terminated after these next 2 calls:
+	memset(line, '\0', CMD_LINE_BYTES);
+	// stop on EOF....
+	if (fgets(line, CMD_LINE_CHARS, f)) { break; }
+	// "if _src_ contains _n_ or more bytes,
+	// strncat() writes _n+1_ bytes to _dest_"
+	// which is why we initialize capacity with -1
+	strncat(capture, line, capacity);
+	capacity -= strlen(line) * sizeof(char);
+    } while (capacity > 0); // ...or, stop if buffer is full
+
+    size_t len = strlen(capture);
+    char *cap = malloc((len + 1) * sizeof(char));
+    strncpy(cap, capture, len);
+    cap[len] = '\0';
+    union event_data *ev = event_data_new(EVENT_SYSTEM_CMD);
+
+    // this will get freed when the event is handled
+    ev->system_cmd.capture = cap;
+    event_post(ev);
+    
+    free(line);
+    free(capture);
+    pclose(f);
+    
     return NULL;
 }


### PR DESCRIPTION
2nd look at `system_cmd.c`

i'm now reasonably sure this will not bork even when command output massively exceeds buffer capacity. (it will truncate to the last complete line that fits in the buffer.)