### PR TITLE
add norns.fetch for git clone shortcut

### DIFF
--- a/lua/core/norns.lua
+++ b/lua/core/norns.lua
@@ -170,6 +170,14 @@ else
 end
 
 
+-- fetch (git clone)
+norns.fetch = function(url)
+  local status = os.execute("cd "..os.getenv("HOME").."/dust/code; git clone "..url)
+  if status then print("fetch: success. you may need to SYSTEM > RESET if the new project contains an engine")
+  else print("fetch: FAIL") end
+end
+
+
 -- Util (system_cmd)
 local system_cmd_q = {}
 local system_cmd_busy = false


### PR DESCRIPTION
for cloning pre-release projects (not yet added to community repo)

in maiden/etc:

```
> norns.fetch("https://github.com/tehn/test-update")
fatal: destination path 'test-update' already exists and is not an empty directory.
fetch: FAIL

> os.execute("rm -rf /home/dust/code/test-update")
true	exit	0

> norns.fetch("https://github.com/tehn/test-update")
Cloning into 'test-update'...
fetch: success. you may need to SYSTEM > RESET if the new project contains an engine
```