### PR TITLE
remove trailing carriage returns in script preview

### DIFF
--- a/lua/core/script.lua
+++ b/lua/core/script.lua
@@ -148,12 +148,12 @@ Script.load = function(filename)
     else
       print("### cleanup failed with error: "..err)
     end
-    
+
     -- unload asl package entry so `require 'asl'` works
     -- todo(pq): why is this not needed generally (e.g., for 'ui', 'util', etc.)?
     if package.loaded['asl'] ~= nil then
       package.loaded['asl'] = nil
-    end 
+    end
 
     Script.clear() -- clear script variables and functions
 
@@ -206,7 +206,9 @@ Script.metadata = function(filename)
     io.close(f)
     for line in io.lines(filename) do
       if util.string_starts(line,"--") then
-        table.insert(meta, string.sub(line,4,-1))
+        local skip_hyphens = string.sub(line,4,-1)
+        local fix_newlines = string.gsub(skip_hyphens,"\r$","")
+        table.insert(meta, fix_newlines)
       else
         if #meta == 0 then
           table.insert(meta, "no script information")


### PR DESCRIPTION
This is just a super minor irritation that arises due to my workflow -- if I'm SSHing from within emacs running on my windows machine, emacs decides to use windows line endings when I save a file, resulting in rectangles at the end of each line when viewing the script preview. The line endings don't make any functional difference besides this which is why I think stripping them here is reasonable, but it really should be something I'm able to fix on my end.... I have most certainly tried.