### PR TITLE
hide params inside of group

### DIFF
--- a/lua/core/menu/params.lua
+++ b/lua/core/menu/params.lua
@@ -57,7 +57,9 @@ end
 local function build_sub(sub)
   page = {}
   for i = 1,params:get(sub) do
-    table.insert(page, i + sub)
+    if params:visible(i + sub) then
+      table.insert(page, i + sub)
+    end
   end
 end
 


### PR DESCRIPTION
I noticed `params:hide(index)` only works parameters at the top level, this allows hiding to work within groups as well.