### PR TITLE
skip unnecessary rsyslog removal

### DIFF
--- a/update/update.sh
+++ b/update/update.sh
@@ -63,7 +63,10 @@ fi
 
 # logs
 sudo rm -rf /var/log/*
-sudo apt-get remove -y rsyslog
+RSYSLOG_INSTALL=`dpkg -l | grep rsyslog | grep ^ii`
+if [ "$RSYSLOG_INSTALL" ]; then
+    sudo apt-get remove -y rsyslog
+fi
 
 # maiden project setup
 cd /home/we/maiden

--- a/update/update.sh
+++ b/update/update.sh
@@ -63,7 +63,7 @@ fi
 
 # logs
 sudo rm -rf /var/log/*
-RSYSLOG_INSTALL=`dpkg -l | grep rsyslog | grep ^ii`
+RSYSLOG_INSTALL=$(dpkg -l | grep rsyslog | grep ^ii)
 if [ "$RSYSLOG_INSTALL" ]; then
     sudo apt-get remove -y rsyslog
 fi


### PR DESCRIPTION
This fix removes rsyslog only if installed. This way the update script output is less confusing.

Inspired by [this post](https://llllllll.co/t/norns-file-structure-update-question/35859)