### PR TITLE
fileselect resume for each param and TAPE

### DIFF
--- a/lua/core/menu/params.lua
+++ b/lua/core/menu/params.lua
@@ -163,11 +163,11 @@ m.key = function(n,z)
         m.pos = n-1
       elseif t == params.tFILE then
         if m.mode == mEDIT then
-	   fileselect.enter(_path.dust, m.newfile)
-	   if m.dir_prev ~= nil then
-	     fileselect.pushd(m.dir_prev)
-	   end
-	end
+          fileselect.enter(_path.dust, m.newfile)
+          if m.dir_prev ~= nil then
+            fileselect.pushd(m.dir_prev)
+          end
+        end
       elseif t == params.tTEXT then
         if m.mode == mEDIT then
           textentry.enter(m.newtext, params:get(i), "PARAM: "..params:get_name(i))

--- a/lua/core/menu/params.lua
+++ b/lua/core/menu/params.lua
@@ -24,7 +24,8 @@ local m = {
   ps_pos = 0,
   ps_n = 0,
   ps_action = 1,
-  ps_last = 0
+  ps_last = 0,
+  dir_prev = nil,
 }
 
 local page
@@ -92,7 +93,7 @@ local function pset_list(results)
   m.ps_n = m.ps_n + 1
   _menu.redraw()
 end
-  
+
 local function init_pset()
   print("scanning psets...")
   norns.system_cmd('ls -1 '..norns.state.data..norns.state.shortname..'*.pset | sort', pset_list)
@@ -161,7 +162,12 @@ m.key = function(n,z)
         until params:t(page[n]) == params.tSEPARATOR
         m.pos = n-1
       elseif t == params.tFILE then
-        if m.mode == mEDIT then fileselect.enter(_path.dust, m.newfile) end
+        if m.mode == mEDIT then
+	   fileselect.enter(_path.dust, m.newfile)
+	   if m.dir_prev ~= nil then
+	     fileselect.pushd(m.dir_prev)
+	   end
+	end
       elseif t == params.tTEXT then
         if m.mode == mEDIT then
           textentry.enter(m.newtext, params:get(i), "PARAM: "..params:get_name(i))
@@ -241,6 +247,7 @@ end
 m.newfile = function(file)
   if file ~= "cancel" then
     params:set(page[m.pos+1],file)
+    m.dir_prev = file:match(_path.dust .. "(.*/)")
     _menu.redraw()
   end
 end
@@ -559,7 +566,7 @@ norns.menu_midi_event = function(data, dev)
       if _menu.mode then _menu.redraw() end
     else
       --print(cc.." : "..v)
-      local r = norns.pmap.rev[dev][ch][cc] 
+      local r = norns.pmap.rev[dev][ch][cc]
       if r then
         local d = norns.pmap.data[r]
         local t = params:t(r)

--- a/lua/core/menu/params.lua
+++ b/lua/core/menu/params.lua
@@ -164,8 +164,10 @@ m.key = function(n,z)
       elseif t == params.tFILE then
         if m.mode == mEDIT then
           fileselect.enter(_path.dust, m.newfile)
-          if m.dir_prev ~= nil then
-            fileselect.pushd(m.dir_prev)
+          local fparam = params:lookup_param(i)
+          local dir_prev = fparam.dir or m.dir_prev
+          if dir_prev ~= nil then
+            fileselect.pushd(dir_prev)
           end
         end
       elseif t == params.tTEXT then
@@ -247,7 +249,7 @@ end
 m.newfile = function(file)
   if file ~= "cancel" then
     params:set(page[m.pos+1],file)
-    m.dir_prev = file:match(_path.dust .. "(.*/)")
+    m.dir_prev = file:match("(.*/)")
     _menu.redraw()
   end
 end

--- a/lua/core/menu/tape.lua
+++ b/lua/core/menu/tape.lua
@@ -18,6 +18,7 @@ local m = {
     sel = TAPE_PLAY_LOAD,
     status = TAPE_PLAY_STOP,
     file = nil,
+    dir_prev = nil,
     pos_tick = 0
   },
   rec = {
@@ -90,6 +91,7 @@ m.key = function(n,z)
           if path ~= "cancel" then
             audio.tape_play_open(path)
             m.play.file = path:match("[^/]*$")
+            m.play.dir_prev = path:match("(.*/)")
             m.play.status = TAPE_PLAY_PAUSE
             m.play.sel = TAPE_PLAY_PLAY
             local _, samples, rate = _norns.sound_file_inspect(path)
@@ -123,6 +125,9 @@ m.key = function(n,z)
           _menu.redraw()
         end
         fileselect.enter(_path.audio, playfile_callback)
+        if m.play.dir_prev ~= nil then
+          fileselect.pushd(m.play.dir_prev)
+        end
       elseif m.play.sel == TAPE_PLAY_PLAY then
         tape_play_counter:start()
         audio.tape_play_start()

--- a/lua/core/params/file.lua
+++ b/lua/core/params/file.lua
@@ -13,6 +13,7 @@ function File.new(id, name, path)
   o.name = name
   o.path = path or '-'
   o.action = function() end
+  o:loaddir()
   return o
 end
 
@@ -24,12 +25,31 @@ function File:set(v, silent)
   local silent = silent or false
   if self.path ~= v then
     self.path = v
+    if self.path ~= '-' then
+      self:loaddir()
+    else
+      self.dir = nil
+      self.dirfiles = nil
+      self.dirpos = nil
+    end
     if silent==false then self:bang() end
   end
 end
 
 function File:delta(d)
-  --noop
+  if self.dirpos ~= nil then
+    if d > 0 then
+      if self.dirpos < #self.dirfiles then
+        self.dirpos = self.dirpos + 1
+      end
+    elseif d < 0 then
+      if self.dirpos > 1 then
+        self.dirpos = self.dirpos - 1
+      end
+    end
+    local newfile = self.dirfiles[self.dirpos]
+    self:set(self.dir .. self.dirfiles[self.dirpos])
+  end
 end
 
 function File:set_default()
@@ -44,6 +64,23 @@ function File:string()
   if self.path == '-' then return "-" end
   local display = self.path:match("[^/]*$") -- strip path from name
   return display
+end
+
+function File:loaddir()
+  if self.path ~= "-" then
+    self.dir = self.path:match("(.*/)")
+    local name = self.path:match("[^/]*$")
+    local files = util.scandir(self.dir)
+    self.dirfiles = {}
+    for _, fname in ipairs(files) do
+      if not string.find(fname, '/') then
+        self.dirfiles[#self.dirfiles + 1] = fname
+        if fname == name then
+          self.dirpos = #self.dirfiles
+        end
+      end
+    end
+  end
 end
 
 

--- a/lua/core/params/file.lua
+++ b/lua/core/params/file.lua
@@ -67,17 +67,19 @@ function File:string()
 end
 
 function File:loaddir()
-  if self.path ~= "-" then
-    self.dir = self.path:match("(.*/)")
-    local name = self.path:match("[^/]*$")
-    local files = util.scandir(self.dir)
-    self.dirfiles = {}
-    for _, fname in ipairs(files) do
-      if not string.find(fname, '/') then
-        self.dirfiles[#self.dirfiles + 1] = fname
-        if fname == name then
-          self.dirpos = #self.dirfiles
-        end
+  self.dir = self.path:match("(.*/)")
+  if self.dir == nil then
+    return
+  end
+
+  local name = self.path:match("[^/]*$")
+  local files = util.scandir(self.dir)
+  self.dirfiles = {}
+  for _, fname in ipairs(files) do
+    if not string.find(fname, '/') then
+      self.dirfiles[#self.dirfiles + 1] = fname
+      if fname == name then
+        self.dirpos = #self.dirfiles
       end
     end
   end

--- a/lua/lib/fileselect.lua
+++ b/lua/lib/fileselect.lua
@@ -51,6 +51,15 @@ function fs.exit()
   else fs.callback("cancel") end
 end
 
+function fs.pushd(dir)
+  for match in dir:gmatch("([^/]*)/") do
+    fs.depth = fs.depth + 1
+    fs.folders[fs.depth] = match .. "/"
+  end
+  fs.getlist()
+  fs.redraw()
+end
+
 
 fs.getdir = function()
   local path = fs.folder

--- a/lua/lib/fileselect.lua
+++ b/lua/lib/fileselect.lua
@@ -52,7 +52,8 @@ function fs.exit()
 end
 
 function fs.pushd(dir)
-  for match in dir:gmatch("([^/]*)/") do
+  local subdir = dir:match(fs.folder .. '(.*)')
+  for match in subdir:gmatch("([^/]*)/") do
     fs.depth = fs.depth + 1
     fs.folders[fs.depth] = match .. "/"
   end
@@ -75,8 +76,12 @@ fs.getlist = function()
   fs.list = util.scandir(dir)
   fs.display_list = {}
   fs.lengths = {}
-  fs.len = #fs.list
   fs.pos = 0
+
+  if fs.depth > 0 then
+    table.insert(fs.list, 1, "../")
+  end
+  fs.len = #fs.list
 
   -- Generate display list and lengths
   for k, v in ipairs(fs.list) do
@@ -99,20 +104,17 @@ end
 fs.key = function(n,z)
   -- back
   if n==2 and z==1 then
-    if fs.depth > 0 then
-      --print('back')
-      fs.folders[fs.depth] = nil
-      fs.depth = fs.depth - 1
-      fs.getlist()
-      fs.redraw()
-    else
-      fs.done = true
-    end
-    -- select
+    fs.done = true
+  -- select
   elseif n==3 and z==1 then
     if #fs.list > 0 then
       fs.file = fs.list[fs.pos+1]
-      if string.find(fs.file,'/') then
+      if fs.file == "../" then
+	 fs.folders[fs.depth] = nil
+	 fs.depth = fs.depth - 1
+	 fs.getlist()
+	 fs.redraw()
+      elseif string.find(fs.file,'/') then
         --print("folder")
         fs.depth = fs.depth + 1
         fs.folders[fs.depth] = fs.file

--- a/lua/lib/fileselect.lua
+++ b/lua/lib/fileselect.lua
@@ -110,10 +110,10 @@ fs.key = function(n,z)
     if #fs.list > 0 then
       fs.file = fs.list[fs.pos+1]
       if fs.file == "../" then
-	 fs.folders[fs.depth] = nil
-	 fs.depth = fs.depth - 1
-	 fs.getlist()
-	 fs.redraw()
+        fs.folders[fs.depth] = nil
+        fs.depth = fs.depth - 1
+        fs.getlist()
+        fs.redraw()
       elseif string.find(fs.file,'/') then
         --print("folder")
         fs.depth = fs.depth + 1


### PR DESCRIPTION
Fixes #1019 

* Adds a `../` directory entry when browsing a directory below the fileselect's root directory (/home/we/dust for file params, /home/we/dust/audio for tape). You now select this to go up a directory, and K2 instead cancels out of the file select menu completely.
* File select menus will remember the last folder where a file was selected, allowing quick selection of files in the same folder. This was also added to the TAPE > PLAY file selector. If a param value is already set, the folder containing that file will be opened. If no value is set, the last selected folder will be opened.
* For file params, added a `File:delta` implementation so that you can use E3 to scroll through files in the same directory as the currently selected file.