### PR TITLE
platform checking

### DIFF
--- a/lua/core/menu/home.lua
+++ b/lua/core/menu/home.lua
@@ -59,10 +59,12 @@ m.redraw = function()
     screen.text(line)
   else
     screen.level(1)
-    screen.move(0,10)
-    screen.text("BAT " .. norns.battery_percent)
-    screen.move(36,10)
-    screen.text(norns.battery_current .. "mA")
+    if norns.is_norns then
+      screen.move(0,10)
+      screen.text("BAT " .. norns.battery_percent)
+      screen.move(36,10)
+      screen.text(norns.battery_current .. "mA")
+    end
     screen.move(127,10)
     screen.text_right("DISK " .. norns.disk .. "M")
     screen.move(0,20)

--- a/lua/core/menu/sleep.lua
+++ b/lua/core/menu/sleep.lua
@@ -28,7 +28,7 @@ m.redraw = function()
     screen.level(1)
     if norns.is_shield then
       screen.move(10,40)
-      screen.text("when the green light")
+      screen.text("when the light")
       screen.move(10,48)
       screen.text("stops blinking")
       screen.move(10,56)

--- a/lua/core/menu/sleep.lua
+++ b/lua/core/menu/sleep.lua
@@ -25,16 +25,17 @@ m.redraw = function()
   screen.clear()
   screen.move(48,40)
   if m.sleep then
-	screen.level(1)
-	screen.text("sleep.")
-  if norns.is_shield then
-    screen.move(10,50)
-    screen.text("wait for the green light to stop blinking")
-    screen.move(10,60)
-    screen.text("then disconnect power")
+    screen.level(1)
+    screen.text("sleep.")
+    if norns.is_shield then
+      screen.move(10,50)
+      screen.text("wait for the green light to stop blinking")
+      screen.move(10,60)
+      screen.text("then disconnect power")
+    end
   else
-	screen.level(15)
-  screen.text("sleep?")
+    screen.level(15)
+    screen.text("sleep?")
   end
   --TODO do an animation here! fade the volume down
   screen.update()

--- a/lua/core/menu/sleep.lua
+++ b/lua/core/menu/sleep.lua
@@ -26,12 +26,15 @@ m.redraw = function()
   screen.move(48,40)
   if m.sleep then
     screen.level(1)
-    screen.text("sleep.")
     if norns.is_shield then
-      screen.move(10,50)
-      screen.text("wait for the green light to stop blinking")
-      screen.move(10,60)
-      screen.text("then disconnect power")
+      screen.move(10,40)
+      screen.text("when the green light")
+      screen.move(10,48)
+      screen.text("stops blinking")
+      screen.move(10,56)
+      screen.text("disconnect power")
+    else
+      screen.text("sleep.")
     end
   else
     screen.level(15)

--- a/lua/core/menu/sleep.lua
+++ b/lua/core/menu/sleep.lua
@@ -27,6 +27,11 @@ m.redraw = function()
   if m.sleep then
 	screen.level(1)
 	screen.text("sleep.")
+  if norns.is_shield then
+    screen.move(10,50)
+    screen.text("wait for the green light to stop blinking")
+    screen.move(10,60)
+    screen.text("then disconnect power")
   else
 	screen.level(15)
   screen.text("sleep?")

--- a/lua/core/norns.lua
+++ b/lua/core/norns.lua
@@ -177,6 +177,14 @@ norns.fetch = function(url)
   else print("fetch: FAIL") end
 end
 
+-- platform detection
+-- 0 = UNKNOWN
+-- 1 = OTHER
+-- 2 = CM3 (norns)
+-- 3 = PI3 (norns shield)
+norns.platform = _norns.platform()
+norns.is_norns = norns.platform == 2
+norns.is_shield = norns.platform == 3
 
 -- Util (system_cmd)
 local system_cmd_q = {}

--- a/matron/src/hardware/battery.c
+++ b/matron/src/hardware/battery.c
@@ -15,6 +15,7 @@
 #include <unistd.h>
 
 #include "events.h"
+#include "platform.h"
 
 #define BATTERY_POLL_INTERVAL 5
 
@@ -27,6 +28,8 @@ void *battery_check(void *);
 // extern def
 
 void battery_init() {
+    if (platform() != PLATFORM_CM3) return;
+
     fd[0] = open("/sys/class/power_supply/bq27441-0/capacity", O_RDONLY | O_NONBLOCK);
     fd[1] = open("/sys/class/power_supply/bq27441-0/status", O_RDONLY | O_NONBLOCK);
     fd[2] = open("/sys/class/power_supply/bq27441-0/current_now", O_RDONLY | O_NONBLOCK);

--- a/matron/src/hardware/i2c.c
+++ b/matron/src/hardware/i2c.c
@@ -18,6 +18,7 @@
 #include <unistd.h>
 
 #include "i2c.h"
+#include "platform.h"
 
 #define ADDR_HP 0x60
 #define ADDR_IN 0x29
@@ -28,6 +29,8 @@ static char buf[10];
 void *i2c_write(void *);
 
 void i2c_init(void) {
+    if (platform() != PLATFORM_CM3) return;
+
     char filename[40];
 
     sprintf(filename, "/dev/i2c-1");
@@ -55,6 +58,8 @@ void i2c_deinit() {
 }
 
 void i2c_hp(int level) {
+    if (platform() != PLATFORM_CM3) return;
+
     if (level < 0) {
         level = 0;
     } else if (level > 63) {

--- a/matron/src/hardware/platform.c
+++ b/matron/src/hardware/platform.c
@@ -1,0 +1,24 @@
+#include <unistd.h>
+#include <stdlib.h>
+
+#include "platform.h"
+
+#define PLATFORM_PATH "/sys/firmware/devicetree/base/model"
+
+platform_t p;
+
+void init_platform() {
+  if(access(PLATFORM_PATH, F_OK ) != -1) {
+    if(system("sudo cat /sys/firmware/devicetree/base/model | grep 'Compute'")) {
+      p = PLATFORM_PI3;
+    } else {
+      p = PLATFORM_CM3;
+    }
+  } else {
+    p = PLATFORM_OTHER;
+  }
+}
+
+platform_t platform() {
+  return p;
+}

--- a/matron/src/hardware/platform.c
+++ b/matron/src/hardware/platform.c
@@ -3,12 +3,10 @@
 
 #include "platform.h"
 
-#define PLATFORM_PATH "/sys/firmware/devicetree/base/model"
-
 platform_t p;
 
 void init_platform() {
-  if(access(PLATFORM_PATH, F_OK ) != -1) {
+  if(access("/sys/firmware/devicetree/base/model", F_OK ) != -1) {
     if(system("sudo cat /sys/firmware/devicetree/base/model | grep 'Compute'")) {
       p = PLATFORM_PI3;
     } else {

--- a/matron/src/hardware/platform.c
+++ b/matron/src/hardware/platform.c
@@ -7,7 +7,7 @@ platform_t p;
 
 void init_platform() {
   if(access("/sys/firmware/devicetree/base/model", F_OK ) != -1) {
-    if(system("sudo cat /sys/firmware/devicetree/base/model | grep 'Compute'")) {
+    if(system("cat /sys/firmware/devicetree/base/model | grep 'Compute'")) {
       p = PLATFORM_PI3;
     } else {
       p = PLATFORM_CM3;

--- a/matron/src/hardware/platform.h
+++ b/matron/src/hardware/platform.h
@@ -1,0 +1,11 @@
+#pragma once
+
+typedef enum {
+  PLATFORM_UNKNOWN = 0,
+  PLATFORM_OTHER,
+  PLATFORM_CM3,
+  PLATFORM_PI3,
+} platform_t;
+
+extern void init_platform(void);
+extern platform_t platform(void);

--- a/matron/src/main.c
+++ b/matron/src/main.c
@@ -25,6 +25,7 @@
 #include "input.h"
 #include "metro.h"
 #include "osc.h"
+#include "platform.h"
 #include "screen.h"
 #include "stat.h"
 #include "watch.h"
@@ -54,6 +55,8 @@ int main(int argc, char **argv) {
     args_parse(argc, argv);
 
     print_version();
+    init_platform();
+    printf("platform: %d\n",platform());
 
     events_init(); // <-- must come first!
     screen_init();

--- a/matron/src/weaver.c
+++ b/matron/src/weaver.c
@@ -37,6 +37,7 @@
 #include "metro.h"
 #include "oracle.h"
 #include "osc.h"
+#include "platform.h"
 #include "screen.h"
 #include "snd_file.h"
 #include "system_cmd.h"
@@ -220,6 +221,8 @@ static int _system_cmd(lua_State *l);
 
 // reset LVM
 static int _reset_lvm(lua_State *l);
+
+// clock
 static int _clock_schedule_sleep(lua_State *l);
 static int _clock_schedule_sync(lua_State *l);
 static int _clock_cancel(lua_State *l);
@@ -227,15 +230,16 @@ static int _clock_internal_set_tempo(lua_State *l);
 static int _clock_internal_start(lua_State *l);
 static int _clock_internal_stop(lua_State *l);
 static int _clock_crow_in_div(lua_State *l);
-
 #if HAVE_ABLETON_LINK
 static int _clock_link_set_tempo(lua_State *l);
 static int _clock_link_set_quantum(lua_State *l);
 #endif
-
 static int _clock_set_source(lua_State *l);
 static int _clock_get_time_beats(lua_State *l);
 static int _clock_get_tempo(lua_State *l);
+
+// platform detection (CM3 vs PI3 vs OTHER)
+static int _platform(lua_State *l);
 
 // boilerplate: push a function to the stack, from field in global 'norns'
 static inline void _push_norns_func(const char *field, const char *func) {
@@ -441,6 +445,9 @@ void w_init(void) {
     lua_register_norns("clock_set_source", &_clock_set_source);
     lua_register_norns("clock_get_time_beats", &_clock_get_time_beats);
     lua_register_norns("clock_get_tempo", &_clock_get_tempo);
+
+    // platform
+    lua_register_norns("platform", &_platform);
 
     // name global extern table
     lua_setglobal(lvm, "_norns");
@@ -2421,5 +2428,12 @@ int _system_cmd(lua_State *l) {
     system_cmd((char *)cmd);
     return 0;
 }
+
+int _platform(lua_State *l) {
+    lua_check_num_args(0);
+    lua_pushinteger(l, platform());
+    return 1;
+}
+
 
 #pragma GCC diagnostic pop

--- a/matron/wscript
+++ b/matron/wscript
@@ -13,6 +13,7 @@ def build(bld):
         'src/hardware/battery.c',
         'src/hardware/gpio.c',
         'src/hardware/i2c.c',
+        'src/hardware/platform.c',
         'src/hardware/screen.c',
         'src/hardware/stat.c',
         'src/args.c',


### PR DESCRIPTION
facilities to query the host hardware:
- CM3
- Pi3 (shield)
- "other" (not tested, but feasibly detectable)

this prevents irrelevant error messages from the battery and i2c on the shield, which though harmless looks alarming.

also allows customization of some menus:
- shield, don't show battery
- shield, give better shutdown message

lua helpers:
```
norns.platform -- 2=norns 3=shield
norns.is_norns -- boolean
norns.is_shield -- boolean
```

this could've been done with a config file, but i'd rather not have the user even worry about having the right config.

ps. i'll submit a followup pr which scrubs the hardware/device formatting, it's a little messy