### PR TITLE
paramset default between sessions

### DIFF
--- a/lua/core/menu.lua
+++ b/lua/core/menu.lua
@@ -24,7 +24,7 @@ _menu.panel = 3
 _menu.panels = {"MIX", "TAPE", "HOME", "PARAMS"}
 _menu.alt = false
 _menu.scripterror = false
-_menu.locked = true
+_menu.locked = false
 _menu.errormsg = ""
 _menu.shownav = false
 _menu.showstats = false
@@ -218,4 +218,6 @@ m["UPDATE"] = require 'core/menu/update'
 m["SLEEP"] = require 'core/menu/sleep'
 m["MIX"] = require 'core/menu/mix'
 m["TAPE"] = require 'core/menu/tape'
+
+_menu.set_mode(true)
 

--- a/lua/core/menu/params.lua
+++ b/lua/core/menu/params.lua
@@ -40,7 +40,7 @@ m.reset = function()
   m.ps_pos = 0
   m.ps_n = 0
   m.ps_action = 1
-  m.ps_last = 0
+  m.ps_last = norns.state.pset_last
   m.mode = mSELECT
 end
 
@@ -99,11 +99,21 @@ local function init_pset()
   norns.system_cmd('ls -1 '..norns.state.data..norns.state.shortname..'*.pset | sort', pset_list)
 end
 
+local function write_pset_last(x)
+  local file = norns.state.data.."pset-last.txt"
+  local f = io.open(file,"w")
+  io.output(f)
+  io.write(x)
+  io.close(f)
+end
+
 local function write_pset(name)
   if name then
+    local i = m.ps_pos+1
     if name == "" then name = params.name end
-    params:write(m.ps_pos+1,name)
-    m.ps_last = m.ps_pos+1
+    params:write(i,name)
+    m.ps_last = i
+    write_pset_last(i) -- save last pset loaded
     init_pset()
     norns.pmap.write() -- write parameter map too
   end

--- a/lua/core/menu/params.lua
+++ b/lua/core/menu/params.lua
@@ -105,6 +105,7 @@ local function write_pset_last(x)
   io.output(f)
   io.write(x)
   io.close(f)
+  norns.state.pset_last = x
 end
 
 local function write_pset(name)
@@ -256,9 +257,11 @@ m.key = function(n,z)
         textentry.enter(write_pset, txt, "PSET NAME: "..m.ps_pos+1)
         -- load
       elseif m.ps_action == 2 then
-        if pset[m.ps_pos+1] then
-          params:read(m.ps_pos+1)
-          m.ps_last = m.ps_pos+1
+        local i = m.ps_pos+1
+        if pset[i] then
+          params:read(i)
+          m.ps_last = i
+          write_pset_last(i) -- save last pset loaded
         end
         -- delete
       elseif m.ps_action == 3 then

--- a/lua/core/paramset.lua
+++ b/lua/core/paramset.lua
@@ -383,9 +383,9 @@ function ParamSet:write(filename, name)
 end
 
 --- read from disk.
--- @param filename either an absolute path, number (to read [scriptname]-[number].pset from local data folder) or nil (to read default [scriptname]-01.pset from local data folder)
+-- @param filename either an absolute path, number (to read [scriptname]-[number].pset from local data folder) or nil (to read pset number specified by pset-last.txt in the data folder)
 function ParamSet:read(filename)
-  filename = filename or 1
+  filename = filename or norns.state.pset_last
   if type(filename) == "number" then
     local n = filename
     filename = norns.state.data .. norns.state.shortname

--- a/lua/core/script.lua
+++ b/lua/core/script.lua
@@ -106,6 +106,8 @@ Script.init = function()
   _norns.screen_save()
 end
 
+
+
 --- load a script from the /scripts folder.
 -- @tparam string filename file to load. leave blank to reload current file.
 Script.load = function(filename)
@@ -167,6 +169,22 @@ Script.load = function(filename)
     if util.file_exists(norns.state.data) == false then
       print("### initializing data folder")
       util.make_dir(norns.state.data)
+      if util.file_exists(norns.state.path.."/data") then
+        os.execute("cp "..norns.state.path.."/data/*.pset "..norns.state.data)
+        print("### copied default psets")
+      end
+    end
+
+    local file = norns.state.data.."pset-last.txt"
+    if util.file_exists(file) then
+      local f = io.open(file,"r")
+      io.input(f)
+      local i = io.read("*line")
+      io.close(f)
+      print("pset last used: "..i)
+      norns.state.pset_last = tonumber(i)
+    else
+      norns.state.pset_last = 1
     end
 
     local status = norns.try(function() dofile(filename) end, "load fail") -- do the new script
@@ -219,6 +237,7 @@ Script.metadata = function(filename)
   end
   return meta
 end
+
 
 
 return Script

--- a/lua/core/script.lua
+++ b/lua/core/script.lua
@@ -165,6 +165,7 @@ Script.load = function(filename)
     norns.state.path = path .. '/'
     norns.state.lib = path .. '/lib/'
     norns.state.data = _path.data .. name .. '/'
+    norns.state.pset_last = 1
 
     if util.file_exists(norns.state.data) == false then
       print("### initializing data folder")
@@ -181,10 +182,10 @@ Script.load = function(filename)
       io.input(f)
       local i = io.read("*line")
       io.close(f)
-      print("pset last used: "..i)
-      norns.state.pset_last = tonumber(i)
-    else
-      norns.state.pset_last = 1
+      if i then
+        print("pset last used: "..i)
+        norns.state.pset_last = tonumber(i)
+      end
     end
 
     local status = norns.try(function() dofile(filename) end, "load fail") -- do the new script


### PR DESCRIPTION
remember last used pset per script, and if `init` contains `params:read()` (no args) it will load last pset, which is stored in `norns.state.last_pset` and the file is `dust/data/(SCRIPT)/pset-last.txt

fixes #1123 (the primary request at least... the other part is a more complex ask)