### PR TITLE
add screen rotate, translate, save, & restore

### DIFF
--- a/lua/core/screen.lua
+++ b/lua/core/screen.lua
@@ -233,5 +233,19 @@ end
 -- @tparam number y y position
 Screen.display_png = function(filename,x,y) _norns.screen_display_png(filename,x,y) end
 
+--- rotate
+-- @param number radians
+Screen.rotate = function(r) _norns.screen_rotate(r) end
+
+--- move origin position
+-- @tparam number x position x
+-- @tparam number y position y
+Screen.translate = function(x, y) _norns.screen_translate(x, y) end
+
+--- save
+Screen.save = function() _norns.screen_save() end
+
+-- restore
+Screen.restore = function() _norns.screen_restore() end
 
 return Screen

--- a/matron/src/hardware/screen.c
+++ b/matron/src/hardware/screen.c
@@ -449,5 +449,15 @@ extern void screen_export_png(const char *s) {
     cairo_surface_write_to_png(surface, s);
 }
 
+void screen_rotate(double r) {
+    CHECK_CR
+    cairo_rotate(cr, r);
+}
+
+void screen_translate(double x, double y) {
+    CHECK_CR
+    cairo_translate(cr, x, y);
+}
+
 #undef CHECK_CR
 #undef CHECK_CRR

--- a/matron/src/hardware/screen.h
+++ b/matron/src/hardware/screen.h
@@ -32,3 +32,5 @@ extern void screen_close_path(void);
 extern double *screen_text_extents(const char *s);
 extern void screen_export_png(const char *s);
 extern void screen_display_png(const char *filename, double x, double y);
+extern void screen_rotate(double r);
+extern void screen_translate(double x, double y);

--- a/matron/src/weaver.c
+++ b/matron/src/weaver.c
@@ -109,6 +109,8 @@ static int _screen_close(lua_State *l);
 static int _screen_text_extents(lua_State *l);
 static int _screen_export_png(lua_State *l);
 static int _screen_display_png(lua_State *l);
+static int _screen_rotate(lua_State *l);
+static int _screen_translate(lua_State *l);
 // i2c
 static int _gain_hp(lua_State *l);
 // osc
@@ -374,6 +376,8 @@ void w_init(void) {
     lua_register_norns("screen_text_extents", &_screen_text_extents);
     lua_register_norns("screen_export_png", &_screen_export_png);
     lua_register_norns("screen_display_png", &_screen_display_png);
+    lua_register_norns("screen_rotate", &_screen_rotate);
+    lua_register_norns("screen_translate", &_screen_translate);
 
     // analog output control
     lua_register_norns("gain_hp", &_gain_hp);
@@ -863,6 +867,34 @@ int _screen_display_png(lua_State *l) {
     double x = luaL_checknumber(l, 2);
     double y = luaL_checknumber(l, 3);
     screen_display_png(s, x, y);
+    lua_settop(l, 0);
+    return 0;
+}
+
+/***
+ * screen: rotate
+ * @function s_rotate
+ * @tparam float radians
+ */
+int _screen_rotate(lua_State *l) {
+    lua_check_num_args(1);
+    double r = luaL_checknumber(l, 1);
+    screen_rotate(r);
+    lua_settop(l, 0);
+    return 0;
+}
+
+/***
+ * screen: translate origin to new position
+ * @function s_translate
+ * @param x
+ * @param y
+ */
+int _screen_translate(lua_State *l) {
+    lua_check_num_args(2);
+    double x = luaL_checknumber(l, 1);
+    double y = luaL_checknumber(l, 2);
+    screen_translate(x, y);
     lua_settop(l, 0);
     return 0;
 }


### PR DESCRIPTION
![46](https://user-images.githubusercontent.com/1298097/100475882-d4a32500-30a9-11eb-817b-195b2321c55d.png)

implementation example: https://github.com/northern-information/athenaeum/blob/main/rotate.lua

this works fine and good but i think we'll also want bunch of "rotate_rel" functions that cleanup after themselves?

```
screen.move(10, 10)
screen.rotated_text("i'm rotated ninety degrees", 90)
screen.move(10, 20)
screen.text("i'm not")
screen.move(30, 30)
screen.rotated_rect( ...
```