### PR TITLE
update improvements

### DIFF
--- a/lua/core/menu/reset.lua
+++ b/lua/core/menu/reset.lua
@@ -14,6 +14,7 @@ elseif n==3 and z==1 then
     norns.state.save()
     if pcall(cleanup) == false then print("cleanup failed") end
     os.execute("sudo systemctl restart norns-jack.service")
+    os.execute("sudo systemctl restart norns-sclang.service")
     os.execute("sudo systemctl restart norns-matron.service")
   end
 end

--- a/lua/core/menu/update.lua
+++ b/lua/core/menu/update.lua
@@ -3,7 +3,20 @@ local m = {
   version = ''
 }
 
-local function checked(result)
+local function checked() print("what??") end
+local function get_update_2() end
+
+local function check_newest()
+  print("checking for update")
+  norns.system_cmd( [[curl -s \
+      https://api.github.com/repos/monome/norns/releases/latest \
+      | grep "browser_download_url.*" \
+      | cut -d : -f 2,3 \
+      | tr -d \"]],
+      checked)
+end
+
+checked = function(result)
   m.url = result
   print(m.url)
   m.url = string.gsub(m.url,"\n","")
@@ -19,17 +32,31 @@ local function checked(result)
 end
 
 
-local function check_newest()
-  print("checking for update")
-  norns.system_cmd( [[curl -s \
-      https://api.github.com/repos/monome/norns/releases/latest \
-      | grep "browser_download_url.*" \
-      | cut -d : -f 2,3 \
-      | tr -d \"]],
-      checked)
+local function get_update()
+  m.message = "preparing..."
+  _menu.redraw()
+  pcall(cleanup) -- shut down script
+  norns.script.clear()
+  print("shutting down audio...")
+  os.execute("sudo systemctl stop norns-jack.service") -- disable audio
+  print("clearing old updates...")
+  os.execute("sudo rm -rf /home/we/update/*") -- clear old updates
+  m.message = "downloading..."
+  _menu.redraw()
+  print("starting download...")
+  local cmd = "wget -T 180 -q -P /home/we/update/ " .. m.url
+  print("> "..cmd)
+  norns.system_cmd(cmd, get_update_2) --download
+  _menu.timer.time = 0.5
+  _menu.timer.count = -1
+  _menu.timer.event = function()
+    m.blink = m.blink == false
+    _menu.redraw()
+  end
+  _menu.timer:start()
 end
 
-local function get_update_2()
+get_update_2 = function()
   _menu.timer:stop()
   m.message = "unpacking update..."
   _menu.redraw()
@@ -55,32 +82,6 @@ local function get_update_2()
 end
 
 
-local function get_update()
-  m.message = "preparing..."
-  _menu.redraw()
-  pcall(cleanup) -- shut down script
-  norns.script.clear()
-  print("shutting down audio...")
-  os.execute("sudo systemctl stop norns-jack.service") -- disable audio
-  print("clearing old updates...")
-  os.execute("sudo rm -rf /home/we/update/*") -- clear old updates
-  m.message = "downloading..."
-  _menu.redraw()
-  print("starting download...")
-  local cmd = "wget -T 180 -q -P /home/we/update/ " .. m.url
-  print("> "..cmd)
-  m.blink = true
-  norns.system_cmd(cmd, get_update_2) --download
-  _menu.timer.time = 1
-  _menu.timer.count = -1
-  _menu.timer.event = function()
-    m.blink = m.blink == false
-    _menu.redraw()
-  end
-  _menu.timer:start()
-  
-end
-
 m.key = function(n,z)
   if m.stage=="init" and z==1 then
     _menu.set_page("SYSTEM")
@@ -92,6 +93,20 @@ m.key = function(n,z)
     elseif n==3 and z==1 then
       m.stage="update"
       get_update()
+    end
+  elseif m.stage=="update" then
+    if n==2 and z==1 then
+      m.stage="cancel"
+      _menu.redraw()
+    end
+  elseif m.stage=="cancel" then
+    if n==2 and z==1 then
+      m.stage="update"
+      _menu.redraw()
+    elseif n==3 and z==1 then
+      os.execute("sudo systemctl restart norns-jack.service")
+      os.execute("sudo systemctl restart norns-sclang.service")
+      os.execute("sudo systemctl restart norns-matron.service")
     end
   elseif m.stage=="done" and z==1 then
     print("shutting down.")
@@ -108,14 +123,16 @@ m.redraw = function()
   screen.clear()
   screen.level(15)
   screen.move(64,40)
-  if m.stage == "init" then
-    screen.text_center(m.message)
-  elseif m.stage == "confirm" then
+  if m.stage == "confirm" then
     screen.text_center("update found: "..m.version)
     screen.move(64,50)
     screen.text_center("install?")
   elseif m.stage == "update" then
     screen.level(m.blink == true and 15 or 3)
+    screen.text_center(m.message)
+  elseif m.stage == "cancel" then
+    screen.text_center("cancel?")
+  else
     screen.text_center(m.message)
   end
   screen.update()

--- a/lua/core/menu/update.lua
+++ b/lua/core/menu/update.lua
@@ -65,11 +65,11 @@ get_update_2 = function()
   local checksum = util.os_capture("cd /home/we/update; sha256sum -c /home/we/update/*.sha256 | grep OK")
   if checksum:match("OK") then
     print("unpacking...")
-    --os.execute("tar xzvf /home/we/update/*.tgz -C /home/we/update/")
+    os.execute("tar xzvf /home/we/update/*.tgz -C /home/we/update/")
     m.message = "running update..."
     _menu.redraw()
     print("running update...")
-    --os.execute("/home/we/update/"..m.version.."/update.sh")
+    os.execute("/home/we/update/"..m.version.."/update.sh")
     m.message = "done. any key to shut down."
     _menu.redraw()
     print("update complete.")

--- a/lua/core/menu/wifi.lua
+++ b/lua/core/menu/wifi.lua
@@ -108,6 +108,12 @@ m.redraw = function()
 end
 
 m.init = function()
+  -- screen enter notification
+  screen.clear()
+  screen.level(4)
+  screen.move(64,40)
+  screen.text_center("scanning...")
+  screen.update()
   wifi.ensure_radio_is_on()
   m.ssid_list = wifi.ssids() or {}
   wifi.update()


### PR DESCRIPTION
fixes #909 

checking for update happens in the other thread so scripts don't bog. if confirmed, audio/scripts are unloaded before download.

gives a blinking indication that downloading is happening, and also a "cancel" option is now available which resets matron.

fixed up some other little issues, ie, added "scanning" indication when entering WIFI instead of a brief stall.