### PR TITLE
grid vports not removing rows/cols on update_devices

### DIFF
--- a/lua/core/grid.lua
+++ b/lua/core/grid.lua
@@ -145,6 +145,8 @@ function Grid.update_devices()
   -- connect available devices to vports
   for i=1,4 do
     Grid.vports[i].device = nil
+    Grid.vports[i].rows = 0
+    Grid.vports[i].cols = 0       
 
     for _,device in pairs(Grid.devices) do
       if device.name == Grid.vports[i].name then


### PR DESCRIPTION
Found a situation where grid vports was reporting rows/cols values when that vport was set to `none`.

Test situation:
- with all grid vports set to none, attach grid.
- remove grid and set vport 1 back to none
- `tab.print(grid.vports[1])` then returns the following:

```
cols	16
name	none
all	function: 0x1f79248
led	function: 0x1f6bd98
rows	8
refresh	function: 0x1fa7e60
intensity	function: 0x1fa8548
rotation	function: 0x1fa8590
```
Thus `name` is set to none, but `rows` and `cols` are not reset to zero

Can also be tested with my [Grid Test script](https://llllllll.co/t/grid-test/29346) in the lines Library when manually changing grid port positions.

Proposed fix: reset rows/cols to zero in Grid.update_devices()