### PR TITLE
extract reset

### DIFF
--- a/lua/core/menu/reset.lua
+++ b/lua/core/menu/reset.lua
@@ -13,9 +13,7 @@ elseif n==3 and z==1 then
     norns.state.clean_shutdown = true
     norns.state.save()
     if pcall(cleanup) == false then print("cleanup failed") end
-    os.execute("sudo systemctl restart norns-jack.service")
-    os.execute("sudo systemctl restart norns-sclang.service")
-    os.execute("sudo systemctl restart norns-matron.service")
+    _norns.reset()
   end
 end
 

--- a/lua/core/menu/update.lua
+++ b/lua/core/menu/update.lua
@@ -104,9 +104,7 @@ m.key = function(n,z)
       m.stage="update"
       _menu.redraw()
     elseif n==3 and z==1 then
-      os.execute("sudo systemctl restart norns-jack.service")
-      os.execute("sudo systemctl restart norns-sclang.service")
-      os.execute("sudo systemctl restart norns-matron.service")
+      _norns.reset()
     end
   elseif m.stage=="done" and z==1 then
     print("shutting down.")

--- a/lua/core/norns.lua
+++ b/lua/core/norns.lua
@@ -183,6 +183,12 @@ _norns.system_cmd_capture = function(cap)
   end
 end
 
+-- audio reset
+_norns.reset = function()
+  os.execute("sudo systemctl restart norns-jack.service")
+  os.execute("sudo systemctl restart norns-sclang.service")
+  os.execute("sudo systemctl restart norns-matron.service")
+end
 
 -- startup function will be run after I/O subsystems are initialized,
 -- but before I/O event loop starts ticking (see readme-script.md)


### PR DESCRIPTION
extract common `reset` logic.

secondary motive: make it easier to reset audio from the repl; though maybe added `;reset` sugar would be even better still?

/cc  @tehn 

