### PR TITLE
create tape dir on record, if the user has deleted it

### DIFF
--- a/lua/core/menu/tape.lua
+++ b/lua/core/menu/tape.lua
@@ -63,8 +63,16 @@ local function update_tape_index()
   end
 
   local f = io.open(_path.tape..'index.txt','w')
-  f:write(tostring(m.fileindex+1))
-  f:close()
+  if f == nil then
+    os.execute("mkdir -p ".._path.tape)
+    f = io.open(_path.tape..'index.txt','w')
+  end
+  if f == nil then
+    print("WARNING: couldn't write index file, even after creating `tape/`")
+  else
+    f:write(tostring(m.fileindex+1))
+    f:close()
+  end
 end
 
 local function edit_filename(txt)


### PR DESCRIPTION
not sure if this is really desired, but:

- currently, there is a check for `nil` file handle to `audio/tape/index.txt` when reading to increment tape filename.
- however, there is no analogous check for `nil` when writing to the same file a few lines later.

it is possible to run into this if a user deletes their `audio/` or `audio/tape/`. (why would they do this? don't ask me. but it happened and this burned some support time.)

so this change creates `~/dust/audio/tape/` and parents before writing the index file, if the initial attempt results in a `nil` handle.