### PR TITLE
add input division for crow clock

### DIFF
--- a/lua/core/clock.lua
+++ b/lua/core/clock.lua
@@ -138,6 +138,12 @@ clock.internal.stop = function()
   return _norns.clock_internal_stop()
 end
 
+clock.crow = {}
+
+clock.crow.in_div = function(div)
+  _norns.clock_crow_in_div(div)
+end
+
 
 clock.midi = {}
 
@@ -223,9 +229,17 @@ function clock.add_params()
   params:set_action("clock_crow_out_div",
     function(x) norns.state.clock.crow_out_div = x end)
   params:set_save("clock_crow_out_div", false)
-  params:add_trigger("crow_clear", "crow clear")
-  params:set_action("crow_clear",
-    function() crow.reset() crow.clear() end)
+  params:add_number("clock_crow_in_div", "crow in div", 1, 32,
+    norns.state.clock.crow_in_div)
+  params:set_action("clock_crow_in_div",
+    function(x)
+      clock.crow.in_div(x)
+      norns.state.clock.crow_in_div = x
+    end)
+  params:set_save("clock_crow_in_div", false)
+  --params:add_trigger("crow_clear", "crow clear")
+  --params:set_action("crow_clear",
+    --function() crow.reset() crow.clear() end)
 
   params:bang("clock_tempo")
 

--- a/lua/core/state.lua
+++ b/lua/core/state.lua
@@ -26,6 +26,7 @@ state.clock.link_quantum = 4
 state.clock.midi_out = 1
 state.clock.crow_out = 1
 state.clock.crow_out_div = 4
+state.clock.crow_in_div = 4
 
 -- read state.lua and set parameters back to stored vals.
 state.resume = function()
@@ -114,6 +115,7 @@ state.save_state = function()
   io.write("norns.state.clock.midi_out = " .. norns.state.clock.midi_out .. "\n")
   io.write("norns.state.clock.crow_out = " .. norns.state.clock.crow_out .. "\n")
   io.write("norns.state.clock.crow_out_div = " .. norns.state.clock.crow_out_div .. "\n")
+  io.write("norns.state.clock.crow_in_div = " .. norns.state.clock.crow_in_div .. "\n")
   for i=1,4 do
     io.write("midi.vports[" .. i .. "].name = '" .. midi.vports[i].name .. "'\n")
   end

--- a/matron/src/clocks/clock_crow.c
+++ b/matron/src/clocks/clock_crow.c
@@ -14,7 +14,11 @@ static uint8_t beat_duration_buf_len = 0;
 static double mean_sum;
 static double mean_scale;
 
-#define CLOCK_CROW_DIV 4.0
+static double crow_in_div = 4.0;
+
+void clock_crow_in_div(int div) {
+  crow_in_div = (double) div;
+}
 
 void clock_crow_init() {
     clock_crow_counter = 0;
@@ -30,7 +34,7 @@ void clock_crow_handle_clock() {
     clock_crow_last_time_set = true;
     clock_crow_last_time = current_time;
   } else { 
-    beat_duration = (current_time - clock_crow_last_time) * CLOCK_CROW_DIV;
+    beat_duration = (current_time - clock_crow_last_time) * crow_in_div;
 
     if(beat_duration > 4) { // assume clock stopped
       clock_crow_last_time = current_time;
@@ -51,7 +55,7 @@ void clock_crow_handle_clock() {
       clock_crow_counter++;
       clock_crow_last_time = current_time;
 
-      double beat = clock_crow_counter / CLOCK_CROW_DIV;
+      double beat = clock_crow_counter / crow_in_div;
       clock_update_reference_from(beat, mean_sum, CLOCK_SOURCE_CROW);
     }
   }

--- a/matron/src/clocks/clock_crow.h
+++ b/matron/src/clocks/clock_crow.h
@@ -4,3 +4,4 @@
 
 void clock_crow_init();
 void clock_crow_handle_clock();
+void clock_crow_in_div(int div);

--- a/matron/src/weaver.c
+++ b/matron/src/weaver.c
@@ -40,6 +40,7 @@
 #include "clock.h"
 #include "clocks/clock_internal.h"
 #include "clocks/clock_link.h"
+#include "clocks/clock_crow.h"
 
 
 // registered lua functions require the LVM state as a parameter.
@@ -224,6 +225,7 @@ static int _clock_cancel(lua_State *l);
 static int _clock_internal_set_tempo(lua_State *l);
 static int _clock_internal_start(lua_State *l);
 static int _clock_internal_stop(lua_State *l);
+static int _clock_crow_in_div(lua_State *l);
 
 #if HAVE_ABLETON_LINK
 static int _clock_link_set_tempo(lua_State *l);
@@ -429,6 +431,7 @@ void w_init(void) {
   lua_register_norns("clock_internal_set_tempo", &_clock_internal_set_tempo);
   lua_register_norns("clock_internal_start", &_clock_internal_start);
   lua_register_norns("clock_internal_stop", &_clock_internal_stop);
+  lua_register_norns("clock_crow_in_div", &_clock_crow_in_div);
 #if HAVE_ABLETON_LINK
   lua_register_norns("clock_link_set_tempo", &_clock_link_set_tempo);
   lua_register_norns("clock_link_set_quantum", &_clock_link_set_quantum);
@@ -1440,6 +1443,13 @@ int _clock_internal_start(lua_State *l) {
 
 int _clock_internal_stop(lua_State *l) {
   clock_internal_stop();
+  return 0;
+}
+
+int _clock_crow_in_div(lua_State *l) {
+  lua_check_num_args(1);
+  int div = (int) luaL_checkinteger(l, 1);
+  clock_crow_in_div(div);
   return 0;
 }
 


### PR DESCRIPTION
was default to 4 subdivisions. now it's settable via the param menu.

also removed "crow clear" as it was a stopgap fix for an improperly initialized crow, which was fixed in a recent PR

tested successfully.

@artfwo i know you don't have a crow, but thought you could just quickly glance at this