### PR TITLE
clamp more parameters, tidy and refactor

### DIFF
--- a/crone/src/SoftcutClient.cpp
+++ b/crone/src/SoftcutClient.cpp
@@ -9,19 +9,19 @@
 #include "SoftcutClient.h"
 
 // clamp to upper bound (unsigned int)
-static inline void clamp(size_t &x, const size_t a) {
-    if (x > a) { x = a; }
+static inline void clamp(size_t &x, const size_t max) {
+    if (x > a) { x = max; }
 }
 
 // clamp to upper bound (float)
-static inline void clamp(float &x, const float a) {
-    x = std::min(a, x);
+static inline void clamp(float &x, const float max) {
+    x = std::min(max, x);
 }
 
 
 // clamp to lower and upper bounds (float)
-static inline void clamp(float &x, const float a, const float b) {
-    x = std::min(a, std::max(b, x));
+static inline void clamp(float &x, const float min, const float max) {
+    x = std::max(min, std::min(max, x));
 }
 
 crone::SoftcutClient::SoftcutClient() : Client<2, 2>("softcut") {

--- a/crone/src/SoftcutClient.cpp
+++ b/crone/src/SoftcutClient.cpp
@@ -8,10 +8,20 @@
 #include "Commands.h"
 #include "SoftcutClient.h"
 
-
-// clamp unsigned int to upper bound, inclusive
+// clamp to upper bound (unsigned int)
 static inline void clamp(size_t &x, const size_t a) {
     if (x > a) { x = a; }
+}
+
+// clamp to upper bound (float)
+static inline void clamp(float &x, const float a) {
+    x = std::min(a, x);
+}
+
+
+// clamp to lower and upper bounds (float)
+static inline void clamp(float &x, const float a, const float b) {
+    x = std::min(a, std::max(b, x));
 }
 
 crone::SoftcutClient::SoftcutClient() : Client<2, 2>("softcut") {
@@ -72,135 +82,146 @@ void crone::SoftcutClient::mixOutput(size_t numFrames) {
 }
 
 void crone::SoftcutClient::handleCommand(Commands::CommandPacket *p) {
+    size_t idx_0 = p->idx_0;
+    size_t idx_1 = p->idx_1;
     float value = p->value;
+    clamp(idx_0, NumVoices-1);
     switch (p->id) {
         //-- softcut routing
     case Commands::Id::SET_ENABLED_CUT:
-	enabled[p->idx_0] = value > 0.f;
+	enabled[idx_0] = value > 0.f;
 	break;
     case Commands::Id::SET_LEVEL_CUT:
-	outLevel[p->idx_0].setTarget(value);
+	outLevel[idx_0].setTarget(value);
 	break;;
     case Commands::Id::SET_PAN_CUT:
-	outPan[p->idx_0].setTarget((value/2)+0.5); // map -1,1 to 0,1
+	clamp(value, -1.f, 1.f);
+	outPan[idx_0].setTarget((value/2)+0.5);
 	break;
     case Commands::Id::SET_LEVEL_IN_CUT:
-	inLevel[p->idx_0][p->idx_1].setTarget(value);
+	clamp(idx_1, NumVoices-1);
+	inLevel[idx_0][idx_1].setTarget(value);
 	break;
     case Commands::Id::SET_LEVEL_CUT_CUT:
-	fbLevel[p->idx_0][p->idx_1].setTarget(value);
+	clamp(idx_1, NumVoices-1);
+	fbLevel[idx_0][idx_1].setTarget(value);
 	break;
 	//-- softcut commands
     case Commands::Id::SET_CUT_RATE:
-	cut.setRate(p->idx_0, value);
+	clamp(value, MinRate, MaxRate);
+	cut.setRate(idx_0, value);
 	break;
     case Commands::Id::SET_CUT_LOOP_START:
-	value = std::min(bufDur, std::max(0.f, value));
-	cut.setLoopStart(p->idx_0, value);
+	clamp(value, 0.f, bufDur);
+	cut.setLoopStart(idx_0, value);
 	break;
     case Commands::Id::SET_CUT_LOOP_END:
-	value = std::min(bufDur, std::max(0.f, value));
-	cut.setLoopEnd(p->idx_0, value);
+	clamp(value, 0.f, bufDur);
+	cut.setLoopEnd(idx_0, value);
 	break;
     case Commands::Id::SET_CUT_LOOP_FLAG:
-	cut.setLoopFlag(p->idx_0, value > 0.f);
+	cut.setLoopFlag(idx_0, value > 0.f);
 	break;
     case Commands::Id::SET_CUT_FADE_TIME:
-	cut.setFadeTime(p->idx_0, value);
+	value = std::max(0.f, value);
+	cut.setFadeTime(idx_0, value);
 	break;
     case Commands::Id::SET_CUT_REC_LEVEL:
-	cut.setRecLevel(p->idx_0, value);
+	cut.setRecLevel(idx_0, value);
 	break;
     case Commands::Id::SET_CUT_PRE_LEVEL:
-	cut.setPreLevel(p->idx_0, value);
+	cut.setPreLevel(idx_0, value);
 	break;
     case Commands::Id::SET_CUT_REC_FLAG:
-	cut.setRecFlag(p->idx_0, value > 0.f);
+	cut.setRecFlag(idx_0, value > 0.f);
 	break;
     case Commands::Id::SET_CUT_PLAY_FLAG:
-	cut.setPlayFlag(p->idx_0, value > 0.f);
+	cut.setPlayFlag(idx_0, value > 0.f);
 	break;
     case Commands::Id::SET_CUT_REC_OFFSET:
 	value = std::min(bufDur, std::max(0.f, value));
-	cut.setRecOffset(p->idx_0, value);
+	cut.setRecOffset(idx_0, value);
 	break;
     case Commands::Id::SET_CUT_POSITION:
-	value = std::min(bufDur, std::max(0.f, value));
-	cut.cutToPos(p->idx_0, value);
+	clamp(value, 0.f, bufDur);
+	cut.cutToPos(idx_0, value);
 	break;
 	// input filter
     case Commands::Id::SET_CUT_PRE_FILTER_FC:
-	cut.setPreFilterFc(p->idx_0, value);
+	clamp(value, 10.f, 12000.f);
+	cut.setPreFilterFc(idx_0, value);
 	break;
     case Commands::Id::SET_CUT_PRE_FILTER_FC_MOD:
-	value = std::min(1.f, std::max(0.f, value));
-	cut.setPreFilterFcMod(p->idx_0, value);
+	clamp(value, 0.f, 1.f);
+	cut.setPreFilterFcMod(idx_0, value);
 	break;
     case Commands::Id::SET_CUT_PRE_FILTER_RQ:
-	value = std::min(20.f, std::max(0.0001f, value));
-	cut.setPreFilterRq(p->idx_0, value);
+	clamp(value, 0.0001f, 20.f);
+	cut.setPreFilterRq(idx_0, value);
 	break;
     case Commands::Id::SET_CUT_PRE_FILTER_LP:
-	cut.setPreFilterLp(p->idx_0, value);
+	cut.setPreFilterLp(idx_0, value);
 	break;
     case Commands::Id::SET_CUT_PRE_FILTER_HP:
-	cut.setPreFilterHp(p->idx_0, value);
+	cut.setPreFilterHp(idx_0, value);
 	break;
     case Commands::Id::SET_CUT_PRE_FILTER_BP:
-	cut.setPreFilterBp(p->idx_0, value);
+	cut.setPreFilterBp(idx_0, value);
 	break;
     case Commands::Id::SET_CUT_PRE_FILTER_BR:
-	cut.setPreFilterBr(p->idx_0, value);
+	cut.setPreFilterBr(idx_0, value);
 	break;
     case Commands::Id::SET_CUT_PRE_FILTER_DRY:
-	cut.setPreFilterDry(p->idx_0, value);
+	cut.setPreFilterDry(idx_0, value);
 	break;
 	// -- output filter
     case Commands::Id::SET_CUT_POST_FILTER_FC:
-	value = std::min(12000.f, std::max(10.f, value));
-	cut.setPostFilterFc(p->idx_0, value);
+	clamp(value, 10.f, 12000.f);
+	cut.setPostFilterFc(idx_0, value);
 	break;
     case Commands::Id::SET_CUT_POST_FILTER_RQ:
-	value = std::min(20.f, std::max(0.0001f, value));		
-	cut.setPostFilterRq(p->idx_0, value);
+	clamp(value, 0.0001f, 20.f);
+	cut.setPostFilterRq(idx_0, value);
 	break;
     case Commands::Id::SET_CUT_POST_FILTER_LP:
-	cut.setPostFilterLp(p->idx_0, value);
+	cut.setPostFilterLp(idx_0, value);
 	break;
     case Commands::Id::SET_CUT_POST_FILTER_HP:
-	cut.setPostFilterHp(p->idx_0, value);
+	cut.setPostFilterHp(idx_0, value);
 	break;
     case Commands::Id::SET_CUT_POST_FILTER_BP:
-	cut.setPostFilterBp(p->idx_0, value);
+	cut.setPostFilterBp(idx_0, value);
 	break;
     case Commands::Id::SET_CUT_POST_FILTER_BR:
-	cut.setPostFilterBr(p->idx_0, value);
+	cut.setPostFilterBr(idx_0, value);
 	break;
     case Commands::Id::SET_CUT_POST_FILTER_DRY:
-	cut.setPostFilterDry(p->idx_0, value);
+	cut.setPostFilterDry(idx_0, value);
 	break;
 
     case Commands::Id::SET_CUT_LEVEL_SLEW_TIME:
 	value = std::max(0.f, value);
-	outLevel[p->idx_0].setTime(value);
+	outLevel[idx_0].setTime(value);
 	break;
     case Commands::Id::SET_CUT_PAN_SLEW_TIME:
 	value = std::max(0.f, value);
-	outPan[p->idx_0].setTime(value);
+	outPan[idx_0].setTime(value);
 	break;
     case Commands::Id::SET_CUT_RECPRE_SLEW_TIME:
 	value = std::max(0.f, value);
-	cut.setRecPreSlewTime(p->idx_0, value);
+	cut.setRecPreSlewTime(idx_0, value);
 	break;
     case Commands::Id::SET_CUT_RATE_SLEW_TIME:
 	value = std::max(0.f, value);
-	cut.setRateSlewTime(p->idx_0, value);
+	cut.setRateSlewTime(idx_0, value);
 	break;
     case Commands::Id::SET_CUT_VOICE_SYNC:
-	cut.syncVoice(p->idx_0, p->idx_1, value);
+	clamp(idx_1, NumVoices-1);
+	cut.syncVoice(idx_0, idx_1, value);
 	break;
     case Commands::Id::SET_CUT_BUFFER:
-	cut.setVoiceBuffer(p->idx_0, buf[std::max(0, std::min(p->idx_1, NumVoices-1))], BufFrames);
+	clamp(idx_1, NumBuffers - 1);
+	cut.setVoiceBuffer(idx_0, buf[idx_1], BufFrames);
 	break;
     default:;;
     }

--- a/crone/src/SoftcutClient.h
+++ b/crone/src/SoftcutClient.h
@@ -18,9 +18,12 @@
 namespace crone {
     class SoftcutClient: public Client<2, 2> {
     public:
+        static constexpr float MaxRate = static_cast<float>(softcut::Resampler::OUT_BUF_FRAMES);
+        static constexpr float MinRate = static_cast<float>(softcut::Resampler::OUT_BUF_FRAMES * -1);
         enum { MaxBlockFrames = 2048};
         enum { BufFrames = 16777216 };
         enum { NumVoices = 6 };
+	enum { NumBuffers = 2 };
         typedef enum { SourceAdc=0 } SourceId;
         typedef Bus<2, MaxBlockFrames> StereoBus;
         typedef Bus<1, MaxBlockFrames> MonoBus;
@@ -31,9 +34,9 @@ namespace crone {
         // processors
         softcut::Softcut<NumVoices> cut;
         // main buffer
-        float buf[2][BufFrames];
+        float buf[NumBuffers][BufFrames];
         // buffer index for use with BufDiskWorker
-        int bufIdx[2];
+        int bufIdx[NumBuffers];
         // busses
         StereoBus mix;
         MonoBus input[NumVoices];


### PR DESCRIPTION
clamp more softcut parameters, including Rate and voice/buffer indices. (in theory, i think it was possible to crash or smash memory by sending OOB indices.)

also some small refactoring for DRY and to avoid magic numbers.

like the last PR, this is not really tested except for compilation.