### PR TITLE
Fix current_time overflow and allow clock_internal_set_tempo to work

### DIFF
--- a/matron/src/clocks/clock_internal.c
+++ b/matron/src/clocks/clock_internal.c
@@ -20,7 +20,7 @@ static void *clock_internal_run(void *p) {
     while (true) {
         clock_gettime(CLOCK_MONOTONIC, &req);
 
-        uint64_t current_time = (uint64_t) (1000000000 * req.tv_sec + req.tv_nsec);
+        uint64_t current_time = (1000000000 * (uint64_t)req.tv_sec) + (uint64_t)req.tv_nsec;
         uint64_t new_time = current_time + interval_nseconds;
 
         req.tv_sec = new_time / 1000000000;


### PR DESCRIPTION
In the comments of #712 both @okyeron and I observed `clock_internal_set_tempo` not having any effect on the internal source for the coroutine clock.

There was one additional cast overflow issue in `clock_internal_run`. Both `req.tv_sec` and `req.tv_nsec` are signed integers and require casts. With this change, I can set the coroutine clock source interactively from script. 

Without this change, calls to `clock_internal_set_tempo` have no effect. Here's some investigation history:
<details>

<p>With the following logging additions to `clock_internal.c`:</p>


```
diff --git a/matron/src/clocks/clock_internal.c b/matron/src/clocks/clock_internal.c
index dcb7775..f22eaa5 100644
--- a/matron/src/clocks/clock_internal.c
+++ b/matron/src/clocks/clock_internal.c
@@ -9,29 +10,42 @@
 #include "clock_internal.h"
 
 static pthread_t clock_internal_thread;
static double interval_seconds;
static uint64_t interval_nseconds;
+
+void pthread_cleanup_fn(void *arg)
+{
+    printf("thread cleanup: %s\n", (char*)arg);
+}
 
 static void *clock_internal_run(void *p) {
+    pthread_cleanup_push(pthread_cleanup_fn, "clock_internal_run");
+
     (void) p;
     struct timespec req;
     int beat = 0;
 
     while (true) {
+       fprintf(stderr, "calling clock_gettime\n");
         clock_gettime(CLOCK_MONOTONIC, &req);
+       fprintf(stderr, "clock_gettime returned req.tv_sec = %ld req.tv_nsec = %ld\n", req.tv_sec, req.tv_nsec);
 
         uint64_t current_time = (uint64_t) (1000000000 * req.tv_sec + req.tv_nsec);
         uint64_t new_time = current_time + interval_nseconds;
 
         req.tv_sec = new_time / 1000000000;
         req.tv_nsec = new_time % 1000000000;
-
+       fprintf(stderr, "calling clock_nanosleep, current_time: %" PRIu64 " new_time: %" PRIu64 "\n", current_time, new_time);
         clock_nanosleep(CLOCK_MONOTONIC, TIMER_ABSTIME, &req, NULL);
 
         beat += 1;
+       fprintf(stderr, "calling clock_update_reference_from\n");
         clock_update_reference_from(beat, interval_seconds, CLOCK_SOURCE_INTERNAL);
+       fprintf(stderr, "updated reference\n");
     }
 
+    pthread_cleanup_pop(0);
+
     return NULL;
 }
```

This is the observed output when starting matron on my hardware:

```
calling clock_gettime
clock_gettime returned req.tv_sec = 21451 req.tv_nsec = 204787083
calling clock_nanosleep, current_time: 2138110859 new_time: 4138110859
calling clock_update_reference_from
updated reference
calling clock_gettime
clock_gettime returned req.tv_sec = 21451 req.tv_nsec = 204814583
calling clock_nanosleep, current_time: 2138138359 new_time: 4138138359
calling clock_update_reference_from
updated reference
calling clock_gettime
clock_gettime returned req.tv_sec = 21451 req.tv_nsec = 204841770
calling clock_nanosleep, current_time: 2138165546 new_time: 4138165546
calling clock_update_reference_from
updated reference
calling clock_gettime
clock_gettime returned req.tv_sec = 21451 req.tv_nsec = 204868957
calling clock_nanosleep, current_time: 2138192733 new_time: 4138192733
calling clock_update_reference_from
updated reference
calling clock_gettime
clock_gettime returned req.tv_sec = 21451 req.tv_nsec = 204896561
calling clock_nanosleep, current_time: 2138220337 new_time: 4138220337
calling clock_update_reference_from
updated reference
calling clock_gettime
clock_gettime returned req.tv_sec = 21451 req.tv_nsec = 247583009
calling clock_nanosleep, current_time: 18446744071595491105 new_time: 18446744073595491105
```

This is the last output in the log from this thread. At this point, the `clock_internal_run` thread is going to wait for... 584 years, so the reference will not be updated with any changes. The time it takes to overflow varies, but for me it's always less than a few seconds.
</details>