### PR TITLE
only map events from devices with vport assignment

### DIFF
--- a/lua/core/midi.lua
+++ b/lua/core/midi.lua
@@ -396,12 +396,13 @@ _norns.midi.event = function(id, data)
       d.event(data)
     end
 
-    if d.port and Midi.vports[d.port].event then
-      Midi.vports[d.port].event(data)
+    if d.port then
+      if Midi.vports[d.port].event then
+        Midi.vports[d.port].event(data)
+      end
+      -- hack = send all midi to menu for param-cc-map
+      norns.menu_midi_event(data, d.port)
     end
-
-    -- hack = send all midi to menu for param-cc-map
-    norns.menu_midi_event(data, d.port)
   else
     error('no entry for midi '..id)
   end


### PR DESCRIPTION
matron posts midi data (from the device level) as soon as a device is attached regardless of whether or not the device is associated with a vport (which are only know to lua). the midi mapping logic provided by the menu tracks mapping assignments by vport (correct?)

this change ensures that the midi mapping logic is **_only_** provided events from devices with vport assignments. the previous logic would generate stack traces when midi from devices without port assignments is received.