### PR TITLE
constrain a positive number to a positive min/max range

### DIFF
--- a/lua/lib/util.lua
+++ b/lua/lib/util.lua
@@ -228,4 +228,19 @@ function util.acronym(name)
   return (name:gsub("%s+", ""))
 end
 
+--- constrain a positive number to a positive min/max range
+-- @tparam number value
+-- @tparam number min
+-- @tparam number max
+-- @treturn number cycled value
+function util.cycle(value, min, max)
+  if value > max then
+    return util.cycle(value - max, min, max)
+  elseif value < min then
+    return util.cycle(max - value, min, max)
+  else
+    return value
+  end
+end
+
 return util

--- a/lua/lib/util.lua
+++ b/lua/lib/util.lua
@@ -228,12 +228,12 @@ function util.acronym(name)
   return (name:gsub("%s+", ""))
 end
 
---- wrap a positive number to a positive min/max range
--- @tparam number value
+--- wrap a number to a positive min/max range
+-- @tparam number n
 -- @tparam number min
 -- @tparam number max
 -- @treturn number cycled value
-function util.wrap(value, min, max)
+function util.wrap(n, min, max)
   local y = value
   local d = max - min + 1
   while y > max do
@@ -243,6 +243,15 @@ function util.wrap(value, min, max)
     y = y + d
   end
   return y
+end
+
+--- wrap a number to a positive min/max range but clamp the min
+-- @tparam number n
+-- @tparam number min
+-- @tparam number max
+-- @treturn number cycled value
+function util.wrap_max(n, min, max)
+  return util.wrap(util.clamp(n, min, max), min, max)
 end
 
 return util

--- a/lua/lib/util.lua
+++ b/lua/lib/util.lua
@@ -234,7 +234,7 @@ end
 -- @tparam number max
 -- @treturn number cycled value
 function util.wrap(n, min, max)
-  local y = value
+  local y = n
   local d = max - min + 1
   while y > max do
     y = y - d
@@ -251,7 +251,15 @@ end
 -- @tparam number max
 -- @treturn number cycled value
 function util.wrap_max(n, min, max)
-  return util.wrap(util.clamp(n, min, max), min, max)
+  local y = n
+  local d = max - min + 1
+  while y > max do
+    y = y - d
+  end
+  if y < min then
+    y = min
+  end
+  return y
 end
 
 return util

--- a/lua/lib/util.lua
+++ b/lua/lib/util.lua
@@ -239,7 +239,7 @@ function util.cycle(value, min, max)
   while y > max do
     y = y - d
   end
-  while value < min do
+  while y < min do
     y = y + d
   end
   return y

--- a/lua/lib/util.lua
+++ b/lua/lib/util.lua
@@ -228,12 +228,12 @@ function util.acronym(name)
   return (name:gsub("%s+", ""))
 end
 
---- constrain a positive number to a positive min/max range
+--- wrap a positive number to a positive min/max range
 -- @tparam number value
 -- @tparam number min
 -- @tparam number max
 -- @treturn number cycled value
-function util.cycle(value, min, max)
+function util.wrap(value, min, max)
   local y = value
   local d = max - min + 1
   while y > max do

--- a/lua/lib/util.lua
+++ b/lua/lib/util.lua
@@ -234,13 +234,15 @@ end
 -- @tparam number max
 -- @treturn number cycled value
 function util.cycle(value, min, max)
-  if value > max then
-    return util.cycle(value - max, min, max)
-  elseif value < min then
-    return util.cycle(max - value, min, max)
-  else
-    return value
+  local y = value
+  local d = max - min + 1
+  while y > max do
+    y = y - d
   end
+  while value < min do
+    y = y + d
+  end
+  return y
 end
 
 return util


### PR DESCRIPTION
i end up writing a function like this for just about every script. it is most often used to keep track of transport steps, but has other applications.

```lua
-- "cycle" back around to 1
util.cycle(17, 1, 16) -- 1 (first beat of 2nd measure)

-- recursive to handle "over cycling"
util.cycle(33, 1, 16) -- 1 (first beat of 3rd measure)
util.cycle(37, 1, 16) -- 5 (fifth beat of 3rd measure)
util.cycle(1024, 1, 16) -- 16 (last beat of 16th measure)

-- adjustable min if you want to confuse yourself
util.cycle(13, 2, 7) -- 6
util.cycle(13, 4, 10) -- 7

-- no change to a value within the range
util.cycle(1, 1, 16) -- 1
util.cycle(13, 1, 16) -- 13
```

