### PR TITLE
fix skipped remainder frames in read-buffer commands

### DIFF
--- a/crone/src/BufDiskWorker.cpp
+++ b/crone/src/BufDiskWorker.cpp
@@ -194,7 +194,7 @@ noexcept {
         frSrc += ioBufFrames;
     }
     for (size_t i = 0; i < rem; ++i) {
-        int res = file.seek(frSrc, SF_SEEK_CUR);
+        int res = file.seek(frSrc, SF_SEEK_SET);
 
         if (res == -1) {
             std::cerr << "error seeking to frame: " << frSrc << "; aborting read" << std::endl;
@@ -262,8 +262,7 @@ noexcept {
         frSrc += ioBufFrames;
     }
     for (size_t i = 0; i < rem; ++i) {
-        int res = file.seek(frSrc, SF_SEEK_CUR);
-
+        int res = file.seek(frSrc, SF_SEEK_SET);
         if (res == -1) {
             std::cerr << "error seeking to frame: " << frSrc << "; aborting read" << std::endl;
             goto cleanup;


### PR DESCRIPTION
this typo made it so that remainder frames (up to the final 1024) were being skipped with an error when executing read-buffer commands.