### PR TITLE
add midi mapping to binary param

### DIFF
--- a/lua/core/menu/params.lua
+++ b/lua/core/menu/params.lua
@@ -179,13 +179,6 @@ m.key = function(n,z)
           params:set(i)
           m.triggered[i] = 2
         end
-      elseif t == params.tBINARY then
-        if m.mode == mEDIT then
-          params:delta(i, 1)
-          if params:lookup_param(i).behavior == 'trigger' then
-            m.triggered[i] = 2
-          else m.on[i] = params:get(i) end
-        end
       elseif m.mode == mMAP and params:get_allow_pmap(i) then
         local n = params:get_id(i)
         local pm = norns.pmap.data[n]
@@ -193,7 +186,7 @@ m.key = function(n,z)
           norns.pmap.new(n)
           pm = norns.pmap.data[n]
           local t = params:t(i)
-          if t == params.tNUMBER or t == params.tOPTION then
+          if t == params.tNUMBER or t == params.tOPTION or t== params.tBINARY then
             local r = params:get_range(i)
             pm.out_lo = r[1]
             pm.out_hi = r[2]
@@ -439,6 +432,7 @@ m.redraw = function()
           screen.move(127,10*i)
           if t ==  params.tNUMBER or
               t == params.tCONTROL or
+              t == params.tBINARY or
               t == params.tOPTION then
             local pm=norns.pmap.data[id]
             if params:get_allow_pmap(p) then
@@ -612,6 +606,8 @@ norns.menu_midi_event = function(data, dev)
         elseif t == params.tNUMBER or t == params.tOPTION then
           s = util.round(s)
           params:set(r,s)
+        elseif t == params.tBINARY then 
+            params:delta(r,s)
         end
         if _menu.mode then _menu.redraw() end
       end

--- a/lua/core/menu/params.lua
+++ b/lua/core/menu/params.lua
@@ -179,6 +179,11 @@ m.key = function(n,z)
           params:set(i)
           m.triggered[i] = 2
         end
+      elseif t == params.tBINARY and m.mode == mEDIT then 
+        params:delta(i,1)
+        if params:lookup_param(i).behavior == 'trigger' then 
+          m.triggered[i] = 2
+        else m.on[i] = params:get(i) end
       elseif m.mode == mMAP and params:get_allow_pmap(i) then
         local n = params:get_id(i)
         local pm = norns.pmap.data[n]
@@ -562,7 +567,11 @@ m.init = function()
   end
   m.on = {}
   for i,param in ipairs(params.params) do
-    if param.t == params.tBINARY and (param.value == 1) then m.on[i] = 1 end
+    if param.t == params.tBINARY then
+        if params:lookup_param(i).behavior == 'trigger' then 
+          m.triggered[i] = 2
+        else m.on[i] = params:get(i) end
+    end
   end
   _menu.timer.time = 0.2
   _menu.timer.count = -1
@@ -607,7 +616,16 @@ norns.menu_midi_event = function(data, dev)
           s = util.round(s)
           params:set(r,s)
         elseif t == params.tBINARY then 
-            params:delta(r,s)
+          params:delta(r,s)
+          if _menu.mode then 
+            for i,param in ipairs(params.params) do
+              if params:lookup_param(i).behavior == params:lookup_param(r).behavior then 
+                if params:lookup_param(i).behavior == 'trigger' then 
+                  m.triggered[i] = 2
+                else m.on[i] = params:get(i) end
+              end
+            end
+          end
         end
         if _menu.mode then _menu.redraw() end
       end

--- a/lua/core/params/binary.lua
+++ b/lua/core/params/binary.lua
@@ -6,7 +6,7 @@ Binary.__index = Binary
 
 local tBINARY = 9
 
-function Binary.new(id, name, behavior, default)
+function Binary.new(id, name, behavior, default, allow_pmap)
   local o = setmetatable({}, Binary)
   o.t = tBINARY
   o.id = id
@@ -15,6 +15,7 @@ function Binary.new(id, name, behavior, default)
   o.value = o.default
   o.behavior = behavior or 'trigger'
   o.action = function() end
+  if allow_pmap == nil then o.allow_pmap = true else o.allow_pmap = allow_pmap end
   return o
 end
 
@@ -36,7 +37,9 @@ function Binary:delta(d)
     self:set(d)
   elseif self.behavior == 'toggle' then
     if d ~= 0 then self:set((self.value == 0) and 1 or 0) end
-  else self:bang() end  
+  elseif d~=0 then 
+    self:bang() 
+  end  
 end
 
 function Binary:set_default()
@@ -51,5 +54,8 @@ function Binary:string()
    return self.value
 end
 
+function Binary:get_range()
+   return {0,1}
+end
 
 return Binary

--- a/lua/core/paramset.lua
+++ b/lua/core/paramset.lua
@@ -107,7 +107,7 @@ function ParamSet:add(args)
     elseif args.type == "trigger" then
       param = trigger.new(id, name)
     elseif args.type == "binary" then
-      param = binary.new(id, name, args.behavior, args.default)
+      param = binary.new(id, name, args.behavior, args.default, args.allow_pmap)
     elseif args.type == "text" then
       param = text.new(id, name, args.text)
     else


### PR DESCRIPTION
i wanted to be able to map triggers to midi keys from a keyboard. @tehn suggested building off @andr-ew's "binary" parameter which does exactly what i need (and more!). it was so lovely to discover that this was extermely easy to do - only took about 45 minutes (including learning the codebase)! 

so here is my patch, which accomplishes this mapping to midi using the binary parameter. built off of and tested with script from @andr-ew (below).

i've never submitted a patch to norns before, i'm happy to follow guidance to make this kosher.

```lu
-- param test test

cs = require 'controlspec'

px = 48
py = 16

function init()
  params:add{ type='binary', id='tog', behavior='toggle', allow_pmap=true, action=function(v) print('tog: ' .. tostring(v)) redraw()  end }
  params:add{ type='binary', id='mom', behavior='momentary', action=function(v) print('mom: ' .. tostring(v)) redraw()  end }
  params:add{ type='binary', id='trig', behavior='trigger', action=function(v) print('trig: ' .. tostring(v)) redraw() end }

  redraw()
end

function key(n, z)
  if n==1 and z==1 then
    params:delta('trig', z)
  elseif n==2 and z==1 then
    params:delta('tog', z)
  elseif n==3 then
    params:delta('mom', z)
  end
  redraw()
end

function redraw()
  screen.move(py + px, py)
  screen.level(15)
  screen.text('trig')
  screen.move(py, py * 2)
  screen.level(params:get('tog') == 1 and 15 or 2)
  screen.text('tog')
  screen.move(py + px, py * 2)
  screen.level(params:get('mom') == 1 and 15 or 2)
  screen.text('mom')
  screen.update()
end
```