### PR TITLE
extend crow.output[]() to accept directive strings

### DIFF
--- a/lua/core/crow.lua
+++ b/lua/core/crow.lua
@@ -101,8 +101,21 @@ output.__index = function(self, i)
   end
 end
 
-output.__call = function(self)
-  crow.send("output["..self.n.."]()")
+output.__call = function(self,arg)
+  local args = ""
+  if type(arg) == "string" then -- asl directive
+    if arg == "start"
+    or arg == "restart"
+    or arg == "attack"
+    or arg == "release"
+    or arg == "step"
+    or arg == "unlock" then
+      args = tostringwithquotes(arg)
+    else -- boolean or asl
+      args = arg
+    end
+  end
+  crow.send("output["..self.n.."]("..args..")")
 end
 
 


### PR DESCRIPTION
This brings norns syntax in-line with native crow syntax for interacting with a running ASL sequence.

The syntax is:
`output[channel](<directive>)` where `<directive>` is a string such as "attack" or "release" in order to allow richer interaction with an existing ASL declaration.

In addition this change means you can pass an ASL directly into the table call to both set the `.action` & begin the ASL:
```
-- current syntax
output[channel].action = 'lfo()'
output[channel]()

-- with this PR
output[channel]( 'lfo()' )
```
This is identical to how it works in a crow-native script.