### PR TITLE
implements Taper:get_range()

### DIFF
--- a/lua/core/params/taper.lua
+++ b/lua/core/params/taper.lua
@@ -112,4 +112,9 @@ function Taper:string()
   return string.format(format, v)
 end
 
+function Taper:get_range()
+  local r = { self.min, self.max }
+  return r
+end
+
 return Taper


### PR DESCRIPTION
adds get_range() to the ``taper`` type param.

this would also make sense for ``control`` types, but i'm not sure how to get the min/max values from the controlspecs.