### PR TITLE
ws-wrapper prints

### DIFF
--- a/ws-wrapper/src/main.c
+++ b/ws-wrapper/src/main.c
@@ -177,5 +177,6 @@ int main(int argc, char **argv) {
         printf("usage: ws-wrapper WS_SOCKET BINARY <child args...>");
     }
 
+    setvbuf(stdout, NULL, _IONBF, 0); 
     launch_exe(argc, argv);
 }

--- a/ws-wrapper/src/main.c
+++ b/ws-wrapper/src/main.c
@@ -66,6 +66,7 @@ void *loop_tx(void *p) {
         nb = read(pipe_tx[PIPE_READ], buf, PIPE_BUF_SIZE - 1);
         if (nb > 0) {
             buf[nb] = '\0';
+            printf("%s", buf);
             nn_send(sock_ws, buf, nb, 0);
         }
     }


### PR DESCRIPTION
this reverts PR #1028

yea or nay?

original problem:
- weird recursive duplicated output when you try and log the `matron` service from lua
- too many logs?

new problem:
- not enough logs?