### PR TITLE
Further pmapping tweaks

### DIFF
--- a/lua/core/menu/params.lua
+++ b/lua/core/menu/params.lua
@@ -241,7 +241,7 @@ m.key = function(n,z)
       elseif m.mpos ==2 then
         norns.pmap.remove(name)
         m.mode = mMAP
-      elseif m.pos==8 or m.pos==9 then
+      elseif m.mpos==8 or m.mpos==9 then
         m.fine = true
       end
     elseif n==3 then

--- a/lua/core/menu/params.lua
+++ b/lua/core/menu/params.lua
@@ -349,8 +349,8 @@ m.enc = function(n,d)
         local param = params:lookup_param(n)
         local min = 0
         local max = 1
-        if t == params.tCONTROL then
-          d = d * param.controlspec.quantum
+        if t == params.tCONTROL or t == params.tTAPER then
+          d = d * param:get_delta()
           if m.fine then
             d = d / 20
           end
@@ -494,10 +494,10 @@ m.redraw = function()
     local out_lo = pm.out_lo
     local out_hi = pm.out_hi
 
-    if t == params.tCONTROL then
+    if t == params.tCONTROL or t == params.tTAPER then
       local param = params:lookup_param(n)
-      out_lo = util.round(param.controlspec:map(pm.out_lo), 0.01)
-      out_hi = util.round(param.controlspec:map(pm.out_hi), 0.01)
+      out_lo = util.round(param:map_value(pm.out_lo), 0.01)
+      out_hi = util.round(param:map_value(pm.out_hi), 0.01)
     end
 
     local function hl(x) if m.mpos==x then screen.level(15) else screen.level(4) end end

--- a/lua/core/params/control.lua
+++ b/lua/core/params/control.lua
@@ -32,10 +32,16 @@ function Control.new(id, name, controlspec, formatter, allow_pmap)
   return p
 end
 
+--- map_value.
+-- takes 0-1 and returns value scaled by controlspec.
+function Control:map_value(value)
+  return self.controlspec:map(value)
+end
+
 --- get.
 -- returns mapped value.
 function Control:get()
-  return self.controlspec:map(self.raw)
+  return self:map_value(self.raw)
 end
 
 --- get_raw.
@@ -44,10 +50,16 @@ function Control:get_raw()
   return self.raw
 end
 
+--- unmap_value.
+-- takes a scaled value and returns 0-1, quantized to step.
+function Control:unmap_value(value)
+  return self.controlspec:unmap(util.round(value, self.controlspec.step))
+end
+
 --- set.
 -- accepts a mapped value
 function Control:set(value, silent)
-  self:set_raw(self.controlspec:unmap(util.round(value,self.controlspec.step)), silent)
+  self:set_raw(self:unmap_value(value), silent)
 end
 
 --- set_raw.
@@ -69,11 +81,17 @@ function Control:set_raw(value, silent)
   end
 end
 
+--- get_delta.
+-- get increment used for delta()
+function Control:get_delta()
+  return self.controlspec.quantum
+end
+
 --- delta.
 -- add delta to current value. checks controlspec for mapped vs not.
 -- default division of delta for 100 steps range.
 function Control:delta(d)
-  self:set_raw(self.raw + d*self.controlspec.quantum)
+  self:set_raw(self.raw + d * self:get_delta())
 end
 
 --- set_default.


### PR DESCRIPTION
Fixes buggy fine control, and adds support for `taper` params by adding generic `map_value()`, `unmap_value()`, and `get_delta()` functions to the Control and Taper param classes. Figured it was best not to duplicate the taper math and instead break it out into separate functions that can be used by both the params menu and `get`/`set`/`delta`.