### PR TITLE
fixed clock documentation - stop should be cancel

### DIFF
--- a/doc/modules/clock.html
+++ b/doc/modules/clock.html
@@ -104,7 +104,7 @@
  must be called from within a coroutine started with clock.run.</td>
 	</tr>
 	<tr>
-	<td class="name" nowrap><a href="#stop">stop (coro_id)</a></td>
+	<td class="name" nowrap><a href="#cancel">cancel (coro_id)</a></td>
 	<td class="summary">stop execution of a coroutine started using clock.run.</td>
 	</tr>
 	<tr>
@@ -194,8 +194,8 @@
 
 </dd>
     <dt>
-    <a name = "stop"></a>
-    <strong>stop (coro_id)</strong>
+    <a name = "cancel"></a>
+    <strong>cancel (coro_id)</strong>
     </dt>
     <dd>
     stop execution of a coroutine started using clock.run.


### PR DESCRIPTION
Documentation for the clock module lists a 'stop' function but it should be 'cancel'