### PR TITLE
Fix util.round_up

### DIFF
--- a/lua/lib/util.lua
+++ b/lua/lib/util.lua
@@ -188,7 +188,7 @@ function util.round_up(number, quant)
   if quant == 0 then
     return number
   else
-    return math.ceil(number/(quant or 1) + 0.5) * (quant or 1)
+    return math.ceil(number/(quant or 1)) * (quant or 1)
   end
 end
 


### PR DESCRIPTION
Shouldn't add 0.5 when using `math.ceil` - this causes e.g. 3.9 to get rounded up to 5.