### PR TITLE
move global reset after cleanup, better error logging

### DIFF
--- a/lua/core/script.lua
+++ b/lua/core/script.lua
@@ -109,25 +109,29 @@ Script.load = function(filename)
 
   print("# script load: " .. filename)
 
-  -- script local state
-  local state = { }
-
-  setmetatable(_G, {
-    __index = function (t,k)
-      return state[k]
-    end,
-    __newindex = function(t,k,v)
-      state[k] = v
-    end,
-  })
-
   local f=io.open(filename,"r")
   if f==nil then
     print("file not found: "..filename)
   else
     io.close(f)
-    if pcall(cleanup) then print("# cleanup")
-    else print("### cleanup failed") end
+    local ok, err
+    ok, err = pcall(cleanup)
+    if ok then print("# cleanup")
+    else
+      print("### cleanup failed with error: "..err)
+    end
+
+    -- script local state
+    local state = { }
+
+    setmetatable(_G, {
+      __index = function (t,k)
+        return state[k]
+      end,
+      __newindex = function(t,k,v)
+        state[k] = v
+      end,
+    })
 
     Script.clear() -- clear script variables and functions
 


### PR DESCRIPTION
globals reset caused errors when globals were referenced in cleanup, ie. https://github.com/tehn/ash/blob/master/playfair.lua#L268. to recreate, load `playfair` script, then another script and check lua output: "### cleanup failed" is printed. `playfair.data` is never saved.

PR moves globals reset after cleanup and prints actual error thrown in `pcall(cleanup)`