### PR TITLE
likely fix for SEGV on USB device removal

### DIFF
--- a/matron/src/device/device_list.c
+++ b/matron/src/device/device_list.c
@@ -122,12 +122,7 @@ void dev_list_add(device_t type, const char *path, const char *name) {
     }
 }
 
-struct dev_node *dev_remove_node(
-    struct dev_node *dn, 
-    union event_data *event_remove,
-    const char *node
-) {
-    struct dev_node *next_node; 
+static void dev_list_remove_node(struct dev_node *dn, union event_data *event_remove) {
     event_post(event_remove);
 
     if(dq.head == dn) { dq.head = dn->next; }
@@ -136,10 +131,7 @@ struct dev_node *dev_remove_node(
     dq.size--;
 
     dev_delete(dn->d);
-    next_node = dev_lookup_path(node, dn);
     free(dn);
-
-    return next_node;
 }
 
 void dev_list_remove(device_t type, const char *node) {
@@ -152,7 +144,8 @@ void dev_list_remove(device_t type, const char *node) {
         while (dn != NULL) {
             ev = event_data_new(EVENT_MIDI_REMOVE);
             ev->midi_remove.id = dn->d->base.id;
-            dn = dev_remove_node(dn, ev, node);
+            dev_list_remove_node(dn, ev);
+            dn = dev_lookup_path(node, NULL);
         }
         return;
     case DEV_TYPE_MONOME:
@@ -171,5 +164,5 @@ void dev_list_remove(device_t type, const char *node) {
         fprintf(stderr, "dev_list_remove(): error posting event (unknown type)\n");
         return;
     }
-    dev_remove_node(dn, ev, node);
+    dev_list_remove_node(dn, ev);
 }

--- a/matron/src/device/device_list.c
+++ b/matron/src/device/device_list.c
@@ -90,7 +90,7 @@ void dev_list_add(device_t type, const char *path, const char *name) {
 
     switch (type) {
     case DEV_TYPE_MIDI:
-        midi_port_count = dev_port_count(path);
+        midi_port_count = dev_midi_port_count(path);
         for (unsigned int pidx = 0; pidx < midi_port_count; pidx++) {
             d = dev_new(type, path, name, midi_port_count > 1, pidx);
             ev = post_add_event(d, EVENT_MIDI_ADD);

--- a/matron/src/device/device_midi.c
+++ b/matron/src/device/device_midi.c
@@ -8,7 +8,7 @@
 #include "device_midi.h"
 #include "../clocks/clock_midi.h"
 
-unsigned int dev_port_count(const char *path) {
+unsigned int dev_midi_port_count(const char *path) {
     int card;
     int alsa_dev;
 

--- a/matron/src/device/device_midi.h
+++ b/matron/src/device/device_midi.h
@@ -10,7 +10,7 @@ struct dev_midi {
     snd_rawmidi_t *handle_out;
 };
 
-extern unsigned int dev_port_count(const char *path);
+extern unsigned int dev_midi_port_count(const char *path);
 extern int dev_midi_init(void *self, unsigned int port_index, bool multiport_device);
 extern void dev_midi_deinit(void *self);
 extern void* dev_midi_start(void *self);


### PR DESCRIPTION
i spent a bit of time trying to get to the bottom of #920 - in particular looking at the changes which were made to the device management for handle multiple midi endpoints.

i believe the problematic change was the introduction of `dev_remove_node`. the `dev_remove_node` function combined existing deletion event posting, `dev_delete`, and device list node removal _with a call to `dev_lookup_path` starting from the device list node being removed/deleted_. the `dev_lookup_path` function walks the device list looking for the first node which matches the given path. in the case of `dev_remove_node` that lookup was started from the device node which was previously passed to `dev_delete`. the `dev_delete` function does several things but in particular it frees memory allocated for the device "path" string pointed to by the node. the net effect is a use after `free()` for one of the strings being fed to `strcmp(...)` and a potential source of crashing.

this change:
- factors out the call from `dev_lookup_path` from `dev_remove_node`
- renames `dev_remove_node` to `dev_list_remove_node` for clarity
- only performs exhaustive searches for multiple device nodes in the case of midi

open questions
- in the case of *midi* devices the repeated searching for matching devices always starts from the head node in the list which means that removal has O(num_endpoints * total_num_devices) complexity (i.e. exponential). in practice this didn't seem to be noticeable when hot pulling 1x grid, 2x single endpoint midi, and 1x four endpoint midi devices...
- the complexity could be reduced to O(num_endpoints) if `insque` and `remque` guaranteed that nodes wouldn't be moved in memory when the list was being modified. i think this is the case but the man page didn't make any statements regarding pointer stability. 


