### PR TITLE
expose configured paths in read only table

### DIFF
--- a/lua/core/config.lua
+++ b/lua/core/config.lua
@@ -15,10 +15,15 @@ local dust = home..'/dust/code/?.lua;'
 package.path = sys..core..params..lib..softcut..dust..package.path
 -- print('package.path: ' .. package.path)
 
-_path = {}
-_path.home = home
-_path.dust = home..'/dust/'
-_path.code = _path.dust..'code/'
-_path.audio = _path.dust..'audio/'
-_path.tape = _path.audio..'tape/'
-_path.data = _path.dust..'data/'
+-- must be done after package path is set
+local tu = require 'tabutil'
+
+local _p = {}
+_p.home = home
+_p.dust = home..'/dust/'
+_p.code = _p.dust..'code/'
+_p.audio = _p.dust..'audio/'
+_p.tape = _p.audio..'tape/'
+_p.data = _p.dust..'data/'
+
+_path = tu.readonly{ table = _p }

--- a/lua/core/norns.lua
+++ b/lua/core/norns.lua
@@ -122,6 +122,15 @@ norns.encoders = require 'core/encoders'
 
 _norns.enc = norns.encoders.process
 
+-- extend paths config table
+paths = {
+  shared = _path,
+  this = tab.readonly{
+    table = norns.state,
+    expose = {'script', 'data', 'path', 'name'}
+  },
+}
+
 -- Error handling.
 norns.scripterror = function(msg) print(msg) end
 norns.try = function(f,msg)

--- a/lua/lib/tabutil.lua
+++ b/lua/lib/tabutil.lua
@@ -195,14 +195,19 @@ function tab.load(sfile)
 end
 
 --- Create a read-only proxy for a given table.
--- @param params params.table is the table to proxy, params.except a list of writable keys
+-- @param params params.table is the table to proxy, params.except a list of writable keys, params.expose limits which keys from params.table are exposed (optional)
 -- @treturn table the proxied read-only table
 function tab.readonly(params)
   local t = params.table
   local exceptions = params.except or {}
   local proxy = {}
   local mt = {
-    __index = t,
+    __index = function(_, k)
+      if params.expose == nil or tab.contains(params.expose, k) then
+        return t[k]
+      end
+      return nil
+    end,
     __newindex = function (_,k,v)
       if (tab.contains(exceptions, k)) then
         t[k] = v


### PR DESCRIPTION
- makes `_path` global table read only
- adds public `paths` table which exposes _path and state related paths
- teach tabutil.readonly optional limit which keys are exposed