### PR TITLE
api for sending arbitrary lua

### DIFF
--- a/matron/src/weaver.c
+++ b/matron/src/weaver.c
@@ -217,6 +217,7 @@ static int _sound_file_inspect(lua_State *l);
 
 // util
 static int _system_cmd(lua_State *l);
+static int _system_cmd_lua(lua_State *l);
 
 // reset LVM
 static int _reset_lvm(lua_State *l);
@@ -334,6 +335,7 @@ void w_init(void) {
 
     // util
     lua_register_norns("system_cmd", &_system_cmd);
+    lua_register_norns("system_cmd_lua", &_system_cmd_lua);
 
     // low-level monome grid control
     lua_register_norns("grid_set_led", &_grid_set_led);
@@ -2419,6 +2421,13 @@ int _system_cmd(lua_State *l) {
     lua_check_num_args(1);
     const char *cmd = luaL_checkstring(l, 1);
     system_cmd((char *)cmd);
+    return 0;
+}
+
+int _system_cmd_lua(lua_State *l) {
+    lua_check_num_args(1);
+    const char *cmd = luaL_checkstring(l, 1);
+    w_run_code((char *)cmd);
     return 0;
 }
 


### PR DESCRIPTION
maybe this pr is not needed but i wasn't aware of any alternative to send norns arbitrary lua via matron. if there is a way please let me know.

this commit is motivated by making a "remote controlled norns": https://llllllll.co/t/norns-online-crowdsource-your-norns/ basically i'm using this patch to be able to communicate directly to matron with arbitrarily setting keys/encoders when those inputs are manipulated remotely: https://github.com/schollz/norns.online/blob/main/main.go#L142

though i made a remote norns for fun i've been messaged that it would be useful in a classroom setting so i'd like to eliminate some of the barriers for others to run it. if this pr can be merged (or alternative suggested!) i'd like to make this "remote norns" an app that is easy to get from maiden.
