### PR TITLE
fix removal funcs

### DIFF
--- a/lua/core/arc.lua
+++ b/lua/core/arc.lua
@@ -192,12 +192,13 @@ _norns.arc.add = function(id, serial, name, dev)
 end
 
 _norns.arc.remove = function(id)
-  if Arc.devices[id] then
-    if Arc.remove ~= nil then
-      Arc.remove(Arc.devices[id])
+  local g = Arc.devices[id]
+  if g then
+    if Arc.vports[g.port].remove then
+      Arc.vports[g.port].remove()
     end
-    if Arc.devices[id].remove then
-      Arc.devices[id].remove()
+    if Arc.remove then
+      Arc.remove(Arc.devices[id])
     end
   end
   Arc.devices[id] = nil

--- a/lua/core/grid.lua
+++ b/lua/core/grid.lua
@@ -171,12 +171,13 @@ end
 
 -- grid remove
 _norns.grid.remove = function(id)
-  if Grid.devices[id] then
-    if Grid.remove ~= nil then
-      Grid.remove(Grid.devices[id])
+  local g = Grid.devices[id]
+  if g then
+    if Grid.vports[g.port].remove then
+      Grid.vports[g.port].remove()
     end
-    if Grid.devices[id].remove then
-      Grid.devices[id].remove()
+    if Grid.remove then
+      Grid.remove(Grid.devices[id])
     end
   end
   Grid.devices[id] = nil


### PR DESCRIPTION
fixes #1220 for specific device removals

note that global device removals was working fine (ie redefining `grid.remove` instead `g.remove`)