### PR TITLE
osc remote for key/enc

### DIFF
--- a/lua/core/osc.lua
+++ b/lua/core/osc.lua
@@ -79,10 +79,20 @@ local function param_handler(path, args)
   end
 end
 
+local function remote_handler(path, args)
+  if path=="/remote/key" then
+    if args[1] and args[2] then _norns.key(args[1],args[2]) end
+  elseif path=="/remote/enc" then
+    if args[1] and args[2] then _norns.enc(args[1],args[2]) end
+  end
+end
+
 -- handle an osc event.
 _norns.osc.event = function(path, args, from)
   if util.string_starts(path, "/param") then
     param_handler(path, args)
+  elseif util.string_starts(path, "/remote") then
+    remote_handler(path, args)
   end
 
   if OSC.event ~= nil then OSC.event(path, args, from) end


### PR DESCRIPTION
fixes https://github.com/monome/norns/issues/1023

added the `/remote/` OSC pattern

- `/remote/key 2 1` --- effectively executes `key(2,1)` at the lowest level (menu or play mode)
- `/remote/enc 1 -3`

same OSC port: 10111

important to remember that with key remotes it should be treated like a state-ful toggle. ie, don't send a bunch of key-downs in a row. some menu/script logic may get super weird since a script could be tracking down-up positions.

@dndrks need some docs for this