### PR TITLE
Use device hostname for wifi hotspot ssid

### DIFF
--- a/lua/core/wifi.lua
+++ b/lua/core/wifi.lua
@@ -6,6 +6,7 @@ local util = require "util"
 --
 
 local HOTSPOT = "Hotspot"
+local hotspot_password = "nnnnnnnn"
 
 --
 -- common functions
@@ -191,7 +192,7 @@ function Wifi.hotspot()
   print("activating hotspot")
   Wifi.ensure_radio_is_on()
   os.execute("nmcli c delete Hotspot")
-  os.execute("nmcli dev wifi hotspot ifname wlan0 ssid norns password nnnnnnnn")
+  os.execute("nmcli dev wifi hotspot ifname wlan0 ssid $(hostname) password " .. hotspot_password)
 end
 
 function Wifi.on(connection)


### PR DESCRIPTION
Currently the hotspot ssid / password are hard coded to "norns" / "nnnnnnnn"

In a situation with multiple devices, having the script pick up the device hostname instead would be nice. Mostly applicable to someone with norns + shield, or shield + shield, etc.

I've added a variable `hotspot_password` but I'm not sure if there's a better place to establish that. For the moment it's local to `wifi.lua`. (also not sure if there's a preferred variable naming scheme I should use).