### PR TITLE
path table

### DIFF
--- a/lua/core/config.lua
+++ b/lua/core/config.lua
@@ -18,12 +18,11 @@ package.path = sys..core..params..lib..softcut..dust..package.path
 -- must be done after package path is set
 local tu = require 'tabutil'
 
-local _p = {}
-_p.home = home
-_p.dust = home..'/dust/'
-_p.code = _p.dust..'code/'
-_p.audio = _p.dust..'audio/'
-_p.tape = _p.audio..'tape/'
-_p.data = _p.dust..'data/'
+_path = {}
+_path.home = home
+_path.dust = home..'/dust/'
+_path.code = _path.dust..'code/'
+_path.audio = _path.dust..'audio/'
+_path.tape = _path.audio..'tape/'
+_path.data = _path.dust..'data/'
 
-_path = tu.readonly{ table = _p }

--- a/lua/core/norns.lua
+++ b/lua/core/norns.lua
@@ -123,13 +123,12 @@ norns.encoders = require 'core/encoders'
 _norns.enc = norns.encoders.process
 
 -- extend paths config table
-paths = {
-  shared = _path,
-  this = tab.readonly{
-    table = norns.state,
-    expose = {'script', 'data', 'path', 'name', 'lib'}
-  },
+local p = _path
+p.this = tab.readonly{
+  table = norns.state,
+  expose = {'data', 'path', 'lib'}
 }
+paths = tab.readonly{ table = p }
 
 -- Error handling.
 norns.scripterror = function(msg) print(msg) end

--- a/lua/core/norns.lua
+++ b/lua/core/norns.lua
@@ -127,7 +127,7 @@ paths = {
   shared = _path,
   this = tab.readonly{
     table = norns.state,
-    expose = {'script', 'data', 'path', 'name'}
+    expose = {'script', 'data', 'path', 'name', 'lib'}
   },
 }
 

--- a/lua/core/script.lua
+++ b/lua/core/script.lua
@@ -67,6 +67,8 @@ Script.clear = function()
   norns.state.name = 'none'
   norns.state.shortname = 'none'
   norns.state.path = _path["dust"]
+  norns.state.data = _path.data
+  norns.state.lib = norns.state.path
 
   -- clear params
   params:clear()
@@ -159,6 +161,7 @@ Script.load = function(filename)
     norns.state.name = name
     norns.state.shortname = norns.state.name:match( "([^/]+)$" )
     norns.state.path = path .. '/'
+    norns.state.lib = path .. '/lib/'
     norns.state.data = _path.data .. name .. '/'
 
     if util.file_exists(norns.state.data) == false then

--- a/lua/core/state.lua
+++ b/lua/core/state.lua
@@ -4,6 +4,7 @@
 local state = {}
 state.script = ''
 state.path = _path.code
+state.lib = _path.code
 state.data = _path.data
 state.name = ''
 state.shortname = ''
@@ -57,11 +58,6 @@ state.resume = function()
       norns.script.load()
     else
       norns.script.clear()
-      state.script=''
-      state.name = 'none'
-      state.shortname = 'none'
-      state.path = _path.code
-      state.data = _path.data
       norns.scripterror("NO SCRIPT")
     end
     -- reset clean_shutdown flag and save state so that
@@ -70,11 +66,6 @@ state.resume = function()
     state.save_state()
   else
     norns.script.clear()
-    state.script=''
-    state.name = 'none'
-    state.shortname = 'none'
-    state.path = _path.code
-    state.data = _path.data
     norns.scripterror("NO SCRIPT")
   end
 end


### PR DESCRIPTION
@ngwese after some use i propose some minor changes... basically to reduce the verbosity of the `shared` table:

```
paths.code
paths.data
paths.audio
paths.tape
paths.this.path
paths.this.data
paths.this.lib
```

this realistically covers all the needed paths, and puts the shared ones at the root level.

note, `_path` is no longer protected, but the global state gets reset in between loads...