### PR TITLE
Fix nil value error in Script.load

### DIFF
--- a/lua/core/script.lua
+++ b/lua/core/script.lua
@@ -117,8 +117,8 @@ Script.load = function(filename)
     name = norns.state.name
     path = norns.state.path
   else
-    filename = string.sub(filename,1,1) == "/" and filename or _path["dust"].."/"..filename
-    name = filename:match("^.*/(.+)$")
+    filename = string.sub(filename,1,1) == "/" and filename or _path["dust"]..filename
+    name = filename:match("^.*/(.+)$"):match("^([^.]+).*$")
     path = filename:match("^(.*/).+$")
   end
 

--- a/lua/core/script.lua
+++ b/lua/core/script.lua
@@ -118,8 +118,16 @@ Script.load = function(filename)
     path = norns.state.path
   else
     filename = string.sub(filename,1,1) == "/" and filename or _path["dust"]..filename
-    name = filename:match("^.*/(.+)$"):match("^([^.]+).*$")
-    path = filename:match("^(.*/).+$")
+    path, scriptname = filename:match("^(.*)/([^.]*).*$")
+    name = string.sub(path, string.len(_path["code"]) + 1)
+    
+    -- append scriptname to the name if it doesn't match directory name in case multiple scripts reside in the same directory
+    -- ex: we/study/study1, we/study/study2, ...
+    if string.sub(name, -#scriptname) ~= scriptname then
+      name_parts = tab.split(name, "/")
+      table.insert(name_parts, scriptname)
+      name = table.concat(name_parts, "/")
+    end
   end
 
   print("# script load: " .. filename)

--- a/lua/core/script.lua
+++ b/lua/core/script.lua
@@ -111,30 +111,15 @@ end
 --- load a script from the /scripts folder.
 -- @tparam string filename file to load. leave blank to reload current file.
 Script.load = function(filename)
-  local name, path, relative
+  local name, path
   if filename == nil then
     filename = norns.state.script
     name = norns.state.name
     path = norns.state.path
   else
-	if string.sub(filename,1,1) == "/" then
-	  relative = string.sub(filename,string.len(_path["dust"]))
-	else
-	  relative = filename
-	  filename = _path["dust"] .. filename
-	end
-
-	local t = tab.split(string.sub(relative,0,-5),"/")
-	if t[#t] == t[#t-1] then
-	  name = t[#t]
-	else
-	  name = t[#t-1].."/"..t[#t]
-	end
-  if #t==4 then name = t[2].."/"..name end -- dumb hack for 3-deep subfolers
-	path = string.sub(_path["dust"],0,-2)
-	for i = 1,#t-1 do path = path .. "/" .. t[i] end
-	--print("name "..name)
-	--print("final path "..path)
+    filename = string.sub(filename,1,1) == "/" and filename or _path["dust"].."/"..filename
+    name = filename:match("^.*/(.+)$")
+    path = filename:match("^(.*/).+$")
   end
 
   print("# script load: " .. filename)


### PR DESCRIPTION
I was exploring maiden and ran into an error. I created a simple `print("hello there")` script at `home/we/dust/untitled.lua` and got the following output when running it in maiden:

```
norns.script.load("untitled.lua")
lua: 
/home/we/norns/lua/core/script.lua:131: attempt to concatenate a nil value (field '?')
stack traceback:
	/home/we/norns/lua/core/script.lua:131: in function 'core/script.load'
	(...tail calls...)
```

So, I dug into the `Script.load` function in `script.lua` and got the general idea of what it was doing, but it was a bit confusing with the "hack for 3-deep subfol[d]ers" and all, so I tried to clean it up and got it working for my simple script. I could be missing some assumptions or cases the previous code was handling, but this seems correct.

I verified that various apps seem to work (or at least load without error when I wasn't sure how to _use_ them), including cyrene and orca, which have multiple levels of subfolders.
