### PR TITLE
defaulttable container type

### DIFF
--- a/lua/lib/container/TESTING.md
+++ b/lua/lib/container/TESTING.md
@@ -1,0 +1,8 @@
+TODO: the tests should be made more easily runnable. currently one must manually
+run each container test script individually by:
+
+- `cd norns/lua`
+- `LUA_PATH='lib/?.lua' lua5.3 lib/container/<name_of_container>_test.lua -v`
+
+NB: norns/matron embed lua5.3 while the base os install only includes the lua5.1
+interpreter. to test using lua5.3 as above run `sudo apt-get install lua5.3`

--- a/lua/lib/container/defaulttable.lua
+++ b/lua/lib/container/defaulttable.lua
@@ -1,0 +1,75 @@
+-- DefaultTable - a table which provides a default value initialization for each key
+-- @module DefaultTable
+-- @alias DefaultTable
+
+local function shallow_copy(t)
+  -- MAINT: the {table.unpack(t)} trick doesn't work if the given table has
+  -- non-integer keys or a numeric indicies with gaps
+  local new = {}
+  for k,v in pairs(t) do
+    new[k] = v
+  end
+  return new
+end
+
+local DefaultTable = {}
+DefaultTable.__index = DefaultTable
+
+--- Create a table where every key is inialized with a default value when first
+-- accessed.
+--
+-- Providing a table as the initial value will result in a shallow copy of the
+-- given table being made when a key is initially accessed. Providing a (zero
+-- argument) function will result in the function being called to obtain the
+-- initial value. Providing any other value will result in that value being
+-- used as the initial value for keys (which could result structural sharing
+-- between keys).
+--
+-- @tparam anything initial Value initializer (can be nil).
+-- @treturn table
+function DefaultTable.new(initial)
+  local self = {}
+  self._table = {}
+
+  local t = type(initial)
+  if t == 'table' then
+    self._initializer = function() return shallow_copy(initial) end
+  elseif t == 'function' then
+    self._initializer = initial
+  else
+    self._initializer = function() return initial end
+  end
+
+  setmetatable(self, DefaultTable)
+
+  return self
+end
+
+function DefaultTable:__index(k)
+  local _t = rawget(self, '_table')
+  local v = _t[k]
+  if v == nil then
+    local _i = rawget(self, '_initializer')
+    v = _i()
+    _t[k] = v
+  end
+  return v
+end
+
+function DefaultTable:__newindex(k, v)
+  rawget(self, '_table')[k] = v
+end
+
+function DefaultTable:__len()
+  return #self._table
+end
+
+function DefaultTable.__pairs(this)
+  return pairs(rawget(this, '_table'))
+end
+
+function DefaultTable.__ipairs(this)
+  return ipairs(rawget(this, '_table'))
+end
+
+return DefaultTable

--- a/lua/lib/container/defaulttable_test.lua
+++ b/lua/lib/container/defaulttable_test.lua
@@ -1,0 +1,92 @@
+T = require 'test/luaunit'
+DefaultTable = dofile('lib/container/defaulttable.lua')
+
+--
+-- tests
+--
+
+function test_new_no_args()
+  local dt = DefaultTable.new()
+  T.assertNotNil(dt)
+  T.assertNil(dt['a'])
+  dt['a'] = 1
+  T.assertEquals(dt['a'], 1)
+end
+
+function test_new_with_table_literal()
+  local dt = DefaultTable.new({'a', 'b', 'c'})
+  T.assertEquals(dt['key1'][1], 'a')
+  T.assertEquals(dt['key1'][3], 'c')
+
+  -- ensure different key also has table
+  T.assertEquals(dt['key2'][3], 'c')
+
+  -- ensure keys have different tables
+  dt['key1'][3] = 'changed'
+  T.assertEquals(dt['key2'][3], 'c')
+  T.assertNotEquals(dt['key1'], dt['key2'])
+end
+
+function test_new_with_function()
+  local initializer = function()
+    return { x = 1, y = -16 }
+  end
+
+  local default = initializer()
+  local dt = DefaultTable.new(initializer)
+
+  T.assertEquals(dt['random'], default)
+  dt.random.x = 100
+  T.assertEquals(dt['random']['x'], 100)
+end
+
+function test_len()
+  local dt = DefaultTable.new('value')
+  T.assertEquals(#dt, 0)
+  local v1 = dt[1]
+  T.assertEquals(#dt, 1)
+  local v2 = dt[2]
+  T.assertEquals(#dt, 2)
+
+  -- NB: like ipairs, # stops counting at the first index with a nil value
+  local other = dt[131]
+  T.assertEquals(#dt, 2)
+end
+
+function test_ipairs()
+  local dt = DefaultTable.new()
+  dt[1] = 'first'
+  dt[2] = 'second'
+  dt[3] = 'last'
+  dt[34] = 'not reached'
+
+  local iter, t, i = ipairs(dt)
+  local i, v = iter(t, i)
+  T.assertEquals(v, 'first')
+  local i, v = iter(t, i)
+  T.assertEquals(v, 'second')
+  local i, v = iter(t, i)
+  T.assertEquals(v, 'last')
+  local i, v = iter(t, i)
+  T.assertNil(v)
+end
+
+function test_pairs()
+  local dt = DefaultTable.new()
+  dt['a'] = 'first'
+  dt[2] = 1234
+  dt[{}] = 'other'
+
+  local keys = {}
+  local values = {}
+
+  for k,v in pairs(dt) do
+    table.insert(keys, k)
+    table.insert(values, v)
+  end
+
+  T.assertItemsEquals(keys, {'a', 2, {}})
+  T.assertItemsEquals(values, {1234, 'first', 'other'})
+end
+
+os.exit(T.LuaUnit.run())


### PR DESCRIPTION
adds another container type to the core lib (and a small readme about running the tests)

inspired by python's "defaultdict" type which i've found very useful when trying to collate/correlate data. this combines nicely the `Deque` type in particular:
```
local Deque = require 'container/deque'
local DefaultTable = require 'container/defaulttable'

local events_by_channel = DefaultTable.new(Deque.new)
for _, ev in events do
  events_by_channel[ev.ch]:push_back(ev)
end
```
