### PR TITLE
clock.get_beat_ms

### DIFF
--- a/lua/core/clock.lua
+++ b/lua/core/clock.lua
@@ -111,9 +111,9 @@ clock.get_tempo = function()
   return _norns.clock_get_tempo()
 end
 
-clock.get_beat_ms = function(x)
+clock.get_beat_sec = function(x)
   x = x or 1
-  return (60000.0 / _norns.clock_get_tempo() * x)
+  return (60.0 / _norns.clock_get_tempo() * x)
 end
 
 

--- a/lua/core/clock.lua
+++ b/lua/core/clock.lua
@@ -111,6 +111,11 @@ clock.get_tempo = function()
   return _norns.clock_get_tempo()
 end
 
+clock.get_beat_ms = function(x)
+  x = x or 1
+  return (60000.0 / _norns.clock_get_tempo() * x)
+end
+
 
 clock.transport = {}
 

--- a/lua/core/clock.lua
+++ b/lua/core/clock.lua
@@ -113,7 +113,7 @@ end
 
 clock.get_beat_sec = function(x)
   x = x or 1
-  return (60.0 / _norns.clock_get_tempo() * x)
+  return 60.0 / clock.get_tempo() * x
 end
 
 


### PR DESCRIPTION
default arg is 1 (beat), so it also functions as a simple helper ie `clock.get_beat_ms(3/2)`

ie bpm 120 returns 500ms

mainly for use in other params that want ms values... ie softcut loop time or cut position