### PR TITLE
do not allow fractional tOPTION index

### DIFF
--- a/lua/core/params/option.lua
+++ b/lua/core/params/option.lua
@@ -38,6 +38,8 @@ function Option:set(v, silent)
 end
 
 function Option:delta(d)
+  if d<0 then d = math.floor(d)
+  else d = math.ceil(d) end
   self:set(self:get() + d)
 end
 


### PR DESCRIPTION
param menu sends fractional deltas, which broke tOPTION

fixes #953 