### PR TITLE
Fix crone mixer

### DIFF
--- a/crone/CMakeLists.txt
+++ b/crone/CMakeLists.txt
@@ -1,6 +1,5 @@
 cmake_minimum_required(VERSION 3.7)
 project(crone VERSION 1.0.0)
-
 add_subdirectory(softcut/softcut-lib)
 
 set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
@@ -49,7 +48,7 @@ endif()
 
 
 set_target_properties(crone PROPERTIES
-CXX_STANDARD 14
+CXX_STANDARD 17
 CXX_STANDARD_REQUIRED YES
 CXX_EXTENSIONS YES
 )


### PR DESCRIPTION
fixes for dev branch:

- all level envelopes in mixer are working again (i think)
- filter modulation is working (including shapes, SR divisor)
- fiter cutoff now specified using MIDI note for pre- and post-filters