### PR TITLE
trivial fix to compile on gcc9

### DIFF
--- a/matron/src/device/device_midi.c
+++ b/matron/src/device/device_midi.c
@@ -292,7 +292,7 @@ void *dev_midi_start(void *self) {
         if (snd_rawmidi_status(midi->handle_in, status) == 0) {
             xruns = snd_rawmidi_status_get_xruns(status);
             if (xruns > 0) {
-                fprintf(stderr, "xruns (%d) for midi device: %s\n", xruns, base->name);
+                fprintf(stderr, "xruns (%d) for midi device: %s\n", (int)xruns, base->name);
                 snd_rawmidi_drop(midi->handle_in);
             }
         }


### PR DESCRIPTION
compilation has been broken for me on on gcc 9.3 for a while now, because of a stupid type warning. this trivial change fixes this annoyance.