### PR TITLE
menu mode fix

### DIFF
--- a/lua/core/menu.lua
+++ b/lua/core/menu.lua
@@ -143,8 +143,8 @@ end
 
 -- _menu.set mode
 _menu.set_mode = function(mode)
-  if mode == false and _menu.mode == true then -- ACTIVATE PLAY MODE
-    _norns.screen_restore()
+  if mode == false then -- ACTIVATE PLAY MODE
+    if _menu.mode == true then _norns.screen_restore() end
     _menu.mode = false
     m[_menu.page].deinit()
     screen.clear()
@@ -156,8 +156,8 @@ _menu.set_mode = function(mode)
     --norns.encoders.set_accel(0,false)
     --norns.encoders.set_sens(0,1)
     redraw()
-  elseif mode == true and _menu.mode == false then -- ACTIVATE MENu MODE
-    _norns.screen_save()
+  elseif mode == true then -- ACTIVATE MENu MODE
+    if _menu.mode == false then _norns.screen_save() end
     _menu.mode = true
     _menu.alt = false
     redraw = norns.none


### PR DESCRIPTION
fixes #1238 

bug introduced by #1227 which attempted to more properly implement a "menu lock" (ie, disable K1 when no script was loaded)

the menu logic is fragile. i would very much like to scrap the whole thing and start over.