### PR TITLE
cleanup engine deinit logic

### DIFF
--- a/lua/core/script.lua
+++ b/lua/core/script.lua
@@ -40,7 +40,6 @@ Script.clear = function()
 
   -- clear engine
   engine.name = nil
-  _norns.free_engine()
 
   -- clear softcut
   softcut.reset()

--- a/sc/core/CroneEngine.sc
+++ b/sc/core/CroneEngine.sc
@@ -39,21 +39,19 @@ CroneEngine {
 		^CronePollRegistry.getPollFromName(name);
 	}
 
+	// deinit is called in a routine
 	deinit { arg doneCallback;
-		fork {
-			postln("CroneEngine.free");
-			commands.do({ arg com;
-				com.oscdef.free;
-			});
-			pollNames.do({ arg name;
-				CronePollRegistry.remove(name);
-			});
-			// subclass should implement free, and this method should also be called in a routine
-			this.free;
-			Crone.server.sync;
-			doneCallback.value(this);
-		}
-
+		postln("CroneEngine.free");
+		commands.do({ arg com;
+			com.oscdef.free;
+		});
+		pollNames.do({ arg name;
+			CronePollRegistry.remove(name);
+		});
+		// subclass responsibility to implement free
+		this.free;
+		Crone.server.sync;
+		doneCallback.value(this);
 	}
 
 


### PR DESCRIPTION
when debugging an issue i noticed engine free routine is called two times due to `_norns.free_engine()` in `script.lua` (looks like it isn't needed since engine is deinited in sc code here: https://github.com/monome/norns/blob/master/sc/core/Crone.sc#L109-L115)

also, since `CroneEngine.deinit` is already called in a routine (see https://github.com/monome/norns/blob/master/sc/core/Crone.sc#L108) i removed the `fork { }` wrapping code in CroneEngine.deinit.

(... my original issue was due to multiple forks and server.sync calls stalling sclang, so thought it might be good to do this clean up)