### PR TITLE
user scripts can set encoder attrib

### DIFF
--- a/lua/core/encoders.lua
+++ b/lua/core/encoders.lua
@@ -60,4 +60,41 @@ encoders.process = function(n,d)
   end
 end
 
+
+-- script state
+
+local accel = {true,true,true}
+local sens = {1,1,1}
+
+norns.enc = {}
+norns.enc.accel = function(n,z)
+  if n == 0 then
+    for k=1,3 do
+      accel[k] = z
+    end
+  else
+    accel[n] = z
+  end
+  if(_menu.mode == false) then norns.encoders.set_accel(n,z) end
+end
+
+norns.enc.sens = function(n,s)
+  if n == 0 then
+    for k=1,3 do
+      sens[k] = util.clamp(s,1,16)
+    end
+  else
+    sens[n] = util.clamp(s,1,16)
+  end
+  if(_menu.mode == false) then norns.encoders.set_sens(n,s) end
+end
+
+norns.enc.resume = function()
+  for n=1,3 do
+    norns.encoders.set_accel(n,accel[n])
+    norns.encoders.set_sens(n,sens[n])
+  end
+end
+
+
 return encoders

--- a/lua/core/menu.lua
+++ b/lua/core/menu.lua
@@ -150,8 +150,9 @@ _menu.set_mode = function(mode)
     redraw = norns.script.redraw
     _menu.key = key
     norns.encoders.callback = enc
-    norns.encoders.set_accel(0,false)
-    norns.encoders.set_sens(0,1)
+    norns.enc.resume()
+    --norns.encoders.set_accel(0,false)
+    --norns.encoders.set_sens(0,1)
     redraw()
   else -- _menu.MODE
     if _menu.mode == false then _norns.screen_save() end


### PR DESCRIPTION
fixes #414 

```
norns.enc.sens(0,4)
norns.enc.accel(0,true)
```

sets script sensitivity to 4 and accel on for all encoders.

menu restores state when moving between menu and script