### PR TITLE
Cleanup engine deinit

### DIFF
--- a/crone/src/SoftcutClient.cpp
+++ b/crone/src/SoftcutClient.cpp
@@ -139,7 +139,6 @@ void crone::SoftcutClient::handleCommand(Commands::CommandPacket *p) {
 	cut.setPlayFlag(idx_0, value > 0.f);
 	break;
     case Commands::Id::SET_CUT_REC_OFFSET:
-	value = std::min(bufDur, std::max(0.f, value));
 	cut.setRecOffset(idx_0, value);
 	break;
     case Commands::Id::SET_CUT_POSITION:

--- a/lua/core/menu/home.lua
+++ b/lua/core/menu/home.lua
@@ -23,6 +23,7 @@ m.key = function(n,z)
       _menu.set_page(m.list[m.pos])
     else
       norns.script.clear()
+      _norns.free_engine()
     end
   end
 end

--- a/lua/core/menu/home.lua
+++ b/lua/core/menu/home.lua
@@ -24,7 +24,7 @@ m.key = function(n,z)
     else
       norns.script.clear()
       _norns.free_engine()
-
+      _menu.locked = true
     end
   end
 end

--- a/sc/core/Crone.sc
+++ b/sc/core/Crone.sc
@@ -107,7 +107,7 @@ Crone {
 					postln("free engine: " ++ engine);
 					engine.deinit({ cond.test = true; cond.signal; });
 					cond.wait;
-
+					engine = nil;
 				});
 				class.new(context, {
 					arg theEngine;
@@ -245,7 +245,15 @@ Crone {
 
 			// @function /engine/free
 			'/engine/free':OSCFunc.new({
-				if(engine.notNil, { engine.deinit; });
+				fork {
+					if(engine.notNil, {
+						var cond = Condition.new(false);
+						postln("free engine: " ++ engine);
+						engine.deinit({ cond.test = true; cond.signal; });
+						cond.wait;
+						engine = nil;
+					});
+				}
 			}, '/engine/free'),
 
 			// @function /engine/load/name


### PR DESCRIPTION
another pass at #1215, now correctly handling more cases for explicit engine deallocation from lua.