### PR TITLE
avoid buffer overflow in dev_crow_send

### DIFF
--- a/matron/src/device/device_crow.c
+++ b/matron/src/device/device_crow.c
@@ -113,11 +113,9 @@ void dev_crow_deinit(void *self) {
 }
 
 void dev_crow_send(struct dev_crow *d, const char *line) {
-    char s[256];
-    strcpy(s, line);
-    strcat(s, "\n\0");
     // fprintf(stderr,"crow_send: %s",line);
-    write(d->fd, s, strlen(s));
+    write(d->fd, line, strlen(line));
+    write(d->fd, "\n", 1);
 }
 
 #pragma GCC diagnostic pop


### PR DESCRIPTION
`dev_crow_send ` would `strcpy` the user input string into a 256 byte stack-allocated buffer and `strcat` a newline. Instead, this patch just `write`s the string to the crow fd and then `write`s a newline character. Previously, the following script would cause matron to crash due to a SIGABRT when crow is connected:

```lua
function repeat_str(s, times)
  if times <= 1 then
    return s
  else
    return s .. repeat_str(s, times - 1)
  end
end

function init()
  crow.send(repeat_str('0123456789abcdef', 32))
  crow.send('print("crow ok")')
  print('done')
end
```

With this patch the output is:
```
# script init
done
crow:	repl:1: malformed number near '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
crow:	123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcde
crow:	0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef'
crow:	crow ok
```
