### PR TITLE
Fixed: fine param value control after entering file select

### DIFF
--- a/lua/core/menu/params.lua
+++ b/lua/core/menu/params.lua
@@ -198,8 +198,9 @@ m.key = function(n,z)
         m.mpos = 1
         m.mode = mMAPEDIT
         m.pm = pm
+      else
+        m.fine = true
       end
-      m.fine = true
     elseif n==3 and z==0 then
       m.fine = false
     end
@@ -252,7 +253,6 @@ m.newfile = function(file)
     m.dir_prev = file:match("(.*/)")
     _menu.redraw()
   end
-  m.fine = false  
 end
 
 m.newtext = function(txt)

--- a/lua/core/menu/params.lua
+++ b/lua/core/menu/params.lua
@@ -252,6 +252,7 @@ m.newfile = function(file)
     m.dir_prev = file:match("(.*/)")
     _menu.redraw()
   end
+  m.fine = false  
 end
 
 m.newtext = function(txt)


### PR DESCRIPTION
Hope this is OK, I'm just getting familiar with lua and the norns source.

I noticed that if a script has file and number params, when you select a file parameter and come back out of the file selector the number params are much harder/slower to change. Fine value control is enabled when you go into the file selector but it isn't disabled when you come out.

This change disables fine control when coming out of the file selector.

