### PR TITLE
enable start/stop sync for link clock source

### DIFF
--- a/matron/src/clocks/clock_link.c
+++ b/matron/src/clocks/clock_link.c
@@ -14,6 +14,7 @@ static pthread_t clock_link_thread;
 static struct clock_link_shared_data_t {
     double quantum;
     double requested_tempo;
+    bool playing;
     pthread_mutex_t lock;
 } clock_link_shared_data;
 
@@ -35,8 +36,17 @@ static void *clock_link_run(void *p) {
             double link_tempo = ableton_link_session_state_tempo(state);
             uint64_t micros = ableton_link_clock_micros(clock);
             double link_beat = ableton_link_session_state_beat_at_time(state, micros, clock_link_shared_data.quantum);
+            bool link_playing = ableton_link_session_state_is_playing(state);
 
             clock_update_reference_from(link_beat, 60.0f / link_tempo, CLOCK_SOURCE_LINK);
+
+            if (!clock_link_shared_data.playing && link_playing) {
+                clock_link_shared_data.playing = true;
+                clock_start_from(CLOCK_SOURCE_LINK);
+            } else if (clock_link_shared_data.playing && !link_playing) {
+                clock_link_shared_data.playing = false;
+                clock_stop_from(CLOCK_SOURCE_LINK);
+            }
 
             if (clock_link_shared_data.requested_tempo > 0) {
                 ableton_link_session_state_set_tempo(state, clock_link_shared_data.requested_tempo, micros);

--- a/matron/src/clocks/clock_link.c
+++ b/matron/src/clocks/clock_link.c
@@ -28,6 +28,7 @@ static void *clock_link_run(void *p) {
     link = ableton_link_new(120);
     clock = ableton_link_clock(link);
     ableton_link_enable(link, true);
+    ableton_link_enable_start_stop_sync(link, true);
 
     while (true) {
         if (pthread_mutex_trylock(&clock_link_shared_data.lock) == 0) {


### PR DESCRIPTION
fixes #1064

this PR doesn't implement sending start/stop commands to link, it could be done separately.

this implementation doesn't reset link beat counter.