### PR TITLE
pset save flag per param

### DIFF
--- a/lua/core/audio.lua
+++ b/lua/core/audio.lua
@@ -261,22 +261,28 @@ function Audio.add_params()
   params:add_control("output_level", "output", cs_MAIN_LEVEL)
   params:set_action("output_level",
     function(x) audio.level_dac(util.dbamp(x)) end)
+  params:set_save("output_level", false)
   params:add_control("input_level", "input", cs_MAIN_LEVEL)
   params:set_action("input_level",
     function(x) audio.level_adc(util.dbamp(x)) end)
+  params:set_save("input_level", false)
   local cs_MUTE_LEVEL = cs.new(-math.huge,0,'db',0,-math.huge,"dB")
   params:add_control("monitor_level", "monitor", cs_MUTE_LEVEL)
   params:set_action("monitor_level",
     function(x) audio.level_monitor(util.dbamp(x)) end)
+  params:set_save("monitor_level", false)
   params:add_control("engine_level", "engine", cs_MAIN_LEVEL)
   params:set_action("engine_level",
     function(x) audio.level_eng(util.dbamp(x)) end)
+  params:set_save("engine_level", false)
   params:add_control("softcut_level", "softcut", cs_MAIN_LEVEL)
   params:set_action("softcut_level",
     function(x) audio.level_cut(util.dbamp(x)) end)
+  params:set_save("softcut_level", false)
   params:add_control("tape_level", "tape", cs_MUTE_LEVEL)
   params:set_action("tape_level",
     function(x) audio.level_tape(util.dbamp(x)) end)
+  params:set_save("tape_level", false)
   params:add_separator()
   params:add_option("monitor_mode", "monitor mode", {"STEREO", "MONO"})
   params:set_action("monitor_mode",
@@ -284,9 +290,11 @@ function Audio.add_params()
       if x == 1 then audio.monitor_stereo()
       else audio.monitor_mono() end
     end)
+  params:set_save("monitor_mode", false)
   params:add_number("headphone_gain", "headphone gain", 0, 63, 40)
   params:set_action("headphone_gain",
     function(x) audio.headphone_gain(x) end)
+  params:set_save("headphone_gain", false)
   
   params:add_group("REVERB",11)
   params:add_option("reverb", "reverb", {"OFF", "ON"}, 2)

--- a/lua/core/paramset.lua
+++ b/lua/core/paramset.lua
@@ -103,6 +103,8 @@ function ParamSet:add(args)
     end
   end
 
+  param.save = true
+
   table.insert(self.params, param)
   self.count = self.count + 1
   self.group = self.group - 1
@@ -251,6 +253,14 @@ function ParamSet:set_action(index, func)
   param.action = func
 end
 
+--- set save state.
+-- @param index
+-- @tparam function func set the action for this index
+function ParamSet:set_save(index, state)
+  local param = self:lookup_param(index)
+  param.save = state
+end
+
 --- get type.
 -- @param index
 function ParamSet:t(index)
@@ -318,7 +328,7 @@ function ParamSet:write(filename, name)
     io.output(fd)
     if name then io.write("-- "..name.."\n") end
     for _,param in pairs(self.params) do
-      if param.id and param.t ~= self.tTRIGGER then
+      if param.id and param.save and param.t ~= self.tTRIGGER then
         io.write(string.format("%s: %s\n", quote(param.id), param:get()))
       end
     end


### PR DESCRIPTION
added a param flag for saving to pset (or not)

in this case, we wanted _not_ to save mixer levels in the pset

```
params:set_state("output_level", false)
```

etc. by default now the levels are not saved. i did not extend this to reverb/comp params.

i think this is fine by default, but i suspect there's going to be a request (which is reasonable) that all params get some sort of top-level UI for save-to-pset or not (like the aleph, which was a powerful feature).