### PR TITLE
more complete reset

### DIFF
--- a/lua/core/menu/devices.lua
+++ b/lua/core/menu/devices.lua
@@ -30,7 +30,6 @@ end
 m.key = function(n,z)
   if m.mode == "type" then
     if n==2 and z==1 then
-      norns.state.save()
       _menu.set_page("SYSTEM")
     elseif n==3 and z==1 then
       m.section = m.list[m.pos]

--- a/lua/core/menu/reset.lua
+++ b/lua/core/menu/reset.lua
@@ -5,14 +5,11 @@ local m = {
 m.key = function(n,z)
   if n==2 and z==1 then
     _menu.set_page("SYSTEM")
-elseif n==3 and z==1 then
+  elseif n==3 and z==1 then
     m.confirmed = true
     _menu.redraw()
-    -- TODO
-    --if m.tape.rec.sel == TAPE_REC_STOP then audio.tape_record_stop() end
-    norns.state.clean_shutdown = true
-    norns.state.save()
-    if pcall(cleanup) == false then print("cleanup failed") end
+    os.execute("rm ~/dust/data/system.pset")
+    os.execute("rm ~/dust/data/system.state")
     _norns.reset()
   end
 end

--- a/lua/core/menu/system.lua
+++ b/lua/core/menu/system.lua
@@ -6,7 +6,6 @@ local m = {
 
 m.key = function(n,z)
   if n==2 and z==1 then
-    norns.state.save()
     _menu.set_page("HOME")
   elseif n==3 and z==1 then
     _menu.set_page(m.pages[m.pos])


### PR DESCRIPTION
- SYSTEM > RESET now does a dirty shutdown (no script run on startup) and erases pset/state data (to assist users getting into a sane state re: levels and vports)
- remove unneeded state saves