### PR TITLE
add pull to “fetch”

### DIFF
--- a/lua/core/norns.lua
+++ b/lua/core/norns.lua
@@ -179,10 +179,10 @@ norns.fetch = function(url)
   local script = parts[#parts]
   local checkout = paths.code.."/"..script
 
-  -- fetch if already downloaded.
+  -- pull if already downloaded.
   if (util.file_exists(checkout)) then
-    print(script.." already cloned; fetching instead...")
-    command = "cd "..checkout.."; git fetch"
+    print(script.." already cloned; pulling instead...")
+    command = "cd "..checkout.."; git pull"
   end
 
   local status = os.execute(command)

--- a/lua/core/norns.lua
+++ b/lua/core/norns.lua
@@ -172,7 +172,20 @@ end
 
 -- fetch (git clone)
 norns.fetch = function(url)
-  local status = os.execute("cd "..paths.code.."; git clone "..url)
+  -- default to clone.
+  local command = "cd "..paths.code.."; git clone "..url
+
+  local parts = tab.split(url, "/")
+  local script = parts[#parts]
+  local checkout = paths.code.."/"..script
+
+  -- fetch if already downloaded.
+  if (util.file_exists(checkout)) then
+    print(script.." already cloned; fetching instead...")
+    command = "cd "..checkout.."; git fetch"
+  end
+
+  local status = os.execute(command)
   if status then print("fetch: success. you may need to SYSTEM > RESET if the new project contains an engine")
   else print("fetch: FAIL") end
 end


### PR DESCRIPTION
useful for me but i won't be offended if this stretches the original intent to (and past) a breaking point.

tl;dr: if a script has already been cloned (or if it looks like it has because there's an existing directory with its name), do an actual `"fetch"`.

/cc @tehn 