### PR TITLE
PMAP autosave + 16 MIDI vports

### DIFF
--- a/lua/core/clock.lua
+++ b/lua/core/clock.lua
@@ -234,9 +234,9 @@ function clock.add_params()
     end)
   params:set_save("link_quantum", false)
   local clock_table = {"off"}
-  for i = 2,17 do
-    local short_name = string.len(midi.vports[i-1].name) < 12 and midi.vports[i-1].name or util.acronym(midi.vports[i-1].name)
-    clock_table[i] = "port "..(i-1)..""..(midi.vports[i-1].name ~= "none" and (": "..short_name) or "")
+  for i = 1,16 do
+    local short_name = string.len(midi.vports[i].name) < 12 and midi.vports[i].name or util.acronym(midi.vports[i].name)
+    clock_table[i+1] = "port "..(i)..""..(midi.vports[i].name ~= "none" and (": "..short_name) or "")
   end
   params:add_option("clock_midi_out", "midi out",
       clock_table, norns.state.clock.midi_out)

--- a/lua/core/clock.lua
+++ b/lua/core/clock.lua
@@ -233,9 +233,13 @@ function clock.add_params()
       norns.state.clock.link_quantum = x
     end)
   params:set_save("link_quantum", false)
-
+  local clock_table = {"off"}
+  for i = 2,17 do
+    local short_name = string.len(midi.vports[i-1].name) < 12 and midi.vports[i-1].name or util.abbreviate(midi.vports[i-1].name)
+    clock_table[i] = "port "..(i-1)..""..(midi.vports[i-1].name ~= "none" and (": "..short_name) or "")
+  end
   params:add_option("clock_midi_out", "midi out",
-      {"off", "port 1", "port 2", "port 3", "port 4"}, norns.state.clock.midi_out)
+      clock_table, norns.state.clock.midi_out)
   params:set_action("clock_midi_out", function(x) norns.state.clock.midi_out = x end)
   params:set_save("clock_midi_out", false)
   params:add_option("clock_crow_out", "crow out",

--- a/lua/core/clock.lua
+++ b/lua/core/clock.lua
@@ -235,7 +235,7 @@ function clock.add_params()
   params:set_save("link_quantum", false)
   local clock_table = {"off"}
   for i = 2,17 do
-    local short_name = string.len(midi.vports[i-1].name) < 12 and midi.vports[i-1].name or util.abbreviate(midi.vports[i-1].name)
+    local short_name = string.len(midi.vports[i-1].name) < 12 and midi.vports[i-1].name or util.acronym(midi.vports[i-1].name)
     clock_table[i] = "port "..(i-1)..""..(midi.vports[i-1].name ~= "none" and (": "..short_name) or "")
   end
   params:add_option("clock_midi_out", "midi out",

--- a/lua/core/menu/devices.lua
+++ b/lua/core/menu/devices.lua
@@ -145,7 +145,8 @@ m.redraw = function()
       if m.section == "midi" then
         screen.move(0,20)
         screen.level(4)
-        screen.text("[ "..util.round_up(m.pos/4).."/"..util.round_up(#m.options[m.section]/4).." ]")
+        local page_indicator = util.round_up(#m.options[m.section]/4)
+        screen.text(page_indicator > 1 and "[ "..util.round_up(m.pos/4).."/"..page_indicator.." ]" or "")
         local positions = {{1,4},{5,8},{9,12},{13,16}}
         for j = positions[util.round_up(m.pos/4)][1],positions[util.round_up(m.pos/4)][2] do
           if(j==m.pos) then

--- a/lua/core/menu/devices.lua
+++ b/lua/core/menu/devices.lua
@@ -76,7 +76,7 @@ m.key = function(n,z)
         hid.update_devices()
       end
       m.mode = "list"
-      m.len = m.section == "midi" and 16 or 4
+      m.len = m.section ~= "midi" and 4 or 16
       m.pos = m.last_pos
       _menu.redraw()
     end
@@ -85,8 +85,11 @@ end
 
 m.enc = function(n,delta)
   if n==2 then
+    prev_pos = m.pos
     m.pos = util.clamp(m.pos + delta, 1, m.len)
-    _menu.redraw()
+    if prev_pos ~= m.pos then
+      _menu.redraw()
+    end
   end
 end
 
@@ -112,21 +115,17 @@ m.redraw = function()
       screen.text(string.upper(m.list[i]) .. " >")
     elseif m.mode == "list" then
       if m.section == "midi" then
-        screen.move(0,20)
-        screen.level(4)
-        screen.text("[ "..util.round_up(m.pos/4).."/4 ]")
-        local positions = {{1,4},{5,8},{9,12},{13,16}}
-        for j = positions[util.round_up(m.pos/4)][1],positions[util.round_up(m.pos/4)][2] do
-          if(j==m.pos) then
-            screen.level(15)
-          else
-            screen.level(4)
+        for j = 1,4 do
+          screen.move(0,10*j+20)
+          if m.pos+(j-1) <= m.len then
+            local line = m.pos+(j-1)..". "..midi.vports[m.pos+(j-1)].name
+            if j == 1 then
+              screen.level(15)
+            else
+              screen.level(3)
+            end
+            screen.text(line)
           end
-          local num = j - (4*(util.round_up(m.pos/4)-1))
-          screen.move(0,10*num+20)
-          screen.text(j..".")
-          screen.move(12,10*num+20)
-          screen.text(midi.vports[j].name)
         end
       elseif m.section == "grid" then
         screen.text(i..".")
@@ -143,21 +142,16 @@ m.redraw = function()
       end
     elseif m.mode == "select" then
       if m.section == "midi" then
-        screen.move(0,20)
-        screen.level(4)
-        local page_indicator = util.round_up(#m.options[m.section]/4)
-        screen.text(page_indicator > 1 and "[ "..util.round_up(m.pos/4).."/"..page_indicator.." ]" or "")
-        local positions = {{1,4},{5,8},{9,12},{13,16}}
-        for j = positions[util.round_up(m.pos/4)][1],positions[util.round_up(m.pos/4)][2] do
-          if(j==m.pos) then
-            screen.level(15)
-          else
-            screen.level(4)
-          end
-          local num = j - (4*(util.round_up(m.pos/4)-1))
-          screen.move(8,10*num+20)
-          if m.options[m.section][j] ~= nil then
-            screen.text(m.options[m.section][j])
+        for j = 1,4 do
+          screen.move(0,10*j+20)
+          if m.options[m.section][m.pos+(j-1)] ~= nil then
+            local line = m.options[m.section][m.pos+(j-1)]
+            if j == 1 then
+              screen.level(15)
+            else
+              screen.level(3)
+            end
+            screen.text(line)
           end
         end
       else

--- a/lua/core/menu/home.lua
+++ b/lua/core/menu/home.lua
@@ -3,6 +3,8 @@ local m = {
   list = {"SELECT", "SYSTEM", "SLEEP"}
 }
 
+local p = require 'core/menu/params'
+
 m.init = function()
   _menu.timer.time = 1
   _menu.timer.count = -1
@@ -24,6 +26,7 @@ m.key = function(n,z)
     else
       norns.script.clear()
       _norns.free_engine()
+      p.reset()
       _menu.locked = true
     end
   end

--- a/lua/core/menu/home.lua
+++ b/lua/core/menu/home.lua
@@ -3,8 +3,6 @@ local m = {
   list = {"SELECT", "SYSTEM", "SLEEP"}
 }
 
-local p = require 'core/menu/params'
-
 m.init = function()
   _menu.timer.time = 1
   _menu.timer.count = -1
@@ -26,7 +24,7 @@ m.key = function(n,z)
     else
       norns.script.clear()
       _norns.free_engine()
-      p.reset()
+      params.reset()
       _menu.locked = true
     end
   end

--- a/lua/core/menu/params.lua
+++ b/lua/core/menu/params.lua
@@ -338,7 +338,7 @@ m.enc = function(n,d)
       elseif m.mpos==4 then
         m.ch = util.clamp(m.ch+d,1,16)
       elseif m.mpos==5 then
-        m.dev = util.clamp(m.dev+d,1,16)
+        m.dev = util.clamp(m.dev+d,1,#midi.vports)
       elseif m.mpos==6 then
         pm.in_lo = util.clamp(pm.in_lo+d, 0, pm.in_hi)
         pm.value = util.clamp(pm.value, pm.in_lo, pm.in_hi)
@@ -517,21 +517,36 @@ m.redraw = function()
     screen.level(4)
     screen.move(0,40)
     screen.text("cc")
-    screen.move(40,40)
+    screen.move(55,40)
     hl(3)
     screen.text_right(m.cc)
     screen.level(4)
     screen.move(0,50)
     screen.text("ch")
-    screen.move(40,50)
+    screen.move(55,50)
     hl(4)
     screen.text_right(m.ch)
     screen.level(4)
     screen.move(0,60)
     screen.text("dev")
-    screen.move(40,60)
+    screen.move(55,60)
     hl(5)
-    screen.text_right(m.dev)
+    local raw_name = midi.vports[m.dev].name
+    local function abbreviate (name)
+      -- first replace each word (incl. "'") by its abbreviation...
+      -- (will leave spaces etc. in the string)
+      name = name:gsub( "[%w']+", function( word )
+        if not word:find "%U" then  return word  end -- OPTIONAL keep abbrevs
+        return word:sub( 1, 1 )            -- others: to first letter
+      end )
+      -- ...then remove all non-word characters
+      return (name:gsub("%s+", ""))
+    end
+
+    local long_name = midi.vports[m.dev].name
+    local short_name = string.len(long_name) > 6 and abbreviate(long_name) or long_name
+
+    screen.text_right(tostring(m.dev)..": "..short_name)
 
     screen.level(4)
     screen.move(63,40)

--- a/lua/core/menu/params.lua
+++ b/lua/core/menu/params.lua
@@ -535,7 +535,7 @@ m.redraw = function()
     hl(5)
 
     local long_name = midi.vports[m.dev].name
-    local short_name = string.len(long_name) > 6 and util.abbreviate(long_name) or long_name
+    local short_name = string.len(long_name) > 6 and util.acronym(long_name) or long_name
 
     screen.text_right(tostring(m.dev)..": "..short_name)
 

--- a/lua/core/menu/params.lua
+++ b/lua/core/menu/params.lua
@@ -235,11 +235,13 @@ m.key = function(n,z)
     if n==2 and z==1 then
       m.mode = mMAP
       norns.pmap.assign(name,m.dev,m.ch,m.cc)
+      norns.pmap.write()
     elseif n==3 and z==1 then
       if m.mpos == 1 then
         m.midilearn = not m.midilearn
       elseif m.mpos ==2 then
         norns.pmap.remove(name)
+        norns.pmap.write()
         m.mode = mMAP
       elseif m.mpos==8 or m.mpos==9 then
         m.fine = true

--- a/lua/core/menu/params.lua
+++ b/lua/core/menu/params.lua
@@ -533,20 +533,9 @@ m.redraw = function()
     screen.text("dev")
     screen.move(55,60)
     hl(5)
-    local raw_name = midi.vports[m.dev].name
-    local function abbreviate (name)
-      -- first replace each word (incl. "'") by its abbreviation...
-      -- (will leave spaces etc. in the string)
-      name = name:gsub( "[%w']+", function( word )
-        if not word:find "%U" then  return word  end -- OPTIONAL keep abbrevs
-        return word:sub( 1, 1 )            -- others: to first letter
-      end )
-      -- ...then remove all non-word characters
-      return (name:gsub("%s+", ""))
-    end
 
     local long_name = midi.vports[m.dev].name
-    local short_name = string.len(long_name) > 6 and abbreviate(long_name) or long_name
+    local short_name = string.len(long_name) > 6 and util.abbreviate(long_name) or long_name
 
     screen.text_right(tostring(m.dev)..": "..short_name)
 

--- a/lua/core/midi.lua
+++ b/lua/core/midi.lua
@@ -10,7 +10,7 @@ Midi.__index = Midi
 Midi.devices = {}
 Midi.vports = {}
 
-for i=1,4 do
+for i=1,16 do
   Midi.vports[i] = {
     name = "none",
     device = nil,
@@ -50,11 +50,11 @@ function Midi.new(id, name, dev)
 
   -- autofill next postiion
   local connected = {}
-  for i=1,4 do
+  for i=1,16 do
     table.insert(connected, Midi.vports[i].name)
   end
   if not tab.contains(connected, name) then
-    for i=1,4 do
+    for i=1,16 do
       -- assign device unless device is specialized virtual interface
       if Midi.vports[i].name == "none" and d.name ~= "virtual" then
         Midi.vports[i].name = d.name
@@ -184,7 +184,7 @@ end
 
 --- clear handlers.
 function Midi.cleanup()
-  for i=1,4 do
+  for i=1,16 do
     Midi.vports[i].event = nil
   end
 
@@ -364,7 +364,7 @@ function Midi.update_devices()
   end
 
   -- connect available devices to vports
-  for i=1,4 do
+  for i=1,16 do
     Midi.vports[i].device = nil
 
     for _, device in pairs(Midi.devices) do

--- a/lua/core/pmap.lua
+++ b/lua/core/pmap.lua
@@ -49,7 +49,7 @@ function pmap.clear()
   pmap.data = {}
   pmap.rev = {}
   -- build reverse lookup table: dev -> ch -> cc
-  for i=1,4 do
+  for i=1,16 do
     pmap.rev[i]={}
     for n=1,16 do
       pmap.rev[i][n]={}

--- a/lua/core/script.lua
+++ b/lua/core/script.lua
@@ -9,8 +9,6 @@ local Script = {}
 Script.clear = function()
   print("# script clear")
 
-  norns.pmap.write() -- write parameter map before we go
-
   -- script local state
   local state = { }
 

--- a/lua/core/script.lua
+++ b/lua/core/script.lua
@@ -9,6 +9,8 @@ local Script = {}
 Script.clear = function()
   print("# script clear")
 
+  norns.pmap.write() -- write parameter map before we go
+
   -- script local state
   local state = { }
 

--- a/lua/core/state.lua
+++ b/lua/core/state.lua
@@ -98,7 +98,7 @@ state.save_state = function()
   io.write("norns.state.clock.crow_out = " .. norns.state.clock.crow_out .. "\n")
   io.write("norns.state.clock.crow_out_div = " .. norns.state.clock.crow_out_div .. "\n")
   io.write("norns.state.clock.crow_in_div = " .. norns.state.clock.crow_in_div .. "\n")
-  for i=1,4 do
+  for i=1,16 do
     io.write("midi.vports[" .. i .. "].name = '" .. midi.vports[i].name .. "'\n")
   end
   for i=1,4 do

--- a/lua/lib/util.lua
+++ b/lua/lib/util.lua
@@ -217,4 +217,15 @@ function util.rads_to_degs(radians)
   return radians * (180 / math.pi)
 end
 
+--- convert string to acronym
+-- @tparam string name
+-- @treturn string acronym
+function util.abbreviate(name)
+  name = name:gsub( "[%w']+", function( word )
+    if not word:find "%U" then  return word  end
+    return word:sub( 1, 1 )
+  end )
+  return (name:gsub("%s+", ""))
+end
+
 return util

--- a/lua/lib/util.lua
+++ b/lua/lib/util.lua
@@ -220,7 +220,7 @@ end
 --- convert string to acronym
 -- @tparam string name
 -- @treturn string acronym
-function util.abbreviate(name)
+function util.acronym(name)
   name = name:gsub( "[%w']+", function( word )
     if not word:find "%U" then  return word  end
     return word:sub( 1, 1 )


### PR DESCRIPTION
## PMAP auto-save

### params.lua
**previous behavior**:
- midi mappings (PMAPs) were only saved when a PSET was saved

**new behavior**:
- PMAPs are saved after they're assigned, so they persist between script loads without needing to save a PSET

## 16 MIDI vports

**previous behavior**:
- norns could host up to 16 MIDI devices, but only assigned devices to 4 MIDI vports
- SYSTEM > DEVICES > MIDI reflected only 4 MIDI vports
- users had to remove/reassign vport-assigned devices more often
- this removing/reassigning disrupted accuracy of mapped controls in PMAPs (which restores based on vport device ID)

**new behavior**:
- norns can now assign up to 16 MIDI vports to match its hosting capability
- users can manage all 16 vports via SYSTEM > DEVICES > MIDI
- 16 device history means users will have to do much less device management/rearranging
- restoring static vport device IDs via PMAPs is less problematic, unless the user purposefully rearranges their device

SYSTEM > DEVICES > MIDI:
![mididev1](https://user-images.githubusercontent.com/24821020/101825346-1ba20900-3af3-11eb-8c2e-8578144d4395.png)
![mididev2](https://user-images.githubusercontent.com/24821020/101825355-1d6bcc80-3af3-11eb-9b7a-f6e57f1a3f7a.png)

assigned a connected device to a vport (up to 4 pages can generate, no indicator if only 1 page):
![mididev3](https://user-images.githubusercontent.com/24821020/101825410-2f4d6f80-3af3-11eb-83cb-cbee11694136.png)


### midi.lua
- create 16 MIDI vports (addresses #1260)

### pmap.lua
- expect assignments from all 16 MIDI vports

### state.lua
- remember devices from all 16 MIDI vports

### devices.lua
- add menu redraw handling for 16 MIDI vports
- add `m.last_pos` to remember which port was last highlighted when switching back to port list from device list

### clock.lua
- extended clock params table to include all 16 ports
- added naming (with abbreviations) to help make it easy for users to see port assignments
![midiout](https://user-images.githubusercontent.com/24821020/101825608-70458400-3af3-11eb-8f4a-6e71388e73a7.png)
nb. of course, names are refreshed only at boot, but i think this is helpful regardless. if a device's name is none, it just shows the port number.

## show mapped device's name

### params.lua
**previous behavior**: mapping a midi controller to a parameter showed only its port number
**new behavior**: midi map menu now shows the device's name (abbreviated if longer than 6 characters, eg. "Midi Fighter Twister" becomes "MFT"), which helps with clarity

![new-map](https://user-images.githubusercontent.com/24821020/101712574-71c36d80-3a5b-11eb-9107-e19fca2672ea.png)
![new-map2](https://user-images.githubusercontent.com/24821020/101712578-738d3100-3a5b-11eb-862d-66817ac23992.png)

## fix #1261 

### home.lua
- added parameter menu reset

## add util.acronym()

### util.lua
- util.acronym() will return an acronym from a given string

eg. `util.acronym("Midi Fighter Twister")` returns `MFT`