### PR TITLE
continue if params:read throws error on parameter

### DIFF
--- a/lua/core/paramset.lua
+++ b/lua/core/paramset.lua
@@ -407,13 +407,13 @@ function ParamSet:read(filename, silent)
 
           if index and self.params[index] then
             if tonumber(value) ~= nil then
-              self.params[index]:set(tonumber(value), silent)
+              pcall(function() self.params[index]:set(tonumber(value), silent) end)
             elseif value == "-inf" then
-              self.params[index]:set(-math.huge, silent)
+              pcall(function() self.params[index]:set(-math.huge, silent) end)
             elseif value == "inf" then
-              self.params[index]:set(math.huge, silent)
+              pcall(function() self.params[index]:set(math.huge, silent) end)
             elseif value then
-              self.params[index]:set(value, silent)
+              pcall(function() self.params[index]:set(value, silent) end)
             end
           end
         end


### PR DESCRIPTION
i'm working on scripts to share between users and one thing i'm running into is if users have different versions of a script and thus might be missing a parameter in their script when loading from someone else's parameter file. currently, using `params:read` will cause an error and the reading will be canceled in this case. 

if this is the behavior that you want (perhaps to prevent downstream errors) - that's totally fine and i can make a function to work around it. 

however, just in case, i thought i'd make a pr to continue reading, even if parameters aren't able to be set when reading, and set the parameters that are available. (this might be amended to print something to the console about it too, but i'd like to know if this is of interest first).