### PR TITLE
Allow mapping control params over non-integer ranges

### DIFF
--- a/lua/core/menu/params.lua
+++ b/lua/core/menu/params.lua
@@ -241,7 +241,11 @@ m.key = function(n,z)
       elseif m.mpos ==2 then
         norns.pmap.remove(name)
         m.mode = mMAP
+      elseif m.pos==8 or m.pos==9 then
+        m.fine = true
       end
+    elseif n==3 then
+      m.fine = false
     end
     -- PSET
   elseif m.mode == mPSET then
@@ -347,6 +351,9 @@ m.enc = function(n,d)
         local max = 1
         if t == params.tCONTROL then
           d = d * param.controlspec.quantum
+          if m.fine then
+            d = d / 20
+          end
         elseif t == params.tNUMBER or t == params.tOPTION or t == params.tBINARY then
           local r = param:get_range()
           min = r[1]


### PR DESCRIPTION
This PR allows users to map `control` params with 'out' min/max values between 0 and 1 -- plus, it displays the output range using the controlspec for the param being mapped, so the user can choose scaled/warped values that match what they'd see in the params menu, instead of raw 0.0-1.0 values.

Resolution/precision is determined by the controlspec's `quantum` property, just like `params:delta()`.

![mapping screen](https://user-images.githubusercontent.com/752281/100814097-f0daf500-340e-11eb-8864-83f604cdb576.png)

`number` params work just like they did before.

I've been running this code since last weekend with no problems so far.

Fixes #1249, as mentioned in #1248.
