### PR TITLE
update mechanism to install beta

### DIFF
--- a/lua/core/menu/update.lua
+++ b/lua/core/menu/update.lua
@@ -1,11 +1,10 @@
 local m = {
   alt = false,
-  install = 1,
-  version = ''
+  install = "stable"
 }
 
-local releases = {}
-local VER = { 1="stable", 2="beta" }
+releases = {}
+local VER = { "stable", "beta" }
 
 local function checked() print("what??") end
 local function get_update_2() end
@@ -44,7 +43,7 @@ local function get_update()
   m.message = "downloading..."
   _menu.redraw()
   print("starting download...")
-  local cmd = "wget -T 180 -q -P /home/we/update/ " .. releases[m.install].url
+  local cmd = "wget -T 180 -q -P /home/we/update/ " .. releases[m.install].url .. " " .. releases[m.install].sha
   print("> "..cmd)
   norns.system_cmd(cmd, get_update_2) --download
   _menu.timer.time = 0.5
@@ -159,6 +158,7 @@ m.redraw = function()
 end
 
 m.init = function()
+  m.install = "stable"
   m.alt = _menu.alt
 
   m.stage = "init"

--- a/lua/core/menu/update.lua
+++ b/lua/core/menu/update.lua
@@ -19,6 +19,7 @@ local function check_newest()
 end
 
 checked = function(result)
+  print(result)
   load(result)()
 
   if m.alt==false and tonumber(norns.version.update) >= tonumber(releases.stable.version) then


### PR DESCRIPTION
added `releases.txt` which acts like a catalog

SYSTEM > UPDATE now queries this file (remotely, the live version on github, not the local copy)

normal update is exactly the same, checks against version.

if K1 is held when entering UPDATE, you are presented with two options: stable and beta, select-able with E2.

this allows forced re-update of stable, or installation of beta. theoretically this allows people to switch between both versions.

the backend is the same, ie update.sh. there will be no "reversion" of system-level changes (ie packages, systemctl units, etc), so we need to be aware about that going forward.

will do some additional testing when i get a non-dev unit, but initial tests show all is well.

ps. right now the `releases.txt` just has stable and beta pointing at the same files. we can update what these point to by commiting to `main` whenever, so this adds the benefit of having the system not live-query the github releases API, which had some people accidentally updating early when something wasn't finished.