### PR TITLE
Fixed quantum not set when copying a ControlSpec

### DIFF
--- a/lua/core/controlspec.lua
+++ b/lua/core/controlspec.lua
@@ -150,6 +150,7 @@ function ControlSpec:copy()
   s.step = self.step
   s.default = self.default
   s.units = self.units
+  s.quantum = self.quantum
   return s
 end
 


### PR DESCRIPTION
The quantum property isn't set when copying a ControlSpec causing errors when trying to alter params that copy a ControlSpec.

This can be seen when trying to change any of the Vol properties in playfair.