### PR TITLE
rename function

### DIFF
--- a/lua/core/screen.lua
+++ b/lua/core/screen.lua
@@ -165,7 +165,7 @@ Screen.text_center = function(str) _norns.screen_text_center(str) end
 --- calculate width of text.
 -- uses currently selected font.
 -- @tparam string str : text to calculate width of
-Screen.extents = function(str) return _norns.screen_extents(str) end
+Screen.text_extents = function(str) return _norns.screen_extents(str) end
 
 --- select font face.
 -- @param index font face (see list)


### PR DESCRIPTION
https://github.com/monome/norns/pull/1005#issuecomment-583657182

let's call it `screen.text_extents` instead.

