### PR TITLE
curses maiden ws compat

### DIFF
--- a/maiden/src/io.c
+++ b/maiden/src/io.c
@@ -39,17 +39,15 @@ void *crone_rx_loop(void *x);
 struct sock_io sock_io[IO_COUNT];
 
 char *url_default[IO_COUNT] = {
-  "ipc:///tmp/matron_out.ipc",
-  "ipc:///tmp/matron_in.ipc",
-  "ipc:///tmp/crone_out.ipc",
-  "ipc:///tmp/crone_in.ipc"
+  "ws://localhost:5555/",
+  "ws://localhost:5556/",
+  NULL,
 };
 
 void * (*loop_func[IO_COUNT])(void *) = {
   &matron_rx_loop,
-  &tx_loop, // tx for both children
   &crone_rx_loop,
-  NULL,
+  &tx_loop
 };
 
 //-----------
@@ -57,9 +55,11 @@ void * (*loop_func[IO_COUNT])(void *) = {
 
 void sock_io_init( struct sock_io *io, char *url, void * (*loop)(void *) ) {
   // connect socket
-  io->sock = nn_socket(AF_SP, NN_BUS);
-  if(nn_connect(io->sock, url) < 0) {
-    perror("error connecting socket");
+  if(url) {
+    io->sock = nn_socket(AF_SP, NN_BUS);
+    if(nn_connect(io->sock, url) < 0) {
+      perror("error connecting socket");
+    }
   }
   // launch thread if loop function defined
   io->has_thread = false;
@@ -128,13 +128,6 @@ void *matron_rx_loop(void *p) {
       ui_matron_line(msg);
     }
   }
-  return NULL;
-}
-
-void *matron_tx_loop(void *x) {
-  (void)x;
-  ui_loop(); // <-- quit when this exits
-  io_deinit();
   return NULL;
 }
 

--- a/maiden/src/io.h
+++ b/maiden/src/io.h
@@ -7,10 +7,9 @@
  */
 
 enum {
-  IO_MATRON_RX,
-  IO_MATRON_TX,
-  IO_CRONE_RX,
-  IO_CRONE_TX,
+  IO_MATRON,
+  IO_CRONE,
+  IO_UI,
   IO_COUNT
 };
 

--- a/maiden/src/ui.c
+++ b/maiden/src/ui.c
@@ -194,10 +194,10 @@ void handle_cmd(char *line)
     }
     switch( page_id() ) {
     case PAGE_MATRON:
-      io_send_line(IO_MATRON_TX, line);
+      io_send_line(IO_MATRON, line);
       break;
     case PAGE_CRONE:
-      io_send_line(IO_CRONE_TX, line);
+      io_send_line(IO_CRONE, line);
       break;
     }
     free(line);


### PR DESCRIPTION
fixes #978 

this is a minimal change that allows the original curses based `maiden` to work along side the web based version. through the magic of nanomsg both the console repl and the web repl work at the same time. input is not echoed to each repl but each repl does see the same output.

_note: to compile i needed to `sudo apt-get install libncursesw5-dev`_

an outstanding issue which this PR doesn't address is the duplicate command names. perhaps it is worth reimplementing this in go and rolling it into the maiden backend command as `maiden repl`. one advantage of integrating it in the go based command would be the ability to run it on a different host (along side a non-web based editor). 