### PR TITLE
fix softcut.defaults()

### DIFF
--- a/lua/core/softcut.lua
+++ b/lua/core/softcut.lua
@@ -195,7 +195,7 @@ end
 --- @return table of parameter states for each voice
 function SC.defaults()
   local state = {}
-  for i=1,SC.COUNT do
+  for i=1,SC.VOICE_COUNT do
      state[i] = 0;
      state[i].enable =0
      state[i].play =0


### PR DESCRIPTION
should be SC.VOICE_COUNT not SC.COUNT

yes ?

(did not build to test but confirmed error on my device)

```
### SCRIPT ERROR: load fail
/home/we/norns/lua/core/softcut.lua:201: 'for' limit must be a number
stack traceback:
	/home/we/norns/lua/core/norns.lua:126: in metamethod '__index'
	/home/we/norns/lua/core/softcut.lua:201: in function 'core/softcut.defaults'
	/home/we/dust/code/wrms/lib/softloop.lua:2: in main chunk
	[C]: in function 'dofile'
	/home/we/norns/lua/core/startup.lua:39: in function 'include'
	/home/we/dust/code/wrms/lib/lib_wrms.lua:10: in main chunk
	[C]: in function 'dofile'
	/home/we/norns/lua/core/startup.lua:39: in function 'include'
	/home/we/dust/code/wrms/wrms.lua:9: in main chunk
	[C]: in function 'dofile'
	/home/we/norns/lua/core/script.lua:154: in function </home/we/norns/lua/core/script.lua:154>
	[C]: in function 'xpcall'
	/home/we/norns/lua/core/norns.lua:127: in field 'try'
	/home/we/norns/lua/core/script.lua:154: in function 'core/script.load'
	(...tail calls...)
```