### PR TITLE
don't clamp the record offset parameter

### DIFF
--- a/crone/src/SoftcutClient.cpp
+++ b/crone/src/SoftcutClient.cpp
@@ -139,7 +139,6 @@ void crone::SoftcutClient::handleCommand(Commands::CommandPacket *p) {
 	cut.setPlayFlag(idx_0, value > 0.f);
 	break;
     case Commands::Id::SET_CUT_REC_OFFSET:
-	value = std::min(bufDur, std::max(0.f, value));
 	cut.setRecOffset(idx_0, value);
 	break;
     case Commands::Id::SET_CUT_POSITION:


### PR DESCRIPTION
`rec_offset` was being erroneously clamped to non-negative values.

now it is not clamped at all. (the final read/write indices are always wrapped to the buffer size anyways.)