### PR TITLE
keystroke activated watchdog

### DIFF
--- a/lua/core/norns.lua
+++ b/lua/core/norns.lua
@@ -185,8 +185,8 @@ end
 
 -- audio reset
 _norns.reset = function()
-  os.execute("sudo systemctl restart norns-jack.service")
   os.execute("sudo systemctl restart norns-sclang.service")
+  os.execute("sudo systemctl restart norns-crone.service")
   os.execute("sudo systemctl restart norns-matron.service")
 end
 

--- a/matron/src/hardware/gpio.c
+++ b/matron/src/hardware/gpio.c
@@ -16,6 +16,7 @@
 #include <time.h>
 
 #include "events.h"
+#include "watch.h"
 
 
 int key_fd;
@@ -139,6 +140,8 @@ void *key_check(void *x) {
                 ev->key.n = event[i].code;
                 ev->key.val = event[i].value;
                 event_post(ev);
+
+                watch_key(event[i].code,event[i].value);
             }
         }
     }

--- a/matron/src/main.c
+++ b/matron/src/main.c
@@ -22,6 +22,7 @@
 #include "metro.h"
 #include "screen.h"
 #include "stat.h"
+#include "watch.h"
 #include "clock.h"
 #include "clocks/clock_internal.h"
 #include "clocks/clock_midi.h"
@@ -41,6 +42,7 @@ void cleanup(void) {
     screen_deinit();
     battery_deinit();
     stat_deinit();
+    watch_deinit();
 
     fprintf(stderr, "matron shutdown complete\n");
     exit(0);
@@ -69,6 +71,7 @@ int main(int argc, char **argv) {
     clock_init();
     clock_internal_start();
     clock_midi_init();
+    watch_init();
 
     o_init(); // oracle (audio)
 

--- a/matron/src/watch.c
+++ b/matron/src/watch.c
@@ -43,7 +43,9 @@ void *watch_time(void *x) {
     if(stage==3) count++;
     if(count==10) {
       fprintf(stderr, "RESTARTING...\n");
-      system("nohup systemctl restart norns-* > /dev/null");
+      system("nohup systemctl restart norns-sclang > /dev/null");
+      system("nohup systemctl restart norns-crone > /dev/null");
+      system("nohup systemctl restart norns-matron > /dev/null");
     }
     sleep(WATCH_TIME);
   }

--- a/matron/src/watch.c
+++ b/matron/src/watch.c
@@ -1,0 +1,57 @@
+/*
+ * watch.c
+ *
+ * tracks key state, resets after timer
+ */
+
+#include <stdio.h>
+#include <stdint.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <string.h>
+#include <errno.h>
+#include <stdlib.h>
+#include <pthread.h>
+
+#include "events.h"
+
+#define WATCH_TIME 1
+
+static int count = 0;
+static int stage = 0;
+
+static pthread_t p;
+
+void *watch_time(void *);
+
+// extern def
+
+void watch_init() {
+  if (pthread_create(&p, NULL, watch_time, 0) ) {
+    fprintf(stderr, "WATCH: Error creating thread\n");
+  }
+}
+
+void watch_deinit() {
+    pthread_cancel(p);
+}
+
+void *watch_time(void *x) {
+  (void)x;
+
+  while(1) {
+    if(stage==3) count++;
+    if(count==10) {
+      fprintf(stderr, "RESTARTING...\n");
+      system("systemctl restart norns-*");
+    }
+    sleep(WATCH_TIME);
+  }
+}
+
+void watch_key(int n, int z) {
+  if(z==0) { stage = 0; }
+  else if(stage==0 && n==3) { stage = 1; }
+  else if(stage==1 && n==2) { stage = 2; }
+  else if(stage==2 && n==1) { stage = 3; }
+}

--- a/matron/src/watch.c
+++ b/matron/src/watch.c
@@ -43,7 +43,7 @@ void *watch_time(void *x) {
     if(stage==3) count++;
     if(count==10) {
       fprintf(stderr, "RESTARTING...\n");
-      system("systemctl restart norns-*");
+      system("nohup systemctl restart norns-* > /dev/null");
     }
     sleep(WATCH_TIME);
   }

--- a/matron/src/watch.h
+++ b/matron/src/watch.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#include <stdint.h>
+
+extern void watch_init(void);
+extern void watch_deinit(void);
+extern void watch_key(int n, int z);

--- a/matron/wscript
+++ b/matron/wscript
@@ -23,6 +23,7 @@ def build(bld):
         'src/main.c',
         'src/metro.c',
         'src/oracle.c',
+        'src/watch.c',
         'src/weaver.c',
         'src/snd_file.c',
         'src/system_cmd.c',


### PR DESCRIPTION
further fixes #1014 

in sequence, hold K3, K2, K1. if 10s elapses, services are restart.

however, weird thing i'm seeing:

despite `systemctl restart norns-*` it seems like only matron is being restarted? ie, i don't get the startup animation and things start almost immediately. running the same command on the command line does what we want?