### PR TITLE
params list

### DIFF
--- a/lua/core/paramset.lua
+++ b/lua/core/paramset.lua
@@ -194,6 +194,17 @@ function ParamSet:print()
   end
 end
 
+--- list.
+-- lists param id's
+function ParamSet:list()
+  print("paramset ["..self.name.."]")
+  for k,v in pairs(self.params) do
+    if v.id then
+      print(v.id)
+    end
+  end
+end
+
 -- TODO: @scazan CHECK type here!
 --- name.
 -- @tparam number index


### PR DESCRIPTION
helper function to list param id's.

i find myself doing ugly hacks in the REPL to find these, so better have a sanctioned method

these id's are also visible in the param menu when in MAP mode.

@dndrks you were asking for something like this last month, and i recall showing you a hack