### PR TITLE
teach include() to find code in norns/lua/extn

### DIFF
--- a/lua/core/config.lua
+++ b/lua/core/config.lua
@@ -20,6 +20,7 @@ local tu = require 'tabutil'
 
 _path = {}
 _path.home = home
+_path.extn = norns..'/extn/'
 _path.dust = home..'/dust/'
 _path.code = _path.dust..'code/'
 _path.audio = _path.dust..'audio/'

--- a/lua/core/startup.lua
+++ b/lua/core/startup.lua
@@ -34,18 +34,18 @@ require 'core/menu'
 
 -- global include function
 function include(file)
-  local here = norns.state.path .. file .. '.lua'
-  local there = _path.code .. file .. '.lua'
-  if util.file_exists(here) then 
-    print("including "..here)
-    return dofile(here)
-  elseif util.file_exists(there) then
-    print("including "..there)
-    return dofile(there)
-  else
-    print("### MISSING INCLUDE: "..file)
-    error("MISSING INCLUDE: "..file,2)
+  local dirs = {norns.state.path, _path.code, _path.extn}
+  for _, dir in ipairs(dirs) do
+    local p = dir..file..'.lua'
+    if util.file_exists(p) then
+      print("including "..p)
+      return dofile(p)
+    end
   end
+
+  -- didn't find anything
+  print("### MISSING INCLUDE: "..file)
+  error("MISSING INCLUDE: "..file,2)
 end
 
 -- monome device management


### PR DESCRIPTION
adds the ability to `include(...)` code from a third directory; `lua/extn`, within the norns code base.

aside: @pq it might make sense move the `asl.lua` code here and switch to using `include` instead of `require` (since the asl module is getting forcefully unloaded in the script handling code)