### PR TITLE
update engine status early

### DIFF
--- a/lua/core/engine.lua
+++ b/lua/core/engine.lua
@@ -86,14 +86,14 @@ Engine.load = function(name, callback)
   else
     if type(callback) == 'function' then
       _norns.report.did_engine_load = function()	    
+        Engine.is_loading = false
         local status = norns.try(callback,"init")
         norns.init_done(status)
-        Engine.is_loading = false
       end
     else
       _norns.report.did_engine_load = function()
-        norns.init_done(true)
         Engine.is_loading = false
+        norns.init_done(true)
       end
     end
 


### PR DESCRIPTION
fix other issue raised in #952 

where an error in `refresh` if called by `init` will fail before setting engine status, which then makes loading another engine never happen again.