### PR TITLE
fixes to softcut.defaults(), and lots of docstrings

### DIFF
--- a/lua/core/softcut.lua
+++ b/lua/core/softcut.lua
@@ -3,7 +3,11 @@
 -- API for controlling the "softcut" buffer processor
 -- includes low-level setters and mid-level utilities
 --
--- @classmod softcut
+-- IMPORTANT: all indices are 1-based, per lua convention!
+-- this applies to indices for selecting voice, ADC/DAC channel, buffer, &c.
+-- however, _quantities_ (including units of time) can still start at zero.
+--
+-- @module softcut
 -- @alias SC
 
 local SC = {}
@@ -21,81 +25,153 @@ SC.BUFFER_SIZE = 16777216 / 48000
 -------------------------------
 -- @section setters
 
---- set level of each voice
-SC.level = function(voice, value)
-  _norns.level_cut(voice, value)
+--- set output level of each voice
+-- @tparam int voice : voice index
+-- @tparam int amp : linear amplitude
+SC.level = function(voice, amp)
+  _norns.level_cut(voice, amp)
 end
 
---- set pan of each voice
-SC.pan = function(voice, value)
-  _norns.pan_cut(voice, value)
+--- set pan position of each voice. 
+-- -1 == full left, +1 == full right, 0 == centered
+-- @tparam int voice : voice index
+-- @tparam number pos : position in [-1, 1]
+SC.pan = function(voice, pos)
+  _norns.pan_cut(voice, pos)
 end
 
---- set input level to each voice/channel
-SC.level_input_cut = function(ch, voice, value)
-  _norns.level_input_cut(ch, voice, value)
+--- set input level to each voice/channel. 
+-- @tparam int ch : ADC channel index
+-- @tparam int voice : voice index 
+-- @tparam number pos : position in [-1, 1]
+SC.level_input_cut = function(ch, voice, pos)
+  _norns.level_input_cut(ch, voice, pos)
 end
 
---- set mix matrix, voice output to voice input
--- @tparam number src source
--- @tparam number dst destination
--- @tparam number value value
-SC.level_cut_cut = function(src, dst, value)
-  _norns.level_cut_cut(src, dst, value)
+--- set mix matrix, voice output to voice input. 
+-- @tparam number src : source voice index
+-- @tparam number dst : destination voice index
+-- @tparam number amp : linear amplitude
+SC.level_cut_cut = function(src, dst, amp)
+  _norns.level_cut_cut(src, dst, amp) 
 end
 
---- set play status
--- @tparam integer voice : voice number (1-?)
--- @tparam integer state : off/on (0,1)
+--- set play status. 
+-- @tparam int voice : voice index
+-- @tparam int state : off/on (0,1)
 SC.play = function(voice,state) _norns.cut_param("play_flag",voice,state) end
--- set playback rate
-SC.rate = function(voice,value) _norns.cut_param("rate",voice,value) end
---- set loop start
-SC.loop_start = function(voice,value) _norns.cut_param("loop_start",voice,value) end
---- set loop end
-SC.loop_end = function(voice,value) _norns.cut_param("loop_end",voice,value) end
---- set loop mode
--- @tparam integer voice : voice number (1-?)
--- @tparam integer state : off/on (0,1)
+
+--- set playback rate. 
+-- @tparam int voice : voice index
+-- @tparam number rate: speed of read/write head (unitless; 1 == normal)
+SC.rate = function(voice,rate) _norns.cut_param("rate",voice,rate) end
+
+--- set loop start.
+-- @tparam int voice : voice index
+-- @tparam number pos : loop start position in seconds
+SC.loop_start = function(voice,pos) _norns.cut_param("loop_start",voice,pos) end
+
+--- set loop end. 
+-- @tparam int voice : voice index
+-- @tparam number pos : loop end position in seconds
+SC.loop_end = function(voice,pos) _norns.cut_param("loop_end",voice,pos) end
+
+--- set loop mode. 
+-- "0" indicates one-shot mode: voice will play to the loop endpoint, fadeout and stop.
+-- "1" indicates crossfaded looping mode.
+-- @tparam int voice : voice index
+-- @tparam int state : off/on (0,1)
 SC.loop = function(voice,state) _norns.cut_param("loop_flag",voice,state) end
---- set fade time
-SC.fade_time = function(voice,value) _norns.cut_param("fade_time",voice,value) end
---- set record level
-SC.rec_level = function(voice,value) _norns.cut_param("rec_level",voice,value) end
---- set pre level (overdub preserve)
-SC.pre_level = function(voice,value) _norns.cut_param("pre_level",voice,value) end
---- set record status
--- @tparam integer voice : voice number (1-?)
--- @tparam integer state : off/on (0,1)
+
+--- set fade time. 
+-- @tparam int voice : voice index
+-- @tparam number pos : loop start position in seconds
+SC.fade_time = function(voice,pos) _norns.cut_param("fade_time",voice,pos) end
+
+--- set record level.
+-- this sets the realtime-modulated record level,
+-- by which incoming signal is scaled before writing to the buffer
+-- `recpre` slew level applies
+-- @tparam int voice : voice index
+-- @tparam number amp : linear amplitude of new signal
+SC.rec_level = function(voice,amp) _norns.cut_param("rec_level",voice,amp) end
+
+--- set pre level (overdub preserve.)
+-- this sets the realtime-modulated "preserve" level,
+-- by which existing material is scaled on each pass of the write head.
+-- `recpre` slew level applies
+-- @tparam int voice : voice index
+-- @tparam number amp : linear amplitude of preserved signal 
+SC.pre_level = function(voice,amp) _norns.cut_param("pre_level",voice,amp) end
+
+--- set record state. 
+-- @tparam int voice : voice number (1-?)
+-- @tparam int state : off/on (0,1)
 SC.rec = function(voice,state) _norns.cut_param("rec_flag",voice,state) end
 --- set record head offset
 SC.rec_offset = function(voice,value) _norns.cut_param("rec_offset",voice,value) end
 --- set play position
 SC.position = function(voice,value) _norns.cut_param("position",voice,value) end
 
---- specify buffer used by voice
--- @tparam integer i : voice number
--- @tparam integer b : buffer number (1,2)
+--- specify buffer used by voice. 
+-- @tparam int i : voice number
+-- @tparam int b : buffer number (1,2)
 SC.buffer = function(i,b) _norns.cut_param_ii("buffer",i,b) end
---- sync two voices
-SC.voice_sync = function(src, dest, v) _norns.cut_param_iif("voice_sync",src,dest,v) end
 
---- set pre_filter cutoff
-SC.pre_filter_fc = function(voice,value) _norns.cut_param("pre_filter_fc",voice,value) end
---- set pre_filter mod
-SC.pre_filter_fc_mod = function(voice,value) _norns.cut_param("pre_filter_fc_mod",voice,value) end
---- set pre_filter q
-SC.pre_filter_rq = function(voice,value) _norns.cut_param("pre_filter_rq",voice,value) end
---- set pre_filter lp
-SC.pre_filter_lp = function(voice,value) _norns.cut_param("pre_filter_lp",voice,value) end
---- set pre_filter hp
-SC.pre_filter_hp = function(voice,value) _norns.cut_param("pre_filter_hp",voice,value) end
---- set pre_filter bp
-SC.pre_filter_bp = function(voice,value) _norns.cut_param("pre_filter_bp",voice,value) end
---- set pre_filter br
-SC.pre_filter_br = function(voice,value) _norns.cut_param("pre_filter_br",voice,value) end
---- set pre_filter dry
-SC.pre_filter_dry = function(voice,value) _norns.cut_param("pre_filter_dry",voice,value) end
+--- synchronize two voices. 
+--- position of "dst" will be immediately set to that of "source"
+-- @tparam int src : source voice index
+-- @tparam int dst : destination voice index
+-- @tparam number offset : additional offset in seconds
+SC.voice_sync = function(src, dst, offset) _norns.cut_param_iif("voice_sync",src,dest,offset) end
+
+--- set pre_filter cutoff frequency. 
+--- @tparam int voice : voice index
+--- @tparam number fc : cutoff frequency in Hz
+SC.pre_filter_fc = function(voice,fc) _norns.cut_param("pre_filter_fc",voice,fc) end
+
+--- set pre_filter amount of rate modulation. 
+-- this parameter controls the amount by which the current rate affects filter cutoff frequency 
+-- (always in a negative direction, towards zero.) 
+-- with mod == 1, setting rate = 0 will also fully close the filter. 
+-- this can be useful as a crude anti-aliasing method...
+--- @tparam int voice : voice index
+--- @tparam number amount : modulation amount in [0, 1]
+SC.pre_filter_fc_mod = function(voice,aount) _norns.cut_param("pre_filter_fc_mod",voice,value) end
+
+--- set pre_filter reciprocal of Q-factor. 
+-- the reciprocal of the filter's Q-factor is a measure of bandwidth,
+-- that is independent of center frequency.
+-- RQ ~= 0 will result in self-oscillation;
+-- RQ == 4 gives a bandwidth of 2 octaves.
+-- @tparam int voice : voice index
+-- @tparam number : reciprocal of filter Q-factor for voice
+SC.pre_filter_rq = function(voice,rq) _norns.cut_param("pre_filter_rq",voice,rq) end
+
+--- set pre_filter lowpass output level. 
+-- @tparam int voice : voice index
+-- @tparam number amp : linear amplitude 
+SC.pre_filter_lp = function(voice,amp) _norns.cut_param("pre_filter_lp",voice,amp) end
+
+--- set pre-filter highpass output level. 
+-- @tparam int voice : voice index
+-- @tparam number amp : linear amplitude 
+SC.pre_filter_hp = function(voice,amp) _norns.cut_param("pre_filter_hp",voice,amp) end
+
+--- set pre-filter bandpass output level.
+-- @tparam int voice : voice index
+-- @tparam number amp : linear amplitude 
+SC.pre_filter_bp = function(voice,amp) _norns.cut_param("pre_filter_bp",voice,amp) end
+
+--- set pre_filter band-reject output level.
+-- @tparam int voice : voice index
+-- @tparam number amp : linear amplitude 
+SC.pre_filter_br = function(voice,amp) _norns.cut_param("pre_filter_br",voice,amp) end
+
+--- set pre_filter dry output level. 
+-- @tparam int voice : voice index
+-- @tparam number amp : linear amplitude 
+SC.pre_filter_dry = function(voice,amp) _norns.cut_param("pre_filter_dry",voice,amp) end
 
 
 ---------------------
@@ -109,46 +185,97 @@ SC.filter_bp = function(voice,value) SC.pre_filter_bp(voice, value) end
 SC.filter_br = function(voice,value) SC.pre_filter_br(voice, value) end 
 SC.filter_dry = function(voice,value) SC.pre_filter_dry(voice, value) end 
 
---- set post_filter cutoff
+--- set post-filter cutoff
+-- @tparam int voice : voice index
+-- @tparam number value : cutoff frequency in Hz
 SC.post_filter_fc = function(voice,value) _norns.cut_param("post_filter_fc",voice,value) end
---- set post_filter mod
-SC.post_filter_fc_mod = function(voice,value) _norns.cut_param("post_filter_fc_mod",voice,value) end
---- set post_filter q
+
+--- set post-filter reciprocal of Q
+-- the reciprocal of the filter's Q factor is a measure of bandwidth,
+-- that is independent of center frequency. 
+-- RQ ~= 0 will result in self oscillation;
+-- RQ == 4 gives a bandwidth of 2 octaves. 
+-- @tparam int voice : voice index
+-- @tparam number : reciprocal of filter Q-factor for voice
 SC.post_filter_rq = function(voice,value) _norns.cut_param("post_filter_rq",voice,value) end
---- set post_filter lp
-SC.post_filter_lp = function(voice,value) _norns.cut_param("post_filter_lp",voice,value) end
---- set post_filter hp
-SC.post_filter_hp = function(voice,value) _norns.cut_param("post_filter_hp",voice,value) end
---- set post_filter bp
-SC.post_filter_bp = function(voice,value) _norns.cut_param("post_filter_bp",voice,value) end
---- set post_filter br
-SC.post_filter_br = function(voice,value) _norns.cut_param("post_filter_br",voice,value) end
---- set post_filter dry
-SC.post_filter_dry = function(voice,value) _norns.cut_param("post_filter_dry",voice,value) end
 
 
---- set level slew time
-SC.level_slew_time = function(voice,value) _norns.cut_param("level_slew_time",voice,value) end
+--- set post_filter lowpass output level. 
+-- @tparam int voice : voice index
+-- @tparam number amp : linear amplitude 
+SC.post_filter_lp = function(voice,amp) _norns.cut_param("post_filter_lp",voice,amp) end
+
+--- set post-filter highpass output level. 
+-- @tparam int voice : voice index
+-- @tparam number amp : linear amplitude 
+SC.post_filter_hp = function(voice,amp) _norns.cut_param("post_filter_hp",voice,amp) end
+
+--- set post-filter bandpass output level.
+-- @tparam int voice : voice index
+-- @tparam number amp : linear amplitude 
+SC.post_filter_bp = function(voice,amp) _norns.cut_param("post_filter_bp",voice,amp) end
+
+--- set post_filter band-reject output level.
+-- @tparam int voice : voice index
+-- @tparam number amp : linear amplitude 
+SC.post_filter_br = function(voice,amp) _norns.cut_param("post_filter_br",voice,amp) end
+
+--- set post_filter dry output level. 
+-- @tparam int voice : voice index
+-- @tparam number amp : linear amplitude 
+SC.post_filter_dry = function(voice,amp) _norns.cut_param("post_filter_dry",voice,amp) end
+
+--- set level-slew time
+-- this slew time applies to level at all mix points: ADC->voice, voice->voice, &c.
+-- @tparam int voice : voice index
+-- @tparam number time : exponential slew time in seconds (-60db convergence)
+SC.level_slew_time = function(voice,time) _norns.cut_param("level_slew_time",voice,time) end
+
 --- set pan slew time
-SC.pan_slew_time = function(voice,value) _norns.cut_param("pan_slew_time",voice,value) end
---- set recpre slew time
-SC.recpre_slew_time = function(voice,value) _norns.cut_param("recpre_slew_time",voice,value) end
---- set rate slew time
-SC.rate_slew_time = function(voice,value) _norns.cut_param("rate_slew_time",voice,value) end
+-- @tparam int voice : voice index
+-- @tparam number time : exponential slew time in seconds (-60db convergence)
+SC.pan_slew_time = function(voice,time) _norns.cut_param("pan_slew_time",voice,time) end
 
---- set phase poll quantization
-SC.phase_quant = function(voice,value) _norns.cut_param("phase_quant",voice,value) end
---- set phase poll offset
-SC.phase_offset = function(voice,value) _norns.cut_param("phase_offset",voice,value) end
+--- set recpre slew tiem
+-- affects slew time for record and pre levels
+-- @tparam int voice : voice index
+-- @tparam number time : exponential slew time in seconds (-60db convergence)
+SC.recpre_slew_time = function(voice,time) _norns.cut_param("recpre_slew_time",voice,time) end
+
+--- set rate slew time
+-- affects slew time for rate
+-- @tparam int voice : voice index
+-- @tparam number time : exponential slew time in seconds (-60db convergence)
+SC.rate_slew_time = function(voice,time) _norns.cut_param("rate_slew_time",voice,time) end
+
+--- set phase poll quantum
+-- e.g. 0.25 will produce 4 updates per second with rate=1
+-- judicious use of this parameter is preferable to using a very fast poll (for performance,)
+-- or polling at arbitrary rate (for accuracy when rate is slewed.)
+-- @tparam int voice : voice index
+-- @tparam number quantum : phase reporting interval, in seconds
+SC.phase_quant = function(voice,quantum) _norns.cut_param("phase_quant",voice,quantum) end
+
+--- set phase poll offset in frames
+-- @tparam int voice : voice index
+-- @tparam number offset : phase poll offset in seconds
+SC.phase_offset = function(voice,offset) _norns.cut_param("phase_offset",voice,offset) end
+
 --- start phase poll
 SC.poll_start_phase = function() _norns.poll_start_cut_phase() end
+
 --- stop phase poll
 SC.poll_stop_phase = function() _norns.poll_stop_cut_phase() end
 
 --- set voice enable
--- @tparam integer voice : voice number (1-?)
--- @tparam integer state : off/on (0,1)
+-- disabled voices have no effect and consume basically zero CPU
+-- @tparam int voice : voice number (1-?)
+-- @tparam int state : off/on (0,1)
 SC.enable = function(voice, state) _norns.cut_enable(voice, state) end
+
+
+----------------
+--- TODO: complete function doc comments below here!
 
 --- clear all buffers
 SC.buffer_clear = function() _norns.cut_buffer_clear() end
@@ -188,47 +315,63 @@ SC.event_phase = function(f) _norns.softcut_phase = f end
 -------------------------------
 -- @section utilities
 
---- reset softcut params
+--- reset state of softcut process
 function SC.reset()
    _norns.cut_reset()
   SC.event_phase(norns.none)
 end
 
 --- get the default state of the softcut system
---- @treturn table table of parameter states for each voice
+-- this returns a table for each voice,
+-- in which each key corresponds to the name of one of the setter functions defined above.
+-- for parameters with one value per voice, the corresponding entry is also a single value.
+-- for parameters with multiple values (e.g. matrix indices), the entry is a table.
+-- NB: these values are synchronized by hand with those specified in the softcut cpp sources 
+-- @treturn table table of parameter states for each voice
 function SC.defaults()
-  local state = {}
-  for i=1,SC.VOICE_COUNT do
-     state[i] = 0;
-     state[i].enable =0
-     state[i].play =0
+   zeros = {}
+   for i in 1,SC.VOICE_COUNT do zeros[i] = 0 end
+   
+   local state = {}
+   for i=1,SC.VOICE_COUNT do
+     state[i].enable = 0
+     state[i].play = 0
+     state[i].record = 0
+     
      state[i].buffer = (i%2 + 1)
      state[i].level =0
-     state[i].pan =0.5
-     state[i].level_input_cut =i,0
-     state[i].level_input_cut =i,0
-     state[i].level_cut_cut =i,0
-     state[i].level_cut_cut =i,0
-     state[i].rate =1
+     state[i].pan = 0
+     
+     state[i].level_input_cut = {0,0}
+     state[i].level_cut_cut = zeros
+     
+     state[i].rate = 1
      state[i].loop_start = (i-1)*2
      state[i].loop_end = (i-1)*2+1
      state[i].loop = 1
+     
      state[i].fade_time =  0.0005
      state[i].rec_level = 0
      state[i].pre_level = 0
      state[i].rec = 0
      state[i].rec_offset = -0.00015
      state[i].position = 0
-     state[i].pre_filter_dry = 1
-     state[i].pre_filter_lp = 0
+     
+     state[i].pre_filter_fc = 16000
+     state[i].pre_filter_dry = 0
+     state[i].pre_filter_lp = 1
      state[i].pre_filter_hp = 0
      state[i].pre_filter_bp = 0
      state[i].pre_filter_br = 0
-     state[i].post_filter_dry = 1
+     state[i].pre_filter_fc_mod = 1
+
+     state[i].post_filter_fc = 12000
+     state[i].post_filter_dry = 0
      state[i].post_filter_lp = 0
      state[i].post_filter_hp = 0
      state[i].post_filter_bp = 0
      state[i].post_filter_br = 0
+     
      state[i].level_slew_time = 0.001
      state[i].rate_slew_time = 0.001
      state[i].phase_quant = 1
@@ -314,28 +457,5 @@ function SC.params()
 
   return specs
 end
-
---[[ FIXME:
--- control factory
--- @return array of controls, using .specs() and connected to setters
-function SC.controls
-   local ctl = {}
-   local specs = CS.specs()
-   -- @fixme should definitely memoize
-   for voice,spec in ipairs(specs) do
-      local c = {}
-      for k,spec in specs[v] do
-	 c = control.new(k, k, spec, "")
-	 local act = SC[k]
-	 if act == nil then
-	    print("warning: didn't find SoftCut voice method: "..k)
-	 end
-	 -- @fixme? note the base-0 voice indexing
-	 c.action = function(value) act(v-1, value) end
-      end
-      v = v + 1
-   end
-end
---]]
 
 return SC


### PR DESCRIPTION
this PR is two things.

first, makes `softcut.defaults()` functional, and synchronized with actual default values defined in the backend `reset` functions.

second, add lots of ldoc stuff to the `softcut`. (mostly function and parameter descriptions, but also little things like replacing `@classmod` with `@module` to remove the erroneous colons in ldoc output.)

this is WIP: i can't actually test today, and i haven't added docstrings to every function.