### PR TITLE
Remove custom function by using builtin string library

### DIFF
--- a/lua/core/crow.lua
+++ b/lua/core/crow.lua
@@ -4,10 +4,6 @@
 local ii_events = require 'core/crow/ii_events'
 local ii_actions = require 'core/crow/ii_actions'
 
-local function tostringwithquotes(s)
-  return "'"..tostring(s).."'"
-end
-
 
 -- system setup
 
@@ -94,10 +90,10 @@ function input.new(x)
   i.stream = function(v) print("crow input stream: "..i.n.." "..v) end
   i.change = function(v) print("crow input change: "..i.n.." "..v) end
   i.mode = function(m,a,b,c)
-    local cmd = "input["..i.n.."].mode("..tostringwithquotes(m)
+    local cmd = "input["..i.n.."].mode("..string.format("%q",m)
     if a ~= nil then cmd = cmd .. "," .. a end
     if b ~= nil then cmd = cmd .. "," .. b end
-    if c ~= nil then cmd = cmd .. "," .. tostringwithquotes(c) end
+    if c ~= nil then cmd = cmd .. "," .. string.format("%q",c) end
     cmd = cmd .. ")"
     crow.send(cmd)
   end
@@ -146,7 +142,7 @@ output.__newindex = function(self, i, v)
     crow.send(me..".volts="..v)
   elseif i == 'shape' then
     self._shape = v
-    crow.send(me..".shape="..tostringwithquotes(v))
+    crow.send(me..".shape="..string.format("%q",v))
   elseif i == 'slew' then
     self._slew = v
     crow.send(me..".slew="..v)
@@ -179,7 +175,7 @@ output.__call = function(self,arg)
     or arg == "release"
     or arg == "step"
     or arg == "unlock" then
-      args = tostringwithquotes(arg)
+      args = string.format("%q",arg)
     else -- boolean or asl
       args = arg
     end

--- a/lua/core/crow.lua
+++ b/lua/core/crow.lua
@@ -90,10 +90,10 @@ function input.new(x)
   i.stream = function(v) print("crow input stream: "..i.n.." "..v) end
   i.change = function(v) print("crow input change: "..i.n.." "..v) end
   i.mode = function(m,a,b,c)
-    local cmd = "input["..i.n.."].mode("..string.format("%q",m)
+    local cmd = string.format("input[%i].mode(%q",i.n,m)
     if a ~= nil then cmd = cmd .. "," .. a end
     if b ~= nil then cmd = cmd .. "," .. b end
-    if c ~= nil then cmd = cmd .. "," .. string.format("%q",c) end
+    if c ~= nil then cmd = string.format("%s,%q",cmd,c) end
     cmd = cmd .. ")"
     crow.send(cmd)
   end
@@ -142,7 +142,7 @@ output.__newindex = function(self, i, v)
     crow.send(me..".volts="..v)
   elseif i == 'shape' then
     self._shape = v
-    crow.send(me..".shape="..string.format("%q",v))
+    crow.send(string.format("%s.shape=%q",me,v))
   elseif i == 'slew' then
     self._slew = v
     crow.send(me..".slew="..v)


### PR DESCRIPTION
This just replaces the `tostringwithquotes` function by the built-in `%q` option in `string.format`.

Just a code cleanliness thing because I saw this 'quoted string' option while doing some random googling. Felt more idiomatic to lua.