### PR TITLE
allow taper params to be mapped (again)

### DIFF
--- a/lua/core/menu/params.lua
+++ b/lua/core/menu/params.lua
@@ -451,7 +451,8 @@ m.redraw = function()
           if t ==  params.tNUMBER or
               t == params.tCONTROL or
               t == params.tBINARY or
-              t == params.tOPTION then
+              t == params.tOPTION or
+              t == params.tTAPER then
             local pm=norns.pmap.data[id]
             if params:get_allow_pmap(p) then
               if pm then

--- a/lua/core/params/taper.lua
+++ b/lua/core/params/taper.lua
@@ -13,7 +13,7 @@ local function map(x, from_min, from_max, to_min, to_max)
   return (x - from_min) * (to_max - to_min) / (from_max - from_min) + to_min
 end
 
-function Taper.new(id, name, min, max, default, k, units)
+function Taper.new(id, name, min, max, default, k, units, allow_pmap)
   local p = setmetatable({}, Taper)
   p.t = tTAPER
   p.id = id
@@ -22,6 +22,7 @@ function Taper.new(id, name, min, max, default, k, units)
   p.max = max or 1
   p.k = k or 0
   p.action = function() end
+  if allow_pmap == nil then p.allow_pmap = true else p.allow_pmap = allow_pmap end
   p.default = default or min
   p.units = units or ""
   p:set(p.default)


### PR DESCRIPTION
mapping of taper params was broken by 915c86ca85. this commit
restores mappability and includes taper params in the list of
control types which display their mapping in the menu (which
looks as if it was omitted from the list when the param menu
was reimplemented).

fixes #1241 