### PR TITLE
Buf worker fixed

### DIFF
--- a/crone/CMakeLists.txt
+++ b/crone/CMakeLists.txt
@@ -7,6 +7,7 @@ set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS_DEBUG} -O0")
 set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS_RELEASE} -O2")
 
 set (SRC src/main.cpp
+        src/BufDiskWorker.h
         src/Client.h
         src/Utilities.h
         src/OscInterface.cpp
@@ -26,8 +27,7 @@ set (SRC src/main.cpp
         src/Poll.h
         src/Taper.cpp
         src/Window.cpp
-        src/WindowedPeak.h
-        )
+        src/BufDiskWorker.cpp)
 
 add_executable(crone ${SRC})
 

--- a/crone/src/BufDiskWorker.cpp
+++ b/crone/src/BufDiskWorker.cpp
@@ -41,7 +41,6 @@ int BufDiskWorker::registerBuffer(float *data, size_t frames) {
 }
 
 void BufDiskWorker::requestJob(BufDiskWorker::Job &job) {
-    std::cout << "BufDiskWorker: job requested; type: " << (int) job.type << std::endl;
     qMut.lock();
     jobQ.push(job);
     qMut.unlock();
@@ -55,28 +54,25 @@ void BufDiskWorker::requestClear(size_t idx, float start, float dur) {
 
 void
 BufDiskWorker::requestReadMono(size_t idx, std::string path, float startSrc, float startDst, float dur, int chanSrc) {
-    std::cout << "BufDiskWorker: read_mono requested" << std::endl;
     BufDiskWorker::Job job{BufDiskWorker::JobType::ReadMono, {idx, 0}, std::move(path), startSrc, startDst, dur,
                            chanSrc};
     requestJob(job);
 }
 
-void BufDiskWorker::requestReadStereo(size_t idx0, size_t idx1, std::string path, float startSrc, float startDst,
-                                      float dur) {
-    std::cout << "BufDiskWorker: read_stereo requested" << std::endl;
+void BufDiskWorker::requestReadStereo(size_t idx0, size_t idx1, std::string path,
+				      float startSrc, float startDst, float dur) {
     BufDiskWorker::Job job{BufDiskWorker::JobType::ReadStereo, {idx0, idx1}, std::move(path), startSrc, startDst, dur,
                            0};
     requestJob(job);
 }
 
 void BufDiskWorker::requestWriteMono(size_t idx, std::string path, float start, float dur) {
-    std::cout << "BufDiskWorker: write_mono requested" << std::endl;
     BufDiskWorker::Job job{BufDiskWorker::JobType::WriteMono, {idx, 0}, std::move(path), start, start, dur, 0};
     requestJob(job);
 }
 
-void BufDiskWorker::requestWriteStereo(size_t idx0, size_t idx1, std::string path, float start, float dur) {
-    std::cout << "BufDiskWorker: write_stereo requested" << std::endl;
+void BufDiskWorker::requestWriteStereo(size_t idx0, size_t idx1, std::string path,
+				       float start, float dur) {
     BufDiskWorker::Job job{BufDiskWorker::JobType::WriteStereo, {idx0, idx1}, std::move(path), start, start, dur, 0};
     requestJob(job);
 }

--- a/crone/src/BufDiskWorker.cpp
+++ b/crone/src/BufDiskWorker.cpp
@@ -17,7 +17,7 @@
 
 using namespace crone;
 
-std::unique_ptr<std::> BufDiskWorker::worker = nullptr;
+std::unique_ptr<std::thread> BufDiskWorker::worker = nullptr;
 std::queue<BufDiskWorker::Job> BufDiskWorker::jobQ;
 std::mutex BufDiskWorker::qMut;
 
@@ -270,7 +270,7 @@ void BufDiskWorker::readBufferStereo(const std::string &path, BufDesc &buf0, Buf
 	int res = file.seek(frSrc, SF_SEEK_SET);
 	if (res == -1) {	    
 	    std::cerr << "error seeking to frame: " << frSrc << "; aborting read" << std::endl;
-	    goto done;
+	    return;
 	}
         file.readf(ioBuf, ioBufFrames);
 	// FIXME? SEEK_CUR gives weird results, i must be using it wrong
@@ -287,16 +287,14 @@ void BufDiskWorker::readBufferStereo(const std::string &path, BufDesc &buf0, Buf
 
 	if (res == -1) {
 	    std::cerr << "error seeking to frame: " << frSrc << "; aborting read" << std::endl;
-	    goto done;
+	    return;
 	}
         file.read(ioBuf, numSrcChan);
         buf0.data[frDst] = ioBuf[0];
         buf1.data[frDst] = ioBuf[1];
 	frDst++;
 	frSrc++;
-    }
-    
- done:
+    }    
     // std::cout << "SoftCutClient::readBufferStereo(): done; read " << frDur << " frames" << std::endl;
 }
 

--- a/crone/src/BufDiskWorker.cpp
+++ b/crone/src/BufDiskWorker.cpp
@@ -1,0 +1,447 @@
+//
+// Created by emb on 11/30/19.
+//
+
+
+//-----------------------
+//-- debugging
+#include <iostream>
+#include <iomanip>
+#include <chrono>
+//--------------
+
+#include <sndfile.hh>
+#include <utility>
+
+#include "BufDiskWorker.h"
+
+using namespace crone;
+
+std::unique_ptr<std::thread> BufDiskWorker::worker = nullptr;
+//boost::lockfree::spsc_queue<BufDiskWorker::Job, boost::lockfree::capacity<BufDiskWorker::maxJobs>> BufDiskWorker::jobQ;
+std::queue<BufDiskWorker::Job> BufDiskWorker::jobQ;
+std::mutex BufDiskWorker::qMut;
+
+std::array<BufDiskWorker::BufDesc, BufDiskWorker::maxBufs> BufDiskWorker::bufs;
+int BufDiskWorker::numBufs = 0;
+bool BufDiskWorker::shouldQuit = false;
+int BufDiskWorker::sampleRate = 48000;
+
+
+// clamp unsigned int to upper bound, inclusive
+static inline void clamp(size_t &x, const size_t a) {
+    if (x > a) { x = a; }
+}
+
+
+int BufDiskWorker::registerBuffer(float *data, size_t frames) {
+    int n = numBufs++;
+    bufs[n].data = data;
+    bufs[n].frames = frames;
+    return n;
+}
+
+void BufDiskWorker::requestJob(BufDiskWorker::Job &job) {
+    std::cout << "BufDiskWorker: job requested; type: " << (int) job.type << std::endl;
+    qMut.lock();
+    jobQ.push(job);
+    qMut.unlock();
+    // FIXME: use condvar to signal worker
+}
+
+void BufDiskWorker::requestClear(size_t idx, float start, float dur) {
+    BufDiskWorker::Job job{BufDiskWorker::JobType::Clear, {idx, 0}, "", 0, start, dur, 0};
+    requestJob(job);
+}
+
+void
+BufDiskWorker::requestReadMono(size_t idx, std::string path, float startSrc, float startDst, float dur, int chanSrc) {
+    std::cout << "BufDiskWorker: read_mono requested" << std::endl;
+    BufDiskWorker::Job job{BufDiskWorker::JobType::ReadMono, {idx, 0}, std::move(path), startSrc, startDst, dur,
+                           chanSrc};
+    requestJob(job);
+}
+
+void BufDiskWorker::requestReadStereo(size_t idx0, size_t idx1, std::string path, float startSrc, float startDst,
+                                      float dur) {
+    std::cout << "BufDiskWorker: read_stereo requested" << std::endl;
+    BufDiskWorker::Job job{BufDiskWorker::JobType::ReadStereo, {idx0, idx1}, std::move(path), startSrc, startDst, dur,
+                           0};
+    requestJob(job);
+}
+
+void BufDiskWorker::requestWriteMono(size_t idx, std::string path, float start, float dur) {
+    std::cout << "BufDiskWorker: write_mono requested" << std::endl;
+    BufDiskWorker::Job job{BufDiskWorker::JobType::WriteMono, {idx, 0}, std::move(path), start, start, dur, 0};
+    requestJob(job);
+}
+
+void BufDiskWorker::requestWriteStereo(size_t idx0, size_t idx1, std::string path, float start, float dur) {
+    std::cout << "BufDiskWorker: write_stereo requested" << std::endl;
+    BufDiskWorker::Job job{BufDiskWorker::JobType::WriteStereo, {idx0, idx1}, std::move(path), start, start, dur, 0};
+    requestJob(job);
+}
+
+
+void BufDiskWorker::workLoop() {
+    while (!shouldQuit) {
+        // FIXME: use condvar to wait here instead of sleeping
+        qMut.lock();
+        if (!jobQ.empty()) {
+            Job job = jobQ.front();
+            jobQ.pop();
+            qMut.unlock();
+#if 1
+	    using namespace std::chrono;
+	    auto ms_start = duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count();
+	    
+            std::cout << "BufDiskWorker handling job; " << std::endl << "  type = " << (int) job.type
+                      << "; path = " << job.path
+                      << "; startSrc = " << job.startSrc
+                      << "; startDst = " << job.startDst
+                      << "; dur = " << job.dur
+                      << "; chanSrc = " << job.chan
+                      << std::endl;
+#endif
+
+            switch (job.type) {
+                case JobType::Clear:
+                    clearBuffer(bufs[job.bufIdx[0]], job.startDst, job.dur);
+                    break;
+                case JobType::ReadMono:
+                    readBufferMono(job.path, bufs[job.bufIdx[0]], job.startSrc, job.startDst, job.dur, job.chan);
+                    break;
+                case JobType::ReadStereo:
+                    readBufferStereo(job.path, bufs[job.bufIdx[0]], bufs[job.bufIdx[1]], job.startSrc, job.startDst,
+                                     job.dur);
+                    break;
+                case JobType::WriteMono:
+                    writeBufferMono(job.path, bufs[job.bufIdx[0]], job.startSrc, job.dur);
+                    break;
+                case JobType::WriteStereo:
+                    writeBufferStereo(job.path, bufs[job.bufIdx[0]], bufs[job.bufIdx[1]], job.startSrc, job.dur);
+                    break;
+            }
+	    auto ms_now = duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count();
+	    auto ms_dur = ms_now - ms_start;
+	    std::cout << "job finished; elapsed time = " << ms_dur << " ms" << std::endl;	    
+
+        } else {
+            qMut.unlock();
+            std::this_thread::sleep_for(std::chrono::milliseconds(sleepPeriodMs));
+        }
+    }
+}
+
+void BufDiskWorker::init(int sr) {
+    sampleRate = sr;
+    if (worker == nullptr) {
+        worker = std::make_unique<std::thread>(std::thread(BufDiskWorker::workLoop));
+        worker->detach();
+    }
+}
+
+int BufDiskWorker::secToFrame(float seconds) {
+    return static_cast<int>(seconds * (float) sampleRate);
+}
+
+//------------------------
+//---- private buffer routines
+
+void BufDiskWorker::clearBuffer(BufDesc &buf, float start, float dur) {
+    //-------------
+    // test...
+    std::cout << "clearing buffer: "
+              << std::hex << buf.data
+              << "; start = " << start << "; dur= " << dur
+              << std::dec << std::endl;
+    //    return;
+    //-----------
+
+    size_t frA = secToFrame(start);
+    clamp(frA, buf.frames - 1);
+    size_t frB;
+    if (dur < 0) {
+        frB = buf.frames;
+    } else {
+        frB = frA + secToFrame(dur);
+    }
+    clamp(frB, buf.frames);
+    for (size_t i = frA; i < frB; ++i) {
+        buf.data[i] = 0.f;
+    }
+}
+
+void BufDiskWorker::readBufferMono(const std::string &path, BufDesc &buf,
+                                   float startSrc, float startDst, float dur, int chanSrc) {
+    SndfileHandle file(path);
+
+    if (file.frames() < 1) {
+        std::cout << "readBufferMono(): empty / missing file: " << path << std::endl;
+        return;
+    }
+
+    size_t bufFrames = buf.frames;
+
+    size_t frSrc = secToFrame(startSrc);
+    clamp(frSrc, bufFrames - 1);
+
+    size_t frDst = secToFrame(startDst);
+    clamp(frDst, bufFrames - 1);
+
+    size_t frDur;
+    if (dur < 0.f) {
+        auto maxDurSrc = file.frames() - frSrc;
+        auto maxDurDst = bufFrames - frDst;
+        frDur = maxDurSrc > maxDurDst ? maxDurDst : maxDurSrc;
+    } else {
+        frDur = secToFrame(dur);
+    }
+
+    auto numSrcChan = file.channels();
+    chanSrc = std::min(numSrcChan - 1, std::max(0, chanSrc));
+    std::cout << "reading soundfile channel " << chanSrc << std::endl;
+
+#if 0 // seek every frame
+    
+    float frBuf[numSrcChan];
+    for (size_t fr = 0; fr < frDur; ++fr) {
+        file.seek(frSrc, SEEK_SET);
+        file.read(frBuf, numSrcChan);
+        buf.data[frDst] = frBuf[chanSrc];
+        ++frSrc;
+        if (++frDst >= bufFrames) {
+            std::cout << "readBufferMono(): exceeded buffer size; aborting" << std::endl;
+            return;
+        }
+    }
+#else
+    float ioBuf[numSrcChan * ioBufFrames];
+    
+    size_t numBlocks = frDur / ioBufFrames;
+    size_t rem = frDur - (numBlocks * ioBufFrames);
+    std::cout << "file contains " << file.frames() << " frames" << std::endl;
+    std::cout << "reading " << numBlocks << " blocks and " << rem << " remainder frames..." << std::endl;
+    for (size_t block = 0; block < numBlocks; ++block) {
+	int res = file.seek(frSrc, SF_SEEK_SET);
+	if (res == -1) {	    
+	    std::cerr << "error seeking to frame: " << frSrc << "; aborting read" << std::endl;
+	    return;
+	}
+        file.readf(ioBuf, ioBufFrames);
+	// FIXME? SEEK_CUR gives weird results, i must be using it wrong
+	//int res = file.seek(ioBufFrames, SF_SEEK_CUR);
+        for (int fr=0; fr<ioBufFrames; ++fr) {
+            buf.data[frDst] = ioBuf[fr * numSrcChan + chanSrc];
+            frDst++;
+        }
+	frSrc += ioBufFrames;
+    }
+    for (size_t i=0; i<rem; ++i) {
+	int res = file.seek(frSrc, SF_SEEK_CUR);
+
+	if (res == -1) {
+	    std::cerr << "error seeking to frame: " << frSrc << "; aborting read" << std::endl;
+	    return;
+	}
+        file.read(ioBuf, numSrcChan);
+        buf.data[frDst] = ioBuf[chanSrc];
+	frDst++;
+	frSrc++;
+    }
+    
+#endif
+
+    std::cout << "SoftCutClient::readBufferMono(): done; read " << frDur << " frames" << std::endl;
+}
+
+void BufDiskWorker::readBufferStereo(const std::string &path, BufDesc &buf0, BufDesc &buf1,
+                                     float startTimeSrc, float startTimeDst, float dur) {
+    SndfileHandle file(path);
+
+    if (file.frames() < 1) {
+        std::cout << "SoftCutClient::readBufferStereo(): empty / missing file: " << path << std::endl;
+        return;
+    }
+
+    size_t bufFrames = buf0.frames < buf1.frames ? buf0.frames : buf1.frames;
+
+    size_t frSrc = secToFrame(startTimeSrc);
+    clamp(frSrc, bufFrames - 1);
+
+    size_t frDst = secToFrame(startTimeDst);
+    clamp(frDst, bufFrames - 1);
+
+    size_t frDur;
+    if (dur < 0.f) {
+        auto maxDurSrc = file.frames() - frSrc;
+        auto maxDurDst = bufFrames - frDst;
+        frDur = maxDurSrc > maxDurDst ? maxDurDst : maxDurSrc;
+    } else {
+        frDur = secToFrame(dur);
+    }
+
+    auto numSrcChan = file.channels();
+    if (numSrcChan < 2) {
+        std::cout << "SoftCutClient::readBufferStereo(): not enough channels in source; aborting" << std::endl;
+        return;
+    }
+    float ioBuf[numSrcChan * ioBufFrames];
+    
+    size_t numBlocks = frDur / ioBufFrames;
+    size_t rem = frDur - (numBlocks * ioBufFrames);
+    std::cout << "file contains " << file.frames() << " frames" << std::endl;
+    std::cout << "reading " << numBlocks << " blocks and " << rem << " remainder frames..." << std::endl;
+    for (size_t block = 0; block < numBlocks; ++block) {
+	int res = file.seek(frSrc, SF_SEEK_SET);
+	if (res == -1) {	    
+	    std::cerr << "error seeking to frame: " << frSrc << "; aborting read" << std::endl;
+	    goto done;
+	}
+        file.readf(ioBuf, ioBufFrames);
+	// FIXME? SEEK_CUR gives weird results, i must be using it wrong
+	//int res = file.seek(ioBufFrames, SF_SEEK_CUR);
+        for (int fr=0; fr<ioBufFrames; ++fr) {
+            buf0.data[frDst] = ioBuf[fr * numSrcChan];
+            buf1.data[frDst] = ioBuf[fr * numSrcChan + 1];
+            frDst++;
+        }
+	frSrc += ioBufFrames;
+    }
+    for (size_t i=0; i<rem; ++i) {
+	int res = file.seek(frSrc, SF_SEEK_CUR);
+
+	if (res == -1) {
+	    std::cerr << "error seeking to frame: " << frSrc << "; aborting read" << std::endl;
+	    goto done;
+	}
+        file.read(ioBuf, numSrcChan);
+        buf0.data[frDst] = ioBuf[0];
+        buf1.data[frDst] = ioBuf[1];
+	frDst++;
+	frSrc++;
+    }
+    
+ done:
+    std::cout << "SoftCutClient::readBufferStereo(): done; read " << frDur << " frames" << std::endl;
+}
+
+void BufDiskWorker::writeBufferMono(const std::string &path, BufDesc &buf, float start, float dur) {    
+    const int sr = 48000;
+    const int channels = 1;
+    const int format = SF_FORMAT_WAV | SF_FORMAT_PCM_24;
+    
+    SndfileHandle file(path, SFM_WRITE, format, channels, sr);
+    
+    if (not file) {
+        std::cout << "BufDiskWorker::writeBufferMono(): cannot open sndfile" << path << " for writing" << std::endl;
+	return;
+    }
+    
+    file.command(SFC_SET_CLIPPING, NULL, SF_TRUE);
+    std::cout << "BufDiskWorker::writeBufferMono(): opened file for writing: " << path << std::endl;
+
+    size_t frSrc = secToFrame(start);
+    size_t bufFrames = buf.frames;
+    clamp(frSrc, bufFrames - 1);
+
+    size_t frDur;
+    if (dur < 0.f) {
+        // FIXME: should check available disk space
+        frDur = bufFrames - frSrc;
+    } else {
+        frDur = secToFrame(dur);
+    }
+
+    size_t numBlocks = frDur / ioBufFrames;
+    size_t rem = frDur - (numBlocks * ioBufFrames);
+    size_t nf = 0;
+    std::cout << "writing " << numBlocks << " blocks and " << rem << " remainder frames..." << std::endl;
+    float *pbuf = buf.data + frSrc;
+    for (size_t block = 0; block < numBlocks; ++block) {
+	size_t n = file.writef(pbuf, ioBufFrames);
+	pbuf += ioBufFrames;
+	nf += n;
+	if (n != ioBufFrames) {	    
+	    std::cout << "BufDiskWorker::writeBufferMono(): write aborted (disk space?) after " << nf << " frames"
+                      << std::endl;
+	    return;
+	}
+    }
+    
+    for (size_t i=0; i<rem; ++i) {	
+	if (file.writef(pbuf++, 1) != 1) {
+            std::cout << "BufDiskWorker::writeBufferMono(): write aborted (disk space?) after " << nf << " frames"
+                      << std::endl;
+	    return;
+        }
+        ++nf;
+    }
+    
+    std::cout << std::dec << "BufDiskWorker::writeBufferMono(): done; wrote " << nf << " frames" << std::endl;
+}
+
+void BufDiskWorker::writeBufferStereo(const std::string &path, BufDesc &buf0, BufDesc &buf1, float start, float dur) {    
+    const int sr = 48000;
+    const int channels = 2;
+    const int format = SF_FORMAT_WAV | SF_FORMAT_PCM_24;
+    SndfileHandle file(path, SFM_WRITE, format, channels, sr);
+    
+    if (not file) {
+        std::cout << "ERROR: cannot open sndfile" << path << " for writing" << std::endl;
+	return;
+    }
+    
+    file.command(SFC_SET_CLIPPING, NULL, SF_TRUE);
+    std::cout << "BufDiskWorker::writeBufferStereo(): opened file for writing: " << path << std::endl;
+
+    size_t frSrc = secToFrame(start);
+    size_t bufFrames = buf0.frames < buf1.frames ? buf0.frames : buf1.frames;
+    clamp(frSrc, bufFrames - 1);
+
+    size_t frDur;
+    if (dur < 0.f) {
+        // FIXME: should check available disk space
+        frDur = bufFrames - frSrc;
+    } else {
+        frDur = secToFrame(dur);
+    }
+
+    size_t numBlocks = frDur / ioBufFrames;
+    size_t rem = frDur - (numBlocks * ioBufFrames);
+    size_t nf = 0;
+    std::cout << "writing " << numBlocks << " blocks and " << rem << " remainder frames..." << std::endl;
+    
+    float ioBuf[ioBufFrames*2];
+    float *pbuf0 = buf0.data;
+    float *pbuf1 = buf1.data;
+    for (size_t block = 0; block < numBlocks; ++block) {
+	float *pio = ioBuf;
+	for (size_t fr=0; fr<ioBufFrames; ++fr) {
+	    *pio++ = *pbuf0++;
+	    *pio++ = *pbuf1++;
+	}
+	size_t n = file.writef(ioBuf, ioBufFrames);	
+	nf += n;
+	if (n != ioBufFrames) {	    
+	    std::cout << "BufDiskWorker::writeBufferStereo(): write aborted (disk space?) after " << nf << " frames"
+                      << std::endl;
+	    return;
+	}
+	frSrc += ioBufFrames;
+    }
+    
+    for (size_t i=0; i<rem; ++i) {
+	ioBuf[0] = *(buf0.data + frSrc);
+	ioBuf[1] = *(buf1.data + frSrc);
+	if (file.writef(ioBuf, 1) != 1) {
+            std::cout << "BufDiskWorker::writeBufferStereo(): write aborted (disk space?) after " << nf << " frames"
+                      << std::endl;
+	    return;
+        }
+        ++frSrc;
+        ++nf;
+    }
+    
+    std::cout << std::dec << "BufDiskWorker::writeBufferStereo(): done; wrote " << nf << " frames" << std::endl;
+}

--- a/crone/src/BufDiskWorker.h
+++ b/crone/src/BufDiskWorker.h
@@ -1,0 +1,110 @@
+//
+// Created by emb on 11/30/19.
+//
+/*
+ * BufDiskWorker is an Audio Buffer Disk Interface static class.
+ *
+ * it requires users to _register_ buffers (returns numerical index for registered buf)
+ * disk read/write work can be requested for registered buffers, executed in background thread
+ *
+ * TODO: callback for request completion
+ */
+
+#ifndef CRONE_BUFMANAGER_H
+#define CRONE_BUFMANAGER_H
+
+#include <atomic>
+#include <thread>
+#include <mutex>
+#include <queue>
+//#include <boost/lockfree/spsc_queue.hpp>
+#include <memory>
+
+namespace crone {
+
+    // class for asynchronous management of mono audio buffers
+    class BufDiskWorker {
+
+        enum class JobType {
+            Clear,
+            ReadMono, ReadStereo,
+            WriteMono, WriteStereo
+        };
+        struct Job {
+            JobType type;
+            size_t bufIdx[2];
+            std::string path;
+            float startSrc;
+            float startDst;
+            float dur;
+            int chan;
+        };
+        struct BufDesc {
+            float *data;
+            size_t frames;
+        };
+        static std::queue<Job> jobQ;
+        static std::mutex qMut;
+        static std::unique_ptr<std::thread> worker;
+        static constexpr size_t maxBufs = 16;
+        static std::array<BufDesc, maxBufs> bufs;
+        static int numBufs;
+        static bool shouldQuit;
+        static constexpr int sleepPeriodMs = 100;
+        static int sampleRate;
+        static constexpr int ioBufFrames = 1024;
+
+        static int secToFrame(float seconds);
+
+    private:
+        static void requestJob(Job &job);
+
+    public:
+        // initialize with sample rate
+        static void init(int sr);
+
+        // register a buffer to manage.
+        // returns index to be used in work requests
+        static int registerBuffer(float *data, size_t frames);
+
+        // clear a portion of a mono buffer
+        static void requestClear(size_t idx, float start = 0, float dur = -1);
+
+        // read mono soundfile to mono buffer
+        static void
+        requestReadMono(size_t idx, std::string path, float startSrc = 0, float startDst = 0, float dur = -1,
+                        int chanSrc = 0);
+
+        // read and de-interleave stereo soundfile to 2x mono buffers
+        static void
+        requestReadStereo(size_t idx0, size_t idx1, std::string path, float startSrc = 0, float startDst = 0,
+                          float dur = -1);
+
+        // write mono buf to mono soundfile
+        static void requestWriteMono(size_t idx, std::string path, float start = 0, float dur = -1);
+
+        // write and interleave two mono buffers to one stereo file
+        static void requestWriteStereo(size_t idx0, size_t idx1, std::string path, float start = 0, float dur = -1);
+
+    private:
+        static void workLoop();
+
+        static void clearBuffer(BufDesc &buf, float start = 0, float dur = -1);
+
+        static void readBufferMono(const std::string &path, BufDesc &buf,
+                                   float startSrc = 0, float startDst = 0, float dur = -1, int chanSrc = 0);
+
+        static void readBufferStereo(const std::string &path, BufDesc &buf0, BufDesc &buf1,
+                                     float startSrc = 0, float startDst = 0, float dur = -1);
+
+        static void writeBufferMono(const std::string &path, BufDesc &buf,
+                                    float start = 0, float dur = -1);
+
+        static void writeBufferStereo(const std::string &path, BufDesc &buf0, BufDesc &buf1,
+                                      float start = 0, float dur = -1);
+
+    };
+
+}
+
+#endif //CRONE_BUFMANAGER_H

--- a/crone/src/BufDiskWorker.h
+++ b/crone/src/BufDiskWorker.h
@@ -7,7 +7,9 @@
  * it requires users to _register_ buffers (returns numerical index for registered buf)
  * disk read/write work can be requested for registered buffers, executed in background thread
  *
- * TODO: callback for request completion
+ * TODO: 
+ *  - callback for request completion?
+ *  - use condvar for signaling, instead of sleep+poll
  */
 
 #ifndef CRONE_BUFMANAGER_H
@@ -17,7 +19,6 @@
 #include <thread>
 #include <mutex>
 #include <queue>
-//#include <boost/lockfree/spsc_queue.hpp>
 #include <memory>
 
 namespace crone {

--- a/crone/src/MixerClient.h
+++ b/crone/src/MixerClient.h
@@ -117,11 +117,11 @@ namespace  crone {
 
     public:
         float getInputPeakPos(int ch) {
-            return inPeak[ch].get();
+            return inPeak[ch].getPos();
         }
 
         float getOutputPeakPos(int ch) {
-            return outPeak[ch].get();
+            return outPeak[ch].getPos();
         }
 
         void openTapeRecord(const char* path) {
@@ -135,7 +135,6 @@ namespace  crone {
         void stopTapeRecord() {
             tape.writer.stop();
         }
-
 
         void openTapePlayback(const char* path) {
             tape.reader.open(path);

--- a/crone/src/MixerClient.h
+++ b/crone/src/MixerClient.h
@@ -116,11 +116,11 @@ namespace  crone {
         PeakMeter outPeak[2];
 
     public:
-        float getInputPeak(int ch) {
+        float getInputPeakPos(int ch) {
             return inPeak[ch].get();
         }
 
-        float getOutputPeak(int ch) {
+        float getOutputPeakPos(int ch) {
             return outPeak[ch].get();
         }
 

--- a/crone/src/OscInterface.cpp
+++ b/crone/src/OscInterface.cpp
@@ -12,9 +12,9 @@
 #include "effects/ReverbParams.h"
 #include "softcut/FadeCurves.h"
 
+#include "BufDiskWorker.h"
 #include "Commands.h"
 #include "OscInterface.h"
-#include "Taper.h"
 
 using namespace crone;
 using softcut::FadeCurves;
@@ -30,15 +30,14 @@ unsigned int OscInterface::numMethods = 0;
 
 std::unique_ptr<Poll> OscInterface::vuPoll;
 std::unique_ptr<Poll> OscInterface::phasePoll;
-MixerClient* OscInterface::mixerClient;
-SoftCutClient* OscInterface::softCutClient;
+MixerClient *OscInterface::mixerClient;
+SoftCutClient *OscInterface::softCutClient;
 
 OscInterface::OscMethod::OscMethod(string p, string f, OscInterface::Handler h)
         : path(std::move(p)), format(std::move(f)), handler(h) {}
 
 
-void OscInterface::init(MixerClient *m, SoftCutClient *sc)
-{
+void OscInterface::init(MixerClient *m, SoftCutClient *sc) {
     quitFlag = false;
     // FIXME: should get port configs from program args or elsewhere
     port = "9999";
@@ -57,18 +56,14 @@ void OscInterface::init(MixerClient *m, SoftCutClient *sc)
     // FIXME: polls should really live somewhere else (client classes?)
     //--- VU poll
     vuPoll = std::make_unique<Poll>("vu");
-    vuPoll->setCallback([](const char* path){
+    vuPoll->setCallback([](const char *path) {
         char l[4];
-	float in0 = mixerClient->getInputPeak(0);
-	float in1 = mixerClient->getInputPeak(1);	
-	float out0 = mixerClient->getOutputPeak(0);	
-	float out1 = mixerClient->getOutputPeak(1);
 
-	l[0] = (uint8_t)(64*Taper::Vu::getPos(in0));
-        l[1] = (uint8_t)(64*Taper::Vu::getPos(in1)); 
-        l[2] = (uint8_t)(64*Taper::Vu::getPos(out0));
-        l[3] = (uint8_t)(64*Taper::Vu::getPos(out1));
-	
+        l[0] = (uint8_t) (64 * mixerClient->getInputPeak(0));
+        l[1] = (uint8_t) (64 * mixerClient->getInputPeak(1));
+        l[2] = (uint8_t) (64 * mixerClient->getOutputPeak(0));
+        l[3] = (uint8_t) (64 * mixerClient->getOutputPeak(1));
+
         lo_blob bl = lo_blob_new(sizeof(l), l);
         lo_send(matronAddress, path, "b", bl);
     });
@@ -76,9 +71,9 @@ void OscInterface::init(MixerClient *m, SoftCutClient *sc)
 
     //--- softcut phase poll
     phasePoll = std::make_unique<Poll>("softcut/phase");
-    phasePoll->setCallback([](const char* path) {
-        for (int i=0; i<softCutClient->getNumVoices(); ++i) {
-            if(softCutClient->checkVoiceQuantPhase(i)) {
+    phasePoll->setCallback([](const char *path) {
+        for (int i = 0; i < softCutClient->getNumVoices(); ++i) {
+            if (softCutClient->checkVoiceQuantPhase(i)) {
                 lo_send(matronAddress, path, "if", i, softCutClient->getQuantPhase(i));
             }
         }
@@ -94,22 +89,21 @@ void OscInterface::init(MixerClient *m, SoftCutClient *sc)
 }
 
 
-void OscInterface::addServerMethod(const char* path, const char* format, Handler handler) {
+void OscInterface::addServerMethod(const char *path, const char *format, Handler handler) {
     OscMethod m(path, format, handler);
     methods[numMethods] = m;
     lo_server_thread_add_method(st, path, format,
-                                [] (const char *path,
-                                    const char *types,
-                                    lo_arg **argv,
-                                    int argc,
-                                    lo_message msg,
-                                    void *data)
-                                    -> int
-                                {
+                                [](const char *path,
+                                   const char *types,
+                                   lo_arg **argv,
+                                   int argc,
+                                   lo_message msg,
+                                   void *data)
+                                        -> int {
                                     (void) path;
                                     (void) types;
                                     (void) msg;
-                                    auto pm = static_cast<OscMethod*>(data);
+                                    auto pm = static_cast<OscMethod *>(data);
                                     //std::cerr << "osc rx: " << path << std::endl;
                                     pm->handler(argv, argc);
                                     return 0;
@@ -120,18 +114,21 @@ void OscInterface::addServerMethod(const char* path, const char* format, Handler
 
 void OscInterface::addServerMethods() {
     addServerMethod("/hello", "", [](lo_arg **argv, int argc) {
-        (void)argv; (void)argc;
+        (void) argv;
+        (void) argc;
         std::cout << "hello" << std::endl;
     });
 
     addServerMethod("/goodbye", "", [](lo_arg **argv, int argc) {
-        (void)argv; (void)argc;
+        (void) argv;
+        (void) argc;
         std::cout << "goodbye" << std::endl;
         OscInterface::quitFlag = true;
     });
 
     addServerMethod("/quit", "", [](lo_arg **argv, int argc) {
-        (void)argv; (void)argc;
+        (void) argv;
+        (void) argc;
         OscInterface::quitFlag = true;
     });
 
@@ -140,12 +137,14 @@ void OscInterface::addServerMethods() {
     //--- mixer polls
 
     addServerMethod("/poll/start/vu", "", [](lo_arg **argv, int argc) {
-        (void)argv; (void)argc;
+        (void) argv;
+        (void) argc;
         vuPoll->start();
     });
 
     addServerMethod("/poll/stop/vu", "", [](lo_arg **argv, int argc) {
-        (void)argv; (void)argc;
+        (void) argv;
+        (void) argc;
         vuPoll->stop();
     });
 
@@ -158,65 +157,65 @@ void OscInterface::addServerMethods() {
     //--------------------------
     //--- levels
     addServerMethod("/set/level/adc", "f", [](lo_arg **argv, int argc) {
-        if(argc<1) { return; }
+        if (argc < 1) { return; }
         Commands::mixerCommands.post(Commands::Id::SET_LEVEL_ADC, argv[0]->f);
     });
 
     addServerMethod("/set/level/dac", "f", [](lo_arg **argv, int argc) {
-        if(argc<1) { return; }
+        if (argc < 1) { return; }
         Commands::mixerCommands.post(Commands::Id::SET_LEVEL_DAC, argv[0]->f);
     });
 
     addServerMethod("/set/level/ext", "f", [](lo_arg **argv, int argc) {
-        if(argc<1) { return; }
+        if (argc < 1) { return; }
         Commands::mixerCommands.post(Commands::Id::SET_LEVEL_EXT, argv[0]->f);
     });
 
     addServerMethod("/set/level/cut_master", "f", [](lo_arg **argv, int argc) {
-        if(argc<1) { return; }
+        if (argc < 1) { return; }
         Commands::mixerCommands.post(Commands::Id::SET_LEVEL_CUT_MASTER, argv[0]->f);
     });
 
 
     addServerMethod("/set/level/ext_rev", "f", [](lo_arg **argv, int argc) {
-        if(argc<1) { return; }
+        if (argc < 1) { return; }
         Commands::mixerCommands.post(Commands::Id::SET_LEVEL_EXT_AUX, argv[0]->f);
     });
 
     addServerMethod("/set/level/rev_dac", "f", [](lo_arg **argv, int argc) {
-        if(argc<1) { return; }
+        if (argc < 1) { return; }
         Commands::mixerCommands.post(Commands::Id::SET_LEVEL_AUX_DAC, argv[0]->f);
     });
 
     addServerMethod("/set/level/monitor", "f", [](lo_arg **argv, int argc) {
-        if(argc<1) { return; }
+        if (argc < 1) { return; }
         Commands::mixerCommands.post(Commands::Id::SET_LEVEL_MONITOR, argv[0]->f);
     });
 
     addServerMethod("/set/level/monitor_mix", "if", [](lo_arg **argv, int argc) {
-        if(argc<2) { return; }
+        if (argc < 2) { return; }
         Commands::mixerCommands.post(Commands::Id::SET_LEVEL_MONITOR_MIX, argv[0]->i, argv[1]->f);
     });
 
     addServerMethod("/set/level/monitor_rev", "f", [](lo_arg **argv, int argc) {
-        if(argc<1) { return; }
+        if (argc < 1) { return; }
         Commands::mixerCommands.post(Commands::Id::SET_LEVEL_MONITOR_AUX, argv[0]->f);
     });
 
     addServerMethod("/set/level/compressor_mix", "f", [](lo_arg **argv, int argc) {
-        if(argc<1) { return; }
+        if (argc < 1) { return; }
         Commands::mixerCommands.post(Commands::Id::SET_LEVEL_INS_MIX, argv[0]->f);
     });
 
 
     // toggle enabled
     addServerMethod("/set/enabled/compressor", "f", [](lo_arg **argv, int argc) {
-        if(argc<1) { return; }
+        if (argc < 1) { return; }
         Commands::mixerCommands.post(Commands::Id::SET_ENABLED_COMPRESSOR, argv[0]->f);
     });
 
     addServerMethod("/set/enabled/reverb", "f", [](lo_arg **argv, int argc) {
-        if(argc<1) { return; }
+        if (argc < 1) { return; }
         Commands::mixerCommands.post(Commands::Id::SET_ENABLED_REVERB, argv[0]->f);
     });
 
@@ -224,32 +223,32 @@ void OscInterface::addServerMethods() {
     //-- compressor params
 
     addServerMethod("/set/param/compressor/ratio", "f", [](lo_arg **argv, int argc) {
-        if(argc<1) { return; }
+        if (argc < 1) { return; }
         Commands::mixerCommands.post(Commands::Id::SET_PARAM_COMPRESSOR, CompressorParam::RATIO, argv[0]->f);
     });
 
     addServerMethod("/set/param/compressor/threshold", "f", [](lo_arg **argv, int argc) {
-        if(argc<1) { return; }
+        if (argc < 1) { return; }
         Commands::mixerCommands.post(Commands::Id::SET_PARAM_COMPRESSOR, CompressorParam::THRESHOLD, argv[0]->f);
     });
 
     addServerMethod("/set/param/compressor/attack", "f", [](lo_arg **argv, int argc) {
-        if(argc<1) { return; }
+        if (argc < 1) { return; }
         Commands::mixerCommands.post(Commands::Id::SET_PARAM_COMPRESSOR, CompressorParam::ATTACK, argv[0]->f);
     });
 
     addServerMethod("/set/param/compressor/release", "f", [](lo_arg **argv, int argc) {
-        if(argc<1) { return; }
+        if (argc < 1) { return; }
         Commands::mixerCommands.post(Commands::Id::SET_PARAM_COMPRESSOR, CompressorParam::RELEASE, argv[0]->f);
     });
 
     addServerMethod("/set/param/compressor/gain_pre", "f", [](lo_arg **argv, int argc) {
-        if(argc<1) { return; }
+        if (argc < 1) { return; }
         Commands::mixerCommands.post(Commands::Id::SET_PARAM_COMPRESSOR, CompressorParam::GAIN_PRE, argv[0]->f);
     });
 
     addServerMethod("/set/param/compressor/gain_post", "f", [](lo_arg **argv, int argc) {
-        if(argc<1) { return; }
+        if (argc < 1) { return; }
         Commands::mixerCommands.post(Commands::Id::SET_PARAM_COMPRESSOR, CompressorParam::GAIN_POST, argv[0]->f);
     });
 
@@ -258,27 +257,27 @@ void OscInterface::addServerMethods() {
     //-- reverb params
 
     addServerMethod("/set/param/reverb/pre_del", "f", [](lo_arg **argv, int argc) {
-        if(argc<1) { return; }
+        if (argc < 1) { return; }
         Commands::mixerCommands.post(Commands::Id::SET_PARAM_REVERB, ReverbParam::PRE_DEL, argv[0]->f);
     });
 
     addServerMethod("/set/param/reverb/lf_fc", "f", [](lo_arg **argv, int argc) {
-        if(argc<1) { return; }
+        if (argc < 1) { return; }
         Commands::mixerCommands.post(Commands::Id::SET_PARAM_REVERB, ReverbParam::LF_FC, argv[0]->f);
     });
 
     addServerMethod("/set/param/reverb/low_rt60", "f", [](lo_arg **argv, int argc) {
-        if(argc<1) { return; }
+        if (argc < 1) { return; }
         Commands::mixerCommands.post(Commands::Id::SET_PARAM_REVERB, ReverbParam::LOW_RT60, argv[0]->f);
     });
 
     addServerMethod("/set/param/reverb/mid_rt60", "f", [](lo_arg **argv, int argc) {
-        if(argc<1) { return; }
+        if (argc < 1) { return; }
         Commands::mixerCommands.post(Commands::Id::SET_PARAM_REVERB, ReverbParam::MID_RT60, argv[0]->f);
     });
 
     addServerMethod("/set/param/reverb/hf_damp", "f", [](lo_arg **argv, int argc) {
-        if(argc<1) { return; }
+        if (argc < 1) { return; }
         Commands::mixerCommands.post(Commands::Id::SET_PARAM_REVERB, ReverbParam::HF_DAMP, argv[0]->f);
     });
 
@@ -287,38 +286,38 @@ void OscInterface::addServerMethods() {
     //-- softcut routing
 
     addServerMethod("/set/enabled/cut", "if", [](lo_arg **argv, int argc) {
-        if(argc<2) { return; }
+        if (argc < 2) { return; }
         Commands::softcutCommands.post(Commands::Id::SET_ENABLED_CUT, argv[0]->i, argv[1]->f);
     });
 
     addServerMethod("/set/level/cut", "if", [](lo_arg **argv, int argc) {
-        if(argc<2) { return; }
+        if (argc < 2) { return; }
         Commands::softcutCommands.post(Commands::Id::SET_LEVEL_CUT, argv[0]->i, argv[1]->f);
     });
 
     addServerMethod("/set/pan/cut", "if", [](lo_arg **argv, int argc) {
-        if(argc<2) { return; }
+        if (argc < 2) { return; }
         Commands::softcutCommands.post(Commands::Id::SET_PAN_CUT, argv[0]->i, argv[1]->f);
     });
 
 
     addServerMethod("/set/level/adc_cut", "f", [](lo_arg **argv, int argc) {
-        if(argc<1) { return; }
+        if (argc < 1) { return; }
         Commands::mixerCommands.post(Commands::Id::SET_LEVEL_ADC_CUT, argv[0]->f);
     });
 
     addServerMethod("/set/level/ext_cut", "f", [](lo_arg **argv, int argc) {
-        if(argc<1) { return; }
+        if (argc < 1) { return; }
         Commands::mixerCommands.post(Commands::Id::SET_LEVEL_EXT_CUT, argv[0]->f);
     });
 
     addServerMethod("/set/level/tape_cut", "f", [](lo_arg **argv, int argc) {
-        if(argc<1) { return; }
+        if (argc < 1) { return; }
         Commands::mixerCommands.post(Commands::Id::SET_LEVEL_TAPE_CUT, argv[0]->f);
     });
 
     addServerMethod("/set/level/cut_rev", "f", [](lo_arg **argv, int argc) {
-        if(argc<1) { return; }
+        if (argc < 1) { return; }
         Commands::mixerCommands.post(Commands::Id::SET_LEVEL_CUT_AUX, argv[0]->f);
     });
 
@@ -328,14 +327,14 @@ void OscInterface::addServerMethods() {
 
     // input channel -> voice levels
     addServerMethod("/set/level/in_cut", "iif", [](lo_arg **argv, int argc) {
-        if(argc<3) { return; }
+        if (argc < 3) { return; }
         Commands::softcutCommands.post(Commands::Id::SET_LEVEL_IN_CUT, argv[0]->i, argv[1]->i, argv[2]->f);
     });
 
 
     // voice ->  voice levels
     addServerMethod("/set/level/cut_cut", "iif", [](lo_arg **argv, int argc) {
-        if(argc<3) { return; }
+        if (argc < 3) { return; }
         Commands::softcutCommands.post(Commands::Id::SET_LEVEL_CUT_CUT, argv[0]->i, argv[1]->i, argv[2]->f);
     });
 
@@ -345,141 +344,141 @@ void OscInterface::addServerMethods() {
 
 
     addServerMethod("/set/param/cut/rate", "if", [](lo_arg **argv, int argc) {
-        if(argc<2) { return; }
+        if (argc < 2) { return; }
         Commands::softcutCommands.post(Commands::Id::SET_CUT_RATE, argv[0]->i, argv[1]->f);
     });
 
     addServerMethod("/set/param/cut/loop_start", "if", [](lo_arg **argv, int argc) {
-        if(argc<2) { return; }
+        if (argc < 2) { return; }
         Commands::softcutCommands.post(Commands::Id::SET_CUT_LOOP_START, argv[0]->i, argv[1]->f);
     });
 
     addServerMethod("/set/param/cut/loop_end", "if", [](lo_arg **argv, int argc) {
-        if(argc<2) { return; }
+        if (argc < 2) { return; }
         Commands::softcutCommands.post(Commands::Id::SET_CUT_LOOP_END, argv[0]->i, argv[1]->f);
     });
 
     addServerMethod("/set/param/cut/loop_flag", "if", [](lo_arg **argv, int argc) {
-        if(argc<2) { return; }
+        if (argc < 2) { return; }
         Commands::softcutCommands.post(Commands::Id::SET_CUT_LOOP_FLAG, argv[0]->i, argv[1]->f);
     });
 
     addServerMethod("/set/param/cut/fade_time", "if", [](lo_arg **argv, int argc) {
-        if(argc<2) { return; }
+        if (argc < 2) { return; }
         Commands::softcutCommands.post(Commands::Id::SET_CUT_FADE_TIME, argv[0]->i, argv[1]->f);
     });
 
     addServerMethod("/set/param/cut/rec_level", "if", [](lo_arg **argv, int argc) {
-        if(argc<2) { return; }
+        if (argc < 2) { return; }
         Commands::softcutCommands.post(Commands::Id::SET_CUT_REC_LEVEL, argv[0]->i, argv[1]->f);
     });
 
     addServerMethod("/set/param/cut/pre_level", "if", [](lo_arg **argv, int argc) {
-        if(argc<2) { return; }
+        if (argc < 2) { return; }
         Commands::softcutCommands.post(Commands::Id::SET_CUT_PRE_LEVEL, argv[0]->i, argv[1]->f);
     });
 
     addServerMethod("/set/param/cut/rec_flag", "if", [](lo_arg **argv, int argc) {
-        if(argc<2) { return; }
+        if (argc < 2) { return; }
         Commands::softcutCommands.post(Commands::Id::SET_CUT_REC_FLAG, argv[0]->i, argv[1]->f);
     });
 
     addServerMethod("/set/param/cut/play_flag", "if", [](lo_arg **argv, int argc) {
-        if(argc<2) { return; }
+        if (argc < 2) { return; }
         Commands::softcutCommands.post(Commands::Id::SET_CUT_PLAY_FLAG, argv[0]->i, argv[1]->f);
     });
 
     addServerMethod("/set/param/cut/rec_offset", "if", [](lo_arg **argv, int argc) {
-        if(argc<2) { return; }
+        if (argc < 2) { return; }
         Commands::softcutCommands.post(Commands::Id::SET_CUT_REC_OFFSET, argv[0]->i, argv[1]->f);
     });
 
     addServerMethod("/set/param/cut/position", "if", [](lo_arg **argv, int argc) {
-        if(argc<2) { return; }
+        if (argc < 2) { return; }
         Commands::softcutCommands.post(Commands::Id::SET_CUT_POSITION, argv[0]->i, argv[1]->f);
     });
 
     // --- input filter
     addServerMethod("/set/param/cut/pre_filter_fc", "if", [](lo_arg **argv, int argc) {
-        if(argc<2) { return; }
+        if (argc < 2) { return; }
         Commands::softcutCommands.post(Commands::Id::SET_CUT_PRE_FILTER_FC, argv[0]->i, argv[1]->f);
     });
 
     addServerMethod("/set/param/cut/pre_filter_fc_mod", "if", [](lo_arg **argv, int argc) {
-        if(argc<2) { return; }
+        if (argc < 2) { return; }
         Commands::softcutCommands.post(Commands::Id::SET_CUT_PRE_FILTER_FC_MOD, argv[0]->i, argv[1]->f);
     });
 
     addServerMethod("/set/param/cut/pre_filter_rq", "if", [](lo_arg **argv, int argc) {
-        if(argc<2) { return; }
+        if (argc < 2) { return; }
         Commands::softcutCommands.post(Commands::Id::SET_CUT_PRE_FILTER_RQ, argv[0]->i, argv[1]->f);
     });
 
     addServerMethod("/set/param/cut/pre_filter_lp", "if", [](lo_arg **argv, int argc) {
-        if(argc<2) { return; }
+        if (argc < 2) { return; }
         Commands::softcutCommands.post(Commands::Id::SET_CUT_PRE_FILTER_LP, argv[0]->i, argv[1]->f);
     });
 
     addServerMethod("/set/param/cut/pre_filter_hp", "if", [](lo_arg **argv, int argc) {
-        if(argc<2) { return; }
+        if (argc < 2) { return; }
         Commands::softcutCommands.post(Commands::Id::SET_CUT_PRE_FILTER_HP, argv[0]->i, argv[1]->f);
     });
 
     addServerMethod("/set/param/cut/pre_filter_bp", "if", [](lo_arg **argv, int argc) {
-        if(argc<2) { return; }
+        if (argc < 2) { return; }
         Commands::softcutCommands.post(Commands::Id::SET_CUT_PRE_FILTER_BP, argv[0]->i, argv[1]->f);
     });
 
     addServerMethod("/set/param/cut/pre_filter_br", "if", [](lo_arg **argv, int argc) {
-        if(argc<2) { return; }
+        if (argc < 2) { return; }
         Commands::softcutCommands.post(Commands::Id::SET_CUT_PRE_FILTER_BR, argv[0]->i, argv[1]->f);
     });
 
     addServerMethod("/set/param/cut/pre_filter_dry", "if", [](lo_arg **argv, int argc) {
-        if(argc<2) { return; }
+        if (argc < 2) { return; }
         Commands::softcutCommands.post(Commands::Id::SET_CUT_PRE_FILTER_DRY, argv[0]->i, argv[1]->f);
     });
 
 
-        // --- output filter
+    // --- output filter
     addServerMethod("/set/param/cut/post_filter_fc", "if", [
-](lo_arg **argv, int argc) {
-        if(argc<2) { return; }
+    ](lo_arg **argv, int argc) {
+        if (argc < 2) { return; }
         Commands::softcutCommands.post(Commands::Id::SET_CUT_POST_FILTER_FC, argv[0]->i, argv[1]->f);
     });
 
     addServerMethod("/set/param/cut/post_filter_rq", "if", [](lo_arg **argv, int argc) {
-        if(argc<2) { return; }
+        if (argc < 2) { return; }
         Commands::softcutCommands.post(Commands::Id::SET_CUT_POST_FILTER_RQ, argv[0]->i, argv[1]->f);
     });
 
     addServerMethod("/set/param/cut/post_filter_lp", "if", [](lo_arg **argv, int argc) {
-        if(argc<2) { return; }
+        if (argc < 2) { return; }
         Commands::softcutCommands.post(Commands::Id::SET_CUT_POST_FILTER_LP, argv[0]->i, argv[1]->f);
     });
 
     addServerMethod("/set/param/cut/post_filter_hp", "if", [](lo_arg **argv, int argc) {
-        if(argc<2) { return; }
+        if (argc < 2) { return; }
         Commands::softcutCommands.post(Commands::Id::SET_CUT_POST_FILTER_HP, argv[0]->i, argv[1]->f);
     });
 
     addServerMethod("/set/param/cut/post_filter_bp", "if", [](lo_arg **argv, int argc) {
-        if(argc<2) { return; }
+        if (argc < 2) { return; }
         Commands::softcutCommands.post(Commands::Id::SET_CUT_POST_FILTER_BP, argv[0]->i, argv[1]->f);
     });
 
     addServerMethod("/set/param/cut/post_filter_br", "if", [](lo_arg **argv, int argc) {
-        if(argc<2) { return; }
+        if (argc < 2) { return; }
         Commands::softcutCommands.post(Commands::Id::SET_CUT_POST_FILTER_BR, argv[0]->i, argv[1]->f);
     });
 
     addServerMethod("/set/param/cut/post_filter_dry", "if", [](lo_arg **argv, int argc) {
-        if(argc<2) { return; }
+        if (argc < 2) { return; }
         Commands::softcutCommands.post(Commands::Id::SET_CUT_POST_FILTER_DRY, argv[0]->i, argv[1]->f);
     });
 
     addServerMethod("/set/param/cut/voice_sync", "iif", [](lo_arg **argv, int argc) {
-        if(argc<3) { return; }
+        if (argc < 3) { return; }
         Commands::softcutCommands.post(Commands::Id::SET_CUT_VOICE_SYNC, argv[0]->i, argv[1]->i, argv[2]->f);
     });
 
@@ -492,7 +491,7 @@ void OscInterface::addServerMethods() {
     /// perhaps these parameters should not be modulatable at all.
 
     addServerMethod("/set/param/cut/pre_fade_window", "if", [](lo_arg **argv, int argc) {
-        if(argc<1) { return; }
+        if (argc < 1) { return; }
         float x = argv[0]->f;
         auto t = std::thread([x] {
             FadeCurves::setPreWindowRatio(x);
@@ -501,7 +500,7 @@ void OscInterface::addServerMethods() {
     });
 
     addServerMethod("/set/param/cut/rec_fade_delay", "if", [](lo_arg **argv, int argc) {
-        if(argc<1) { return; }
+        if (argc < 1) { return; }
         float x = argv[0]->f;
         auto t = std::thread([x] {
             FadeCurves::setRecDelayRatio(x);
@@ -510,7 +509,7 @@ void OscInterface::addServerMethods() {
     });
 
     addServerMethod("/set/param/cut/pre_fade_shape", "if", [](lo_arg **argv, int argc) {
-        if(argc<1) { return; }
+        if (argc < 1) { return; }
         float x = argv[0]->f;
         auto t = std::thread([x] {
             FadeCurves::setPreShape(static_cast<FadeCurves::Shape>(x));
@@ -519,7 +518,7 @@ void OscInterface::addServerMethods() {
     });
 
     addServerMethod("/set/param/cut/rec_fade_shape", "if", [](lo_arg **argv, int argc) {
-        if(argc<1) { return; }
+        if (argc < 1) { return; }
         float x = argv[0]->f;
         auto t = std::thread([x] {
             FadeCurves::setRecShape(static_cast<FadeCurves::Shape>(x));
@@ -530,28 +529,28 @@ void OscInterface::addServerMethods() {
     ///////////////////
 
     addServerMethod("/set/param/cut/level_slew_time", "if", [](lo_arg **argv, int argc) {
-        if (argc<2) { return; }
+        if (argc < 2) { return; }
         Commands::softcutCommands.post(Commands::Id::SET_CUT_LEVEL_SLEW_TIME, argv[0]->i, argv[1]->f);
     });
 
     addServerMethod("/set/param/cut/pan_slew_time", "if", [](lo_arg **argv, int argc) {
-        if (argc<2) { return; }
+        if (argc < 2) { return; }
         Commands::softcutCommands.post(Commands::Id::SET_CUT_PAN_SLEW_TIME, argv[0]->i, argv[1]->f);
     });
 
     addServerMethod("/set/param/cut/recpre_slew_time", "if", [](lo_arg **argv, int argc) {
-        if (argc<2) { return; }
+        if (argc < 2) { return; }
         Commands::softcutCommands.post(Commands::Id::SET_CUT_RECPRE_SLEW_TIME, argv[0]->i, argv[1]->f);
     });
 
     addServerMethod("/set/param/cut/rate_slew_time", "if", [](lo_arg **argv, int argc) {
-        if (argc<2) { return; }
+        if (argc < 2) { return; }
         Commands::softcutCommands.post(Commands::Id::SET_CUT_RATE_SLEW_TIME, argv[0]->i, argv[1]->f);
     });
 
 
     addServerMethod("/set/param/cut/buffer", "ii", [](lo_arg **argv, int argc) {
-        if (argc<2) { return; }
+        if (argc < 2) { return; }
         Commands::softcutCommands.post(Commands::Id::SET_CUT_BUFFER, argv[0]->i, argv[1]->i);
     });
 
@@ -565,8 +564,8 @@ void OscInterface::addServerMethods() {
         float startSrc = 0.f;
         float startDst = 0.f;
         float dur = -1.f;
-        int chanSrc=0;
-        int chanDst=0;
+        int chanSrc = 0;
+        int chanDst = 0;
         if (argc < 1) {
             std::cerr << "/softcut/buffer/read_mono requires at least one argument (file path)" << std::endl;
             return;
@@ -581,13 +580,14 @@ void OscInterface::addServerMethods() {
             dur = argv[3]->f;
         }
         if (argc > 4) {
-            chanSrc= argv[4]->i;
+            chanSrc = argv[4]->i;
         }
         if (argc > 5) {
-            chanDst= argv[5]->i;
+            chanDst = argv[5]->i;
         }
         const char *str = &argv[0]->s;
         softCutClient->readBufferMono(str, startSrc, startDst, dur, chanSrc, chanDst);
+
     });
 
     // FIXME: hrm, our system doesn't allow variable argument count. maybe need to make multiple methods
@@ -617,7 +617,7 @@ void OscInterface::addServerMethods() {
     addServerMethod("/softcut/buffer/write_mono", "sffi", [](lo_arg **argv, int argc) {
         float start = 0.f;
         float dur = -1.f;
-        int chan=0;
+        int chan = 0;
         if (argc < 1) {
             std::cerr << "/softcut/buffer/write_mono requires at least one argument (file path)" << std::endl;
             return;
@@ -654,10 +654,9 @@ void OscInterface::addServerMethods() {
     });
 
 
-
     addServerMethod("/softcut/buffer/clear", "", [](lo_arg **argv, int argc) {
-        (void)argc;
-        (void)argv;
+        (void) argc;
+        (void) argv;
         softCutClient->clearBuffer(0);
         softCutClient->clearBuffer(1);
     });
@@ -686,14 +685,14 @@ void OscInterface::addServerMethods() {
     });
 
     addServerMethod("/softcut/reset", "", [](lo_arg **argv, int argc) {
-        (void)argv;
-        (void)argc;
+        (void) argv;
+        (void) argc;
 
         softCutClient->clearBuffer(0, 0, -1);
         softCutClient->clearBuffer(1, 0, -1);
 
         softCutClient->reset();
-        for (int i=0; i<SoftCutClient::NumVoices; ++i) {
+        for (int i = 0; i < SoftCutClient::NumVoices; ++i) {
             phasePoll->stop();
         }
     });
@@ -702,22 +701,24 @@ void OscInterface::addServerMethods() {
     //--- softcut polls
 
     addServerMethod("/set/param/cut/phase_quant", "if", [](lo_arg **argv, int argc) {
-        if (argc<2) { return; }
+        if (argc < 2) { return; }
         softCutClient->setPhaseQuant(argv[0]->i, argv[1]->f);
     });
 
     addServerMethod("/set/param/cut/phase_offset", "if", [](lo_arg **argv, int argc) {
-        if (argc<2) { return; }
+        if (argc < 2) { return; }
         softCutClient->setPhaseOffset(argv[0]->i, argv[1]->f);
     });
 
     addServerMethod("/poll/start/cut/phase", "", [](lo_arg **argv, int argc) {
-        (void)argv; (void)argc;
+        (void) argv;
+        (void) argc;
         phasePoll->start();
     });
 
     addServerMethod("/poll/stop/cut/phase", "", [](lo_arg **argv, int argc) {
-        (void)argv; (void)argc;
+        (void) argv;
+        (void) argc;
         phasePoll->stop();
     });
 
@@ -726,42 +727,46 @@ void OscInterface::addServerMethods() {
     //--- tape control
 
     addServerMethod("/tape/record/open", "s", [](lo_arg **argv, int argc) {
-        if (argc<1) { return; }
+        if (argc < 1) { return; }
         mixerClient->openTapeRecord(&argv[0]->s);
     });
 
     addServerMethod("/tape/record/start", "", [](lo_arg **argv, int argc) {
-        (void) argv; (void) argc;
+        (void) argv;
+        (void) argc;
         mixerClient->startTapeRecord();
     });
 
     addServerMethod("/tape/record/stop", "", [](lo_arg **argv, int argc) {
-        (void) argv; (void) argc;
+        (void) argv;
+        (void) argc;
         mixerClient->stopTapeRecord();
     });
 
     addServerMethod("/tape/play/open", "s", [](lo_arg **argv, int argc) {
-        if (argc<1) { return; }
+        if (argc < 1) { return; }
         mixerClient->openTapePlayback(&argv[0]->s);
     });
 
     addServerMethod("/tape/play/start", "", [](lo_arg **argv, int argc) {
-        (void) argv; (void) argc;
+        (void) argv;
+        (void) argc;
         mixerClient->startTapePlayback();
     });
 
     addServerMethod("/tape/play/stop", "", [](lo_arg **argv, int argc) {
-        (void) argv; (void) argc;
+        (void) argv;
+        (void) argc;
         mixerClient->stopTapePlayback();
     });
 
     addServerMethod("/set/level/tape", "f", [](lo_arg **argv, int argc) {
-        if (argc<1) { return; }
+        if (argc < 1) { return; }
         Commands::mixerCommands.post(Commands::Id::SET_LEVEL_TAPE, argv[0]->f);
     });
 
     addServerMethod("/set/level/tape_rev", "f", [](lo_arg **argv, int argc) {
-        if (argc<1) { return; }
+        if (argc < 1) { return; }
         Commands::mixerCommands.post(Commands::Id::SET_LEVEL_TAPE_AUX, argv[0]->f);
     });
 }
@@ -772,7 +777,7 @@ void OscInterface::printServerMethods() {
     using std::string;
     using boost::format;
     cout << "osc methods: " << endl;
-    for (unsigned int i=0; i<numMethods; ++i) {
+    for (unsigned int i = 0; i < numMethods; ++i) {
         cout << format(" %1% [%2%]") % methods[i].path % methods[i].format << endl;
     }
 }

--- a/crone/src/OscInterface.cpp
+++ b/crone/src/OscInterface.cpp
@@ -64,11 +64,6 @@ void OscInterface::init(MixerClient *m, SoftCutClient *sc) {
         l[2] = (uint8_t) (64 * mixerClient->getOutputPeakPos(0));
         l[3] = (uint8_t) (64 * mixerClient->getOutputPeakPos(1));
 
-        l[0] = (uint8_t)(64*Taper::Vu::getPos(in0));
-        l[1] = (uint8_t)(64*Taper::Vu::getPos(in1));
-        l[2] = (uint8_t)(64*Taper::Vu::getPos(out0));
-        l[3] = (uint8_t)(64*Taper::Vu::getPos(out1));
-
         lo_blob bl = lo_blob_new(sizeof(l), l);
         lo_send(matronAddress, path, "b", bl);
     });

--- a/crone/src/OscInterface.cpp
+++ b/crone/src/OscInterface.cpp
@@ -59,10 +59,10 @@ void OscInterface::init(MixerClient *m, SoftCutClient *sc) {
     vuPoll->setCallback([](const char *path) {
         char l[4];
 
-        l[0] = (uint8_t) (64 * mixerClient->getInputPeak(0));
-        l[1] = (uint8_t) (64 * mixerClient->getInputPeak(1));
-        l[2] = (uint8_t) (64 * mixerClient->getOutputPeak(0));
-        l[3] = (uint8_t) (64 * mixerClient->getOutputPeak(1));
+        l[0] = (uint8_t) (64 * mixerClient->getInputPeakPos(0));
+        l[1] = (uint8_t) (64 * mixerClient->getInputPeakPos(1));
+        l[2] = (uint8_t) (64 * mixerClient->getOutputPeakPos(0));
+        l[3] = (uint8_t) (64 * mixerClient->getOutputPeakPos(1));
 
         lo_blob bl = lo_blob_new(sizeof(l), l);
         lo_send(matronAddress, path, "b", bl);

--- a/crone/src/PeakMeter.h
+++ b/crone/src/PeakMeter.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "Utilities.h"
+#include "Taper.h"
 
 namespace crone { 
 
@@ -21,6 +22,7 @@ namespace crone {
 	}
 
 	float get() const { return val; }
+	float getPos() const { return Taper::Vu::getPos(val); }
 	
     private:    
 	// get max value in audio block

--- a/crone/src/PeakMeter.h
+++ b/crone/src/PeakMeter.h
@@ -22,6 +22,7 @@ namespace crone {
 	}
 
 	float get() const { return val; }
+	float getPos() const { return Taper::Vu::getPos(val); }
 	
     private:    
 	// get max value in audio block

--- a/crone/src/main.cpp
+++ b/crone/src/main.cpp
@@ -10,6 +10,7 @@
 #include "MixerClient.h"
 #include "SoftCutClient.h"
 #include "OscInterface.h"
+#include "BufDiskWorker.h"
 
 static inline void sleep(int ms) {
     std::this_thread::sleep_for(std::chrono::milliseconds(ms));
@@ -24,6 +25,8 @@ int main() {
     std::unique_ptr<MixerClient> m = std::make_unique<MixerClient>();
     std::unique_ptr<SoftCutClient> sc = std::make_unique<SoftCutClient>();
 
+    cout << "initializing buffer management worker.." << endl;
+    BufDiskWorker::init(48000);
 
     cout << "setting up jack clients.." << endl;
     m->setup();

--- a/crone/src/softcut/SoftCutHead.cpp
+++ b/crone/src/softcut/SoftCutHead.cpp
@@ -193,7 +193,7 @@ void SoftCutHead::setRec(float x) {
 }
 
 void SoftCutHead::setPre(float x) {
-    pre= x;
+    pre = x;
 }
 
 phase_t SoftCutHead::getActivePhase() {

--- a/crone/wscript
+++ b/crone/wscript
@@ -10,9 +10,10 @@ def configure(conf):
 def build(bld):
     crone_sources = [
         'src/main.cpp',
-        'src/OscInterface.cpp',
+        'src/BufDiskWorker.cpp',
         'src/Commands.cpp',
         'src/MixerClient.cpp',
+        'src/OscInterface.cpp',
         'src/SoftCutClient.cpp',
         'src/Taper.cpp',
         'src/Window.cpp',


### PR DESCRIPTION
redo of #958. 

not sure what happened there, but possible weirdness with nontrivial `std::string` copy constructor usage in `spsc_queue` on ARM. this situation doesn't actually need to be lockfree so just replaced spsc_queue with mutex. (note the FIXME: this means we can replace worker `sleep` with a condvar, but it's a long sleep and its fine for now)

this also brings in small fix for read destination max frame count.

there are quite a few debug statements in the disk worker module. leaving for now, will remove before merge.