### PR TITLE
revert using 'ls' instead of 'find'

### DIFF
--- a/lua/core/menu.lua
+++ b/lua/core/menu.lua
@@ -362,8 +362,7 @@ end
 m.init[pSELECT] = function()
   m.sel.len = "scan" 
   m.sel.list = {}
-  -- weird command, but it is fast, recursive, skips hidden dirs, and sorts
-  norns.system_cmd('ls ~/dust/code/**/*.lua -1', sort_select_tree)
+  norns.system_cmd('find ~/dust/code/ -name "*.lua" | sort', sort_select_tree)
 end
 
 m.deinit[pSELECT] = norns.none


### PR DESCRIPTION
my bad - tried using `ls -R` instead of `find` to search scripts, didn't realize it somehow is not recursing on norns (though seems to work on my archlinux install! most odd.)

reverting to the previous `find` command for now. this is much slower and more memory-hungry - i suspect because it doesn't skip hidden directories and so is searching through the `.git` tree in every project.

i tried some variations with `find ... -path ... -prune` but couldn't get it to work. maybe someone with more advanced bash-fu can suggest an alternative.