### PR TITLE
add input quantum + wrap to controlspec, add wrap to number param

### DIFF
--- a/lua/core/controlspec.lua
+++ b/lua/core/controlspec.lua
@@ -64,10 +64,10 @@ ControlSpec.__index = ControlSpec
 -- @tparam number quantum input quantization value. adjustments are made by this fraction of the range
 -- @tparam boolean wrap true to wrap around on overflow rather than clamping
 -- @treturn ControlSpec
-function ControlSpec.new(minval, maxval, warp, step, default, units, quantum, wrap)
+function ControlSpec.new(min, max, warp, step, default, units, quantum, wrap)
   local s = setmetatable({}, ControlSpec)
-  s.minval = minval
-  s.maxval = maxval
+  s.minval = min or 0
+  s.maxval = max or 1
   if type(warp) == "string" then
     if warp == 'exp' then
       s.warp = ExponentialWarp

--- a/lua/core/params/control.lua
+++ b/lua/core/params/control.lua
@@ -53,6 +53,14 @@ end
 -- set 0-1.
 function Control:set_raw(value, silent)
   local silent = silent or false
+  if self.controlspec.wrap then
+    while value > 1 do
+      value = value - 1
+    end
+    while value < 0 do
+      value = value + 1
+    end
+  end
   local clamped_value = util.clamp(value, 0, 1)
   if self.raw ~= clamped_value then
     self.raw = clamped_value
@@ -64,7 +72,7 @@ end
 -- add delta to current value. checks controlspec for mapped vs not.
 -- default division of delta for 100 steps range.
 function Control:delta(d)
-  self:set_raw(self.raw + d/100)
+  self:set_raw(self.raw + d*self.controlspec.quantum)
 end
 
 --- set_default.

--- a/lua/core/params/number.lua
+++ b/lua/core/params/number.lua
@@ -6,7 +6,7 @@ Number.__index = Number
 
 local tNUMBER = 1
 
-function Number.new(id, name, min, max, default, formatter)
+function Number.new(id, name, min, max, default, formatter, wrap)
   local o = setmetatable({}, Number)
   o.t = tNUMBER
   o.id = id
@@ -15,8 +15,10 @@ function Number.new(id, name, min, max, default, formatter)
   o.value = o.default
   o.min = min or -2147483648
   o.max = max or 2147483647 -- 32 bit signed
+  o.range = math.abs(o.max - o.min) -- make extra sure it's nonnegative
   o.formatter = formatter
   o.action = function() end
+  o.wrap = wrap and o.range ~= 0 or false
   return o
 end
 
@@ -26,6 +28,14 @@ end
 
 function Number:set(v, silent)
   local silent = silent or false
+  if self.wrap then
+    while v > self.max do
+      v = v - self.range
+    end
+    while v < self.min do
+      v = v + self.range
+    end
+  end
   local c = util.clamp(v,self.min,self.max)
   if self.value ~= c then
     self.value = c

--- a/lua/core/paramset.lua
+++ b/lua/core/paramset.lua
@@ -93,7 +93,7 @@ function ParamSet:add(args)
     local name = args.name or id
 
     if args.type == "number"  then
-      param = number.new(id, name, args.min, args.max, args.default, args.formatter)
+      param = number.new(id, name, args.min, args.max, args.default, args.formatter, args.wrap)
     elseif args.type == "option" then
       param = option.new(id, name, args.options, args.default)
     elseif args.type == "control" then
@@ -129,10 +129,11 @@ end
 -- @tparam string name
 -- @tparam number min
 -- @tparam number max
+-- @tparam boolean wrap
 -- @param default
 -- @param formatter
-function ParamSet:add_number(id, name, min, max, default, formatter)
-  self:add { param=number.new(id, name, min, max, default, formatter) }
+function ParamSet:add_number(id, name, min, max, default, formatter, wrap)
+  self:add { param=number.new(id, name, min, max, default, formatter, wrap) }
 end
 
 --- add option.


### PR DESCRIPTION
Fixes #1144 

Adds a `quantum` arg to controlspec which is used to define the fraction of the value range that `params:delta` adjusts by, rather than this being fixed at 1% of the range.

It is also sometimes useful to have params with values that wrap around rather than clamping, e.g. angles -- this is the case for the script I'm currently working on which is why I started messing with this. Added a `wrap` option to both `control` and `number` params.

Since this winds up being a lot of args on `ControlSpec.new` now I added a `ControlSpec.def` method which accepts a table -- I looked around a bit but I'm not sure what if any naming convention exists for positional vs keyword-argument style constructors. The table args for `ControlSpec.def` are `min` and `max` for consistency with `params:add`, rather than `minvalue` and `maxvalue` as the positional args are named. Perhaps the positional args should be changed to `min` and `max` for clarity of the luadocs?

Test script for all the new functionality:
```lua
function init()
  params:add{
    type='control',
    id='ctl',
    name='ctl',
    controlspec=controlspec.def{
      min=0,
      max=10,
      warp='lin',
      step=0.01,
      default=0,
      quantum=0.05,
      wrap=true,
    },
  }
  params:add{
    type='number',
    id='num',
    name='num',
    min=0,
    max=3,
    wrap=true,
  }
end

function enc(n, d)
  if n == 2 then
    params:delta('ctl', d)
    redraw()
  end
  if n == 3 then
    params:delta('num', d * 0.1)
    redraw()
  end
end

function redraw()
  screen.clear()
  screen.move(0, 8)
  screen.text('ctl: ' .. params:get('ctl'))
  screen.move(0, 16)
  screen.text('num: ' .. params:get('num'))
  screen.update()
end
```