### PR TITLE
softcut: use event_render to set render callback

### DIFF
--- a/lua/core/softcut.lua
+++ b/lua/core/softcut.lua
@@ -365,10 +365,14 @@ SC.event_phase = function(func) _norns.softcut_phase = func end
 -- @tparam number start : beginning of region in seconds
 -- @tparam number dur : length of region in seconds
 -- @tparam integer samples : max number of samples to retrieve. if less than the number of frames in the region, content will be downsampled
--- @tparam function callback : called when buffer content is ready. args: (ch, start, sec_per_frame, samples)
-SC.render_buffer = function(ch, start, dur, samples, callback)
-  _norns.softcut_render = callback
+SC.render_buffer = function(ch, start, dur, samples)
   _norns.cut_buffer_render(ch, start, dur, samples)
+end
+
+--- set function for render callback. use render_buffer to request contents.
+-- @tparam function func : called when buffer content is ready. args: (ch, start, sec_per_sample, samples)
+SC.event_render = function(func)
+  _norns.softcut_render = func
 end
 
 


### PR DESCRIPTION
The previous Lua API for `buffer_render` made it difficult to use for requesting multiple buffer regions at roughly the same time, because the callback would get overwritten. This change just follows the same pattern as the phase poll, giving a separate function to set the callback.

FYI @okyeron -- I think you're maybe the only one besides me scripting with these functions so far.