### PR TITLE
allow parameter mapping to be disabled

### DIFF
--- a/lua/core/menu/params.lua
+++ b/lua/core/menu/params.lua
@@ -184,7 +184,7 @@ m.key = function(n,z)
           params:delta(i, 1)
           m.toggled[i] = params:get(i) and 1 or 0
         end
-      elseif m.mode == mMAP then
+      elseif m.mode == mMAP and params:get_allow_pmap(i) then
         local n = params:get_id(i)
         local pm = norns.pmap.data[n]
         if pm == nil then
@@ -430,10 +430,12 @@ m.redraw = function()
               t == params.tCONTROL or
               t == params.tOPTION then
             local pm=norns.pmap.data[id]
-            if pm then
-              screen.text_right(pm.cc..":"..pm.ch..":"..pm.dev)
-            else
-              screen.text_right("-")
+            if params:get_allow_pmap(p) then
+              if pm then
+                screen.text_right(pm.cc..":"..pm.ch..":"..pm.dev)
+              else
+                screen.text_right("-")
+              end
             end
           end
         end

--- a/lua/core/params/control.lua
+++ b/lua/core/params/control.lua
@@ -13,7 +13,7 @@ local tCONTROL = 3
 -- @param name
 -- @param controlspec
 -- @param formatter
-function Control.new(id, name, controlspec, formatter)
+function Control.new(id, name, controlspec, formatter, allow_pmap)
   local p = setmetatable({}, Control)
   p.t = tCONTROL
   if not controlspec then controlspec = ControlSpec.UNIPOLAR end
@@ -22,6 +22,7 @@ function Control.new(id, name, controlspec, formatter)
   p.controlspec = controlspec
   p.formatter = formatter
   p.action = function(x) end
+  if allow_pmap == nil then p.allow_pmap = true else p.allow_pmap = allow_pmap end
 
   if controlspec.default then
     p.raw = controlspec:unmap(controlspec.default)

--- a/lua/core/params/number.lua
+++ b/lua/core/params/number.lua
@@ -6,7 +6,7 @@ Number.__index = Number
 
 local tNUMBER = 1
 
-function Number.new(id, name, min, max, default, formatter, wrap)
+function Number.new(id, name, min, max, default, formatter, wrap, allow_pmap)
   local o = setmetatable({}, Number)
   o.t = tNUMBER
   o.id = id
@@ -19,6 +19,7 @@ function Number.new(id, name, min, max, default, formatter, wrap)
   o.formatter = formatter
   o.action = function() end
   o.wrap = wrap and o.range ~= 0 or false
+  if allow_pmap == nil then o.allow_pmap = true else o.allow_pmap = allow_pmap end
   return o
 end
 

--- a/lua/core/params/option.lua
+++ b/lua/core/params/option.lua
@@ -8,7 +8,7 @@ Option.__index = Option
 
 local tOPTION = 2
 
-function Option.new(id, name, options, default)
+function Option.new(id, name, options, default, allow_pmap)
   local o = setmetatable({}, Option)
   o.t = tOPTION
   o.id = id
@@ -21,6 +21,7 @@ function Option.new(id, name, options, default)
   o.default = default or 1
   o.selected = o.default
   o.action = function() end
+  if allow_pmap == nil then o.allow_pmap = true else o.allow_pmap = allow_pmap end
   return o
 end
 

--- a/lua/core/paramset.lua
+++ b/lua/core/paramset.lua
@@ -95,11 +95,11 @@ function ParamSet:add(args)
     local name = args.name or id
 
     if args.type == "number"  then
-      param = number.new(id, name, args.min, args.max, args.default, args.formatter, args.wrap)
+      param = number.new(id, name, args.min, args.max, args.default, args.formatter, args.wrap, args.allow_pmap)
     elseif args.type == "option" then
-      param = option.new(id, name, args.options, args.default)
+      param = option.new(id, name, args.options, args.default, args.allow_pmap)
     elseif args.type == "control" then
-      param = control.new(id, name, args.controlspec, args.formatter)
+      param = control.new(id, name, args.controlspec, args.formatter, args.allow_pmap)
     elseif args.type == "file" then
       param = file.new(id, name, args.path)
     elseif args.type == "taper" then
@@ -308,6 +308,14 @@ function ParamSet:get_range(index)
   return param:get_range()
 end
 
+--- get whether or not parameter should be pmap'able
+-- @param index
+function ParamSet:get_allow_pmap(index)
+  local param = self:lookup_param(index)
+  local allow = param.allow_pmap
+  if param == nil then return true end
+  return allow
+end
 
 --- set visibility to hidden.
 -- @param index


### PR DESCRIPTION
some script parameters may not be suitable for live
manipulation via mapped midi controller. this change
adds an optional `allow_pmap` property to `Control`,
`Option`, and `Number` parameter types.

the `get_allow_pmap(...)` method on `ParamSet` will
return the property if set on the param otherwise it will
return `true` in order to retain existing behavior.

the menu code was changed to prevent access to the
MAPEDIT menu unless the `get_allow_pmap(...)` is `true`.