### PR TITLE
added missing fonts to api documentation

### DIFF
--- a/doc/modules/screen.html
+++ b/doc/modules/screen.html
@@ -942,6 +942,59 @@
 <p> 12 Roboto Medium Italic
 <p> 13 Roboto Bold Italic
 <p> 14 Roboto Black Italic
+<p> 15 VeraBd
+<p> 16 VeraBI
+<p> 17 VeraIt
+<p> 18 VeraMoBd
+<p> 19 VeraMoBI
+<p> 20 VeraMoIt
+<p> 21 VeraMono
+<p> 22 VeraSeBd
+<p> 23 VeraSe
+<p> 24 Vera
+<p> 25 bmp/tom-thumb
+<p> 26 creep
+<p> 27 ctrld-fixed-10b
+<p> 28 ctrld-fixed-10r
+<p> 29 ctrld-fixed-13b
+<p> 30 ctrld-fixed-13b-i
+<p> 31 ctrld-fixed-13r
+<p> 32 ctrld-fixed-13r-i
+<p> 33 ctrld-fixed-16b
+<p> 34 ctrld-fixed-16b-i
+<p> 35 ctrld-fixed-16r
+<p> 36 ctrld-fixed-16r-i
+<p> 37 scientifica-11
+<p> 38 scientificaBold-11
+<p> 39 scientificaItalic-11
+<p> 40 ter-u12b
+<p> 41 ter-u12n
+<p> 42 ter-u14b
+<p> 43 ter-u14n
+<p> 44 ter-u14v
+<p> 45 ter-u16b
+<p> 46 ter-u16n
+<p> 47 ter-u16v
+<p> 48 ter-u18b
+<p> 49 ter-u18n
+<p> 50 ter-u20b
+<p> 51 ter-u20n
+<p> 52 ter-u22b
+<p> 53 ter-u22n
+<p> 54 ter-u24b
+<p> 55 ter-u24n
+<p> 56 ter-u28b
+<p> 57 ter-u28n
+<p> 58 ter-u32b
+<p> 59 ter-u32n
+<p> 60 unscii-16-full.pcf
+<p> 61 unscii-16.pcf
+<p> 62 unscii-8-alt.pcf
+<p> 63 unscii-8-fantasy.pcf
+<p> 64 unscii-8-mcr.pcf
+<p> 65 unscii-8.pcf
+<p> 66 unscii-8-tall.pcf
+<p> 67unscii-8-thin.pcf
         </li>
     </ul>
 

--- a/lua/core/screen.lua
+++ b/lua/core/screen.lua
@@ -187,32 +187,72 @@ Screen.text_extents = function(str) return _norns.screen_text_extents(str) end
 -- @param index font face (see list)
 --
 -- 1 04B_03 (norns default)
---
 -- 2 ALEPH
---
 -- 3 Roboto Thin
---
 -- 4 Roboto Light
---
 -- 5 Roboto Regular
---
 -- 6 Roboto Medium
---
 -- 7 Roboto Bold
---
 -- 8 Roboto Black
---
 -- 9 Roboto Thin Italic
---
 -- 10 Roboto Light Italic
---
 -- 11 Roboto Italic
---
 -- 12 Roboto Medium Italic
---
 -- 13 Roboto Bold Italic
---
 -- 14 Roboto Black Italic
+-- 15 VeraBd
+-- 16 VeraBI
+-- 17 VeraIt
+-- 18 VeraMoBd
+-- 19 VeraMoBI
+-- 20 VeraMoIt
+-- 21 VeraMono
+-- 22 VeraSeBd
+-- 23 VeraSe
+-- 24 Vera
+-- 25 bmp/tom-thumb
+-- 26 creep
+-- 27 ctrld-fixed-10b
+-- 28 ctrld-fixed-10r
+-- 29 ctrld-fixed-13b
+-- 30 ctrld-fixed-13b-i
+-- 31 ctrld-fixed-13r
+-- 32 ctrld-fixed-13r-i
+-- 33 ctrld-fixed-16b
+-- 34 ctrld-fixed-16b-i
+-- 35 ctrld-fixed-16r
+-- 36 ctrld-fixed-16r-i
+-- 37 scientifica-11
+-- 38 scientificaBold-11
+-- 39 scientificaItalic-11
+-- 40 ter-u12b
+-- 41 ter-u12n
+-- 42 ter-u14b
+-- 43 ter-u14n
+-- 44 ter-u14v
+-- 45 ter-u16b
+-- 46 ter-u16n
+-- 47 ter-u16v
+-- 48 ter-u18b
+-- 49 ter-u18n
+-- 50 ter-u20b
+-- 51 ter-u20n
+-- 52 ter-u22b
+-- 53 ter-u22n
+-- 54 ter-u24b
+-- 55 ter-u24n
+-- 56 ter-u28b
+-- 57 ter-u28n
+-- 58 ter-u32b
+-- 59 ter-u32n
+-- 60 unscii-16-full.pcf
+-- 61 unscii-16.pcf
+-- 62 unscii-8-alt.pcf
+-- 63 unscii-8-fantasy.pcf
+-- 64 unscii-8-mcr.pcf
+-- 65 unscii-8.pcf
+-- 66 unscii-8-tall.pcf
+-- 67 unscii-8-thin.pcf
 Screen.font_face = function(index) _norns.screen_font_face(index) end
 
 --- set font size.


### PR DESCRIPTION
While trying to insert some special characters into my project i checked this part of the API to find only 14 font faces on norns. Later, the "Foundry"-App was pointed out to me, which made me aware of all the different fonts available.

I am not sure if the API-list was truncated on purpose, if not, here is a proposal for a complete list of fonts.