### PR TITLE
avoid monitoring device types without device files

### DIFF
--- a/matron/src/device/device_common.h
+++ b/matron/src/device/device_common.h
@@ -9,13 +9,17 @@ typedef enum {
     DEV_TYPE_HID = 1,
     // raw midi devices
     DEV_TYPE_MIDI = 2,
-    DEV_TYPE_MIDI_VIRTUAL = 3,
     // usbmodem (crow)
-    DEV_TYPE_CROW = 4,
+    DEV_TYPE_CROW = 3,
+    // place all virtual devices (devices without device files to monitor) below
+    DEV_TYPE_MIDI_VIRTUAL = 4,
     // counter - unused, don't remove
     DEV_TYPE_COUNT,
     DEV_TYPE_INVALID
 } device_t;
+
+// maximum device_t value for devices which have corresponding device files
+#define DEV_TYPE_COUNT_PHYSICAL 4
 
 struct dev_common {
     // device type


### PR DESCRIPTION
fixes a bug in cac8479fcc where crow devices were
mapped to the virtual midi device type (which has no
corresponding device file to watch for) because the
device pattern watch list did not match the order of
the `device_t` enum values.

fixes #1217 