### PR TITLE
only handle one command of each type per audio block

### DIFF
--- a/crone/src/Commands.cpp
+++ b/crone/src/Commands.cpp
@@ -38,14 +38,22 @@ void Commands::post(Commands::Id id, int i, int j, float f) {
 
 
 void Commands::handlePending(MixerClient *client) {
-    CommandPacket p;
+    CommandPacket p{};
+    memset(wasHandled, 0, NUM_COMMANDS * sizeof(bool));
     while (q.pop(p)) {
-        client->handleCommand(&p);
+        if (wasHandled[p.id]) {
+            // we don't want to handle the same type of command more than once per block.
+            // so if we already did one of these, push it back on the queue for next block.
+            q.push(p);
+        } else {
+            wasHandled[p.id] = true;
+            client->handleCommand(&p);
+        }
     }
 }
 
 void Commands::handlePending(SoftcutClient *client) {
-    CommandPacket p;
+    CommandPacket p{};
     while (q.pop(p)) {
         client->handleCommand(&p);
     }

--- a/crone/src/Commands.cpp
+++ b/crone/src/Commands.cpp
@@ -37,24 +37,50 @@ void Commands::post(Commands::Id id, int i, int j, float f) {
 }
 
 
+/// FIXME: D.R.Y.
 void Commands::handlePending(MixerClient *client) {
+    if (!q.empty()) {
+        std::cerr << "handling non-empty command queue (mixerclient)" << std::endl;
+    }
     CommandPacket p{};
     memset(wasHandled, 0, NUM_COMMANDS * sizeof(bool));
+    qtmp.reset();
     while (q.pop(p)) {
         if (wasHandled[p.id]) {
             // we don't want to handle the same type of command more than once per block.
             // so if we already did one of these, push it back on the queue for next block.
-            q.push(p);
+            qtmp.push(p);
         } else {
             wasHandled[p.id] = true;
             client->handleCommand(&p);
         }
     }
+    // transfer everything we saved back from the temp Q back to the main q.
+    while (qtmp.pop(p)) {
+        q.push(p);
+    }
 }
 
+/// FIXME: D.R.Y.
 void Commands::handlePending(SoftcutClient *client) {
+    if (!q.empty()) {
+        std::cerr << "handling non-empty command queue (softcutclient)" << std::endl;
+    }
     CommandPacket p{};
+    memset(wasHandled, 0, NUM_COMMANDS * sizeof(bool));
+    qtmp.reset();
     while (q.pop(p)) {
-        client->handleCommand(&p);
+        if (wasHandled[p.id]) {
+            // we don't want to handle the same type of command more than once per block.
+            // so if we already did one of these, push it back on the queue for next block.
+            qtmp.push(p);
+        } else {
+            wasHandled[p.id] = true;
+            client->handleCommand(&p);
+        }
+    }
+    // transfer everything we saved back from the temp Q back to the main q.
+    while (qtmp.pop(p)) {
+        q.push(p);
     }
 }

--- a/crone/src/Commands.h
+++ b/crone/src/Commands.h
@@ -123,6 +123,9 @@ namespace crone {
     private:
         boost::lockfree::spsc_queue <CommandPacket,
                 boost::lockfree::capacity<200> > q;
+
+        // array of flags indicating which commands were handled in current block
+        bool wasHandled[Commands::NUM_COMMANDS];
     };
 
 }

--- a/crone/src/Commands.h
+++ b/crone/src/Commands.h
@@ -121,8 +121,14 @@ namespace crone {
         static Commands softcutCommands;
 
     private:
+        static constexpr size_t MAX_COMMANDS = 200;
         boost::lockfree::spsc_queue <CommandPacket,
-                boost::lockfree::capacity<200> > q;
+                boost::lockfree::capacity<MAX_COMMANDS> > q;
+
+        boost::lockfree::spsc_queue <CommandPacket,
+                boost::lockfree::capacity<MAX_COMMANDS> > qtmp;
+
+
 
         // array of flags indicating which commands were handled in current block
         bool wasHandled[Commands::NUM_COMMANDS];

--- a/crone/src/OscInterface.cpp
+++ b/crone/src/OscInterface.cpp
@@ -102,7 +102,7 @@ void OscInterface::addServerMethod(const char *path, const char *format, Handler
                                     (void) types;
                                     (void) msg;
                                     auto pm = static_cast<OscMethod *>(data);
-                                    //std::cerr << "osc rx: " << path << std::endl;
+                                    std::cerr << "osc rx: " << path << std::endl;
                                     pm->handler(argv, argc);
                                     return 0;
                                 }, &(methods[numMethods]));

--- a/crone/src/SoftcutClient.cpp
+++ b/crone/src/SoftcutClient.cpp
@@ -21,7 +21,6 @@ crone::SoftcutClient::SoftcutClient() : Client<2, 2>("softcut") {
     }
     bufIdx[0] = BufDiskWorker::registerBuffer(buf[0], BufFrames);
     bufIdx[1] = BufDiskWorker::registerBuffer(buf[1], BufFrames);
-
 }
 
 void crone::SoftcutClient::process(jack_nframes_t numFrames) {

--- a/crone/src/SoftcutClient.cpp
+++ b/crone/src/SoftcutClient.cpp
@@ -8,7 +8,6 @@
 #include "Commands.h"
 #include "SoftcutClient.h"
 
-
 // clamp unsigned int to upper bound, inclusive
 static inline void clamp(size_t &x, const size_t a) {
     if (x > a) { x = a; }
@@ -71,124 +70,125 @@ void crone::SoftcutClient::mixOutput(size_t numFrames) {
 }
 
 void crone::SoftcutClient::handleCommand(Commands::CommandPacket *p) {
+    std::cerr << "softcutclient handle command " << p->id << std::endl;
     switch (p->id) {
         //-- softcut routing
-        case Commands::Id::SET_ENABLED_CUT:
-            enabled[p->idx_0] = p->value > 0.f;
-            break;
-        case Commands::Id::SET_LEVEL_CUT:
-            outLevel[p->idx_0].setTarget(p->value);
-            break;;
-        case Commands::Id::SET_PAN_CUT:
-            outPan[p->idx_0].setTarget((p->value/2)+0.5); // map -1,1 to 0,1
-            break;
-        case Commands::Id::SET_LEVEL_IN_CUT:
-            inLevel[p->idx_0][p->idx_1].setTarget(p->value);
-            break;
-        case Commands::Id::SET_LEVEL_CUT_CUT:
-            fbLevel[p->idx_0][p->idx_1].setTarget(p->value);
-            break;
-            //-- softcut commands
-        case Commands::Id::SET_CUT_RATE:
-            cut.setRate(p->idx_0, p->value);
-            break;
-        case Commands::Id::SET_CUT_LOOP_START:
-            cut.setLoopStart(p->idx_0, p->value);
-            break;
-        case Commands::Id::SET_CUT_LOOP_END:
-            cut.setLoopEnd(p->idx_0, p->value);
-            break;
-        case Commands::Id::SET_CUT_LOOP_FLAG:
-            cut.setLoopFlag(p->idx_0, p->value > 0.f);
-            break;
-        case Commands::Id::SET_CUT_FADE_TIME:
-            cut.setFadeTime(p->idx_0, p->value);
-            break;
-        case Commands::Id::SET_CUT_REC_LEVEL:
-            cut.setRecLevel(p->idx_0, p->value);
-            break;
-        case Commands::Id::SET_CUT_PRE_LEVEL:
-            cut.setPreLevel(p->idx_0, p->value);
-            break;
-        case Commands::Id::SET_CUT_REC_FLAG:
-            cut.setRecFlag(p->idx_0, p->value > 0.f);
-            break;
-        case Commands::Id::SET_CUT_PLAY_FLAG:
-            cut.setPlayFlag(p->idx_0, p->value > 0.f);
-            break;
-        case Commands::Id::SET_CUT_REC_OFFSET:
-            cut.setRecOffset(p->idx_0, p->value);
-            break;
-        case Commands::Id::SET_CUT_POSITION:
-            cut.cutToPos(p->idx_0, p->value);
-            break;
-            // input filter
-        case Commands::Id::SET_CUT_PRE_FILTER_FC:
-            cut.setPreFilterFc(p->idx_0, p->value);
-            break;
-        case Commands::Id::SET_CUT_PRE_FILTER_FC_MOD:
-            cut.setPreFilterFcMod(p->idx_0, p->value);
-            break;
-        case Commands::Id::SET_CUT_PRE_FILTER_RQ:
-            cut.setPreFilterRq(p->idx_0, p->value);
-            break;
-        case Commands::Id::SET_CUT_PRE_FILTER_LP:
-            cut.setPreFilterLp(p->idx_0, p->value);
-            break;
-        case Commands::Id::SET_CUT_PRE_FILTER_HP:
-            cut.setPreFilterHp(p->idx_0, p->value);
-            break;
-        case Commands::Id::SET_CUT_PRE_FILTER_BP:
-            cut.setPreFilterBp(p->idx_0, p->value);
-            break;
-        case Commands::Id::SET_CUT_PRE_FILTER_BR:
-            cut.setPreFilterBr(p->idx_0, p->value);
-            break;
-        case Commands::Id::SET_CUT_PRE_FILTER_DRY:
-            cut.setPreFilterDry(p->idx_0, p->value);
-            break;
-            // output filter
-        case Commands::Id::SET_CUT_POST_FILTER_FC:
-            cut.setPostFilterFc(p->idx_0, p->value);
-            break;
-        case Commands::Id::SET_CUT_POST_FILTER_RQ:
-            cut.setPostFilterRq(p->idx_0, p->value);
-            break;
-        case Commands::Id::SET_CUT_POST_FILTER_LP:
-            cut.setPostFilterLp(p->idx_0, p->value);
-            break;
-        case Commands::Id::SET_CUT_POST_FILTER_HP:
-            cut.setPostFilterHp(p->idx_0, p->value);
-            break;
-        case Commands::Id::SET_CUT_POST_FILTER_BP:
-            cut.setPostFilterBp(p->idx_0, p->value);
-            break;
-        case Commands::Id::SET_CUT_POST_FILTER_BR:
-            cut.setPostFilterBr(p->idx_0, p->value);
-            break;
-        case Commands::Id::SET_CUT_POST_FILTER_DRY:
-            cut.setPostFilterDry(p->idx_0, p->value);
-            break;
+    case Commands::Id::SET_ENABLED_CUT:
+	enabled[p->idx_0] = p->value > 0.f;
+	break;
+    case Commands::Id::SET_LEVEL_CUT:
+	outLevel[p->idx_0].setTarget(p->value);
+	break;;
+    case Commands::Id::SET_PAN_CUT:
+	outPan[p->idx_0].setTarget((p->value/2)+0.5); // map -1,1 to 0,1
+	break;
+    case Commands::Id::SET_LEVEL_IN_CUT:
+	inLevel[p->idx_0][p->idx_1].setTarget(p->value);
+	break;
+    case Commands::Id::SET_LEVEL_CUT_CUT:
+	fbLevel[p->idx_0][p->idx_1].setTarget(p->value);
+	break;
+	//-- softcut commands
+    case Commands::Id::SET_CUT_RATE:
+	cut.setRate(p->idx_0, p->value);
+	break;
+    case Commands::Id::SET_CUT_LOOP_START:
+	cut.setLoopStart(p->idx_0, p->value);
+	break;
+    case Commands::Id::SET_CUT_LOOP_END:
+	cut.setLoopEnd(p->idx_0, p->value);
+	break;
+    case Commands::Id::SET_CUT_LOOP_FLAG:
+	cut.setLoopFlag(p->idx_0, p->value > 0.f);
+	break;
+    case Commands::Id::SET_CUT_FADE_TIME:
+	cut.setFadeTime(p->idx_0, p->value);
+	break;
+    case Commands::Id::SET_CUT_REC_LEVEL:
+	cut.setRecLevel(p->idx_0, p->value);
+	break;
+    case Commands::Id::SET_CUT_PRE_LEVEL:
+	cut.setPreLevel(p->idx_0, p->value);
+	break;
+    case Commands::Id::SET_CUT_REC_FLAG:
+	cut.setRecFlag(p->idx_0, p->value > 0.f);
+	break;
+    case Commands::Id::SET_CUT_PLAY_FLAG:
+	cut.setPlayFlag(p->idx_0, p->value > 0.f);
+	break;
+    case Commands::Id::SET_CUT_REC_OFFSET:
+	cut.setRecOffset(p->idx_0, p->value);
+	break;
+    case Commands::Id::SET_CUT_POSITION:
+	cut.cutToPos(p->idx_0, p->value);
+	break;
+	// input filter
+    case Commands::Id::SET_CUT_PRE_FILTER_FC:
+	cut.setPreFilterFc(p->idx_0, p->value);
+	break;
+    case Commands::Id::SET_CUT_PRE_FILTER_FC_MOD:
+	cut.setPreFilterFcMod(p->idx_0, p->value);
+	break;
+    case Commands::Id::SET_CUT_PRE_FILTER_RQ:
+	cut.setPreFilterRq(p->idx_0, p->value);
+	break;
+    case Commands::Id::SET_CUT_PRE_FILTER_LP:
+	cut.setPreFilterLp(p->idx_0, p->value);
+	break;
+    case Commands::Id::SET_CUT_PRE_FILTER_HP:
+	cut.setPreFilterHp(p->idx_0, p->value);
+	break;
+    case Commands::Id::SET_CUT_PRE_FILTER_BP:
+	cut.setPreFilterBp(p->idx_0, p->value);
+	break;
+    case Commands::Id::SET_CUT_PRE_FILTER_BR:
+	cut.setPreFilterBr(p->idx_0, p->value);
+	break;
+    case Commands::Id::SET_CUT_PRE_FILTER_DRY:
+	cut.setPreFilterDry(p->idx_0, p->value);
+	break;
+	// output filter
+    case Commands::Id::SET_CUT_POST_FILTER_FC:
+	cut.setPostFilterFc(p->idx_0, p->value);
+	break;
+    case Commands::Id::SET_CUT_POST_FILTER_RQ:
+	cut.setPostFilterRq(p->idx_0, p->value);
+	break;
+    case Commands::Id::SET_CUT_POST_FILTER_LP:
+	cut.setPostFilterLp(p->idx_0, p->value);
+	break;
+    case Commands::Id::SET_CUT_POST_FILTER_HP:
+	cut.setPostFilterHp(p->idx_0, p->value);
+	break;
+    case Commands::Id::SET_CUT_POST_FILTER_BP:
+	cut.setPostFilterBp(p->idx_0, p->value);
+	break;
+    case Commands::Id::SET_CUT_POST_FILTER_BR:
+	cut.setPostFilterBr(p->idx_0, p->value);
+	break;
+    case Commands::Id::SET_CUT_POST_FILTER_DRY:
+	cut.setPostFilterDry(p->idx_0, p->value);
+	break;
 
-        case Commands::Id::SET_CUT_LEVEL_SLEW_TIME:
-            outLevel[p->idx_0].setTime(p->value);
-            break;
-        case Commands::Id::SET_CUT_PAN_SLEW_TIME:
-            outPan[p->idx_0].setTime(p->value);
-            break;
-        case Commands::Id::SET_CUT_RECPRE_SLEW_TIME:
-            cut.setRecPreSlewTime(p->idx_0, p->value);
-            break;
-        case Commands::Id::SET_CUT_RATE_SLEW_TIME:
-            cut.setRateSlewTime(p->idx_0, p->value);
-            break;
-        case Commands::Id::SET_CUT_VOICE_SYNC:
-            cut.syncVoice(p->idx_0, p->idx_1, p->value);
-            break;
-        case Commands::Id::SET_CUT_BUFFER:
-            cut.setVoiceBuffer(p->idx_0, buf[p->idx_1], BufFrames);
-            break;
-        default:;;
+    case Commands::Id::SET_CUT_LEVEL_SLEW_TIME:
+	outLevel[p->idx_0].setTime(p->value);
+	break;
+    case Commands::Id::SET_CUT_PAN_SLEW_TIME:
+	outPan[p->idx_0].setTime(p->value);
+	break;
+    case Commands::Id::SET_CUT_RECPRE_SLEW_TIME:
+	cut.setRecPreSlewTime(p->idx_0, p->value);
+	break;
+    case Commands::Id::SET_CUT_RATE_SLEW_TIME:
+	cut.setRateSlewTime(p->idx_0, p->value);
+	break;
+    case Commands::Id::SET_CUT_VOICE_SYNC:
+	cut.syncVoice(p->idx_0, p->idx_1, p->value);
+	break;
+    case Commands::Id::SET_CUT_BUFFER:
+	cut.setVoiceBuffer(p->idx_0, buf[p->idx_1], BufFrames);
+	break;
+    default:;;
     }
 }
 


### PR DESCRIPTION
one possible approach to addressing issue #1003, for your consideration.

only one command of each type is processed from the command queue for each audio block.

if a command's type has been seen already, it is pushed back on the queue to be processed on the next block. processing order should be unchanged.

possible downside is if you're sending really large numbers of duplicate commands, they will end up spaced about 3ms apart in time (or whatever.) this might have weird effects for knob sweeps.

maybe more specific logic is needed, just for commands that have "side effects" for other params, requiring DSP time to execute. (e.g. slew time,) and those that are simple value setters should in fact keep the overwriting behavior.