### PR TITLE
sky: unstable/io/arc improvements

### DIFF
--- a/lua/extn/sky/unstable/io/arc.lua
+++ b/lua/extn/sky/unstable/io/arc.lua
@@ -1,4 +1,6 @@
 local math = require('math')
+local util = require('util')
+local filters = require('filters')
 
 --
 -- ArcInput
@@ -25,6 +27,10 @@ function ArcInput:on_enc_event(n, delta)
   end
 end
 
+function ArcInput.is_enc(event)
+  return sky.is_type(event, ArcInput.ARC_ENC_EVENT)
+end
+
 
 --
 -- ArcDialGesture
@@ -46,24 +52,108 @@ function ArcDialGesture:new(props)
 end
 
 function ArcDialGesture:process(event, output, state)
-  if sky.is_type(event, ArcInput.ARC_ENC_EVENT) then
-    if event.n == self.which then
-      local range = self.max - self.min
-      local inc = range / self.steps
-      local change = inc * event.delta * self.scale
-      local next = util.clamp(self._value + change, self.min, self.max)
-      if next ~= self._value then
-        self._value = next
-        output({
-          type = self.ARC_DIAL_EVENT,
-          arc = event.arc,
-          n = event.n,
-          value = self._value,
-          normalized = self._value / range,
-        })
-      end
+  if sky.is_type(event, ArcInput.ARC_ENC_EVENT) and event.n == self.which then
+    local range = self.max - self.min
+    local inc = range / self.steps
+    local change = inc * event.delta * self.scale
+    local next = util.clamp(self._value + change, self.min, self.max)
+    if next ~= self._value then
+      self._value = next
+      output(self.mk_dial(event.n, self._value, self._value / range, event.arc))
     end
+  else
+    -- if not an arc enc event pass on through
+    output(event)
   end
+end
+
+function ArcDialGesture.mk_dial(n, value, normalized, arc)
+  return {
+    type = ArcDialGesture.ARC_DIAL_EVENT,
+    arc = arc,
+    n = n,
+    value = value,
+    normalized = normalized,
+  }
+end
+
+function ArcDialGesture.is_dial(event)
+  return sky.is_type(event, ArcDialGesture.ARC_DIAL_EVENT)
+end
+
+--
+-- ArcDialSmoother
+--
+
+local ArcDialSmoother = sky.Device:extend()
+ArcDialSmoother.STEP_EVENT = 'ARC_DIAL_SMOOTHER_STEP'
+
+
+function ArcDialSmoother:new(props)
+  ArcDialSmoother.super.new(self, props)
+  self.which = props.which or 1
+  self._time = props.time or 1
+  self._sr = props.sr or 5
+  self._scheduler = nil
+  self._smoother = filters.smoother.new(self._time, self._sr)
+  self._smoothing = false
+  self._target = nil
+
+  self._step = { type = self.STEP_EVENT }
+end
+
+function ArcDialSmoother:device_inserted(chain)
+  if self._scheduler ~= nil then
+    error('ArcDialSmoother: one instance cannot be used in multiple chains at the same time')
+  end
+  self._scheduler = chain:scheduler(self)
+end
+
+function ArcDialSmoother:device_removed(chain)
+  self._scheduler = nil
+end
+
+function ArcDialSmoother:set_time(t)
+  self._time = t
+  self._smoother:set_time(t)
+end
+
+function ArcDialSmoother:set_sr(sr)
+  self._sr = sr
+  -- FIXME: need to implement this
+end
+
+function ArcDialSmoother:do_step(x)
+  local e = sky.clone(self._target)
+  e.target = e.normalized
+  e.normalized = self._smoother:next(x)
+  return e
+end
+
+function ArcDialSmoother:process(event, output)
+  if sky.is_type(event, self.STEP_EVENT) then
+    local next = self:do_step()
+    self._smoothing = math.abs(next.normalized - self._target.normalized) > self._smoother.EPSILON
+    if self._smoothing then
+      self._scheduler:sleep(1 / self._sr, self._step)
+    end
+    output(next)
+    return
+  end
+
+  if ArcDialGesture.is_dial(event) and event.n == self.which then
+    self._target = sky.clone(event)
+    if not self._smoothing then
+      self._smoothing = true
+      output(self:do_step(self._target.normalized))
+      self._scheduler:sleep(1 / self._sr, self._step)
+    else
+      self._smoother:set_target(self._target.normalized)
+    end
+
+    return
+  end
+
   output(event)
 end
 
@@ -96,7 +186,10 @@ function ArcDialRender:render(event, props)
     if self.mode == 'pointer' then
       props.arc:led(which, point, self.level)
     elseif self.mode == 'segment' then
-      props.arc:segment(which, 0, event.normalized * TWO_PI, self.level)
+      -- NB: clamp angle to just below TWO_PI otherwise start and end angle are the
+      -- same and nothing is draw by the segment method.
+      local v = util.clamp(event.normalized * TWO_PI, 0 , TWO_PI - 0.001)
+      props.arc:segment(which, 0, v, self.level)
     elseif self.mode == 'range' then
       local w = self.width / 2
       local p = event.normalized * TWO_PI
@@ -129,9 +222,16 @@ function ArcDisplay:process(event, output, state)
   output(event)
 end
 
+function ArcDisplay.null_render()
+  local Null = sky.Object:extend()
+  function Null:render(...) end
+  return Null
+end
+
 return {
   ArcInput = ArcInput,
   ArcDialGesture = ArcDialGesture,
+  ArcDialSmoother = ArcDialSmoother,
   ArcDialRender = ArcDialRender,
   ArcDisplay = ArcDisplay,
 


### PR DESCRIPTION
- allow ARC_DIAL events to be created external to gesture
- provide `is_dial` predicate
- clamp ArcDialRender segment to prevent poping
- provide `ArcDisplay.null_render()`
