### PR TITLE
fix internal clock reset action, typo in help

### DIFF
--- a/lua/core/clock.lua
+++ b/lua/core/clock.lua
@@ -225,7 +225,7 @@ function clock.add_params()
   params:set_action("clock_reset",
     function()
       local source = params:string("clock_source")
-      if source == "internal" then clock.internal.start(bpm)
+      if source == "internal" then clock.internal.start()
       elseif source == "link" then print("link reset not supported") end
     end)
   params:add_number("link_quantum", "link quantum", 1, 32, norns.state.clock.link_quantum)
@@ -330,7 +330,7 @@ end
 
 -- this function loops forever, printing at 1 second intervals 
 function loop()
-  while true do:
+  while true do
     print("so true")
     clock.sleep(1)
   end


### PR DESCRIPTION
tiny fix - clock "reset" parameter was passing `bpm` to `clock.internal.start()`. `bpm` being a nil value there, it didn't really matter but did obscure the intent of the code.

also fixed a stray pythonism in the clock help() demo code.