### PR TITLE
add function to rebuild params after change in visibility

### DIFF
--- a/lua/core/menu/params.lua
+++ b/lua/core/menu/params.lua
@@ -11,6 +11,7 @@ local m = {
   pos = 0,
   oldpos = 0,
   group = false,
+  groupid = 0,
   alt = false,
   mode = mSELECT,
   mode_prev = mSELECT,
@@ -162,6 +163,7 @@ m.key = function(n,z)
       if t == params.tGROUP then
         build_sub(i)
         m.group = true
+        m.groupid = i
         m.groupname = params:string(i)
         m.oldpos = m.pos
         m.pos = 0
@@ -630,6 +632,17 @@ m.deinit = function()
   _menu.timer:stop()
 end
 
+_menu.rebuild_params = function()
+  if m.mode == mEDIT or m.mode == mMAP then 
+    if m.group then
+      build_sub(m.groupid)
+      _menu.redraw()
+    else
+      build_page()
+      _menu.redraw()
+    end
+  end
+end
 
 norns.menu_midi_event = function(data, dev)
   local ch = data[1] - 175


### PR DESCRIPTION
as mentioned in #1319 this change is meant to provide a way to refresh a menu screen manually when the visibility of elements change. this requires "rebuilding" the page/group menu to find newly visible/invisible elements. 

here is some test code that doesn't work without this change, but does work with this change.

```lua
-- test rebuild_params

function init()
    params:add_option("switch","switch",{"a","b"},1)
    params:set_action("switch",function(val)
      params:show("param"..val)
      params:hide("param"..(3-val))
      if _menu.rebuild_params ~= nil then
          _menu.rebuild_params()
      end
    end)
    params:add_control("param1","a",controlspec.new(0,1,"lin",0.1,0.1))
    params:add_control("param2","b",controlspec.new(0,1,"lin",0.1,0.5))
    params:hide("param2")

    params:add_group("grouped",3)
    params:add_option("switch2","switch2",{"c","d"},1)
    params:set_action("switch2",function(val)
      params:show("gparam"..val)
      params:hide("gparam"..(3-val))
      if _menu.rebuild_params ~= nil then
          _menu.rebuild_params()
      end
    end)
    params:add_control("gparam1","c",controlspec.new(0,1,"lin",0.1,0.3))
    params:add_control("gparam2","d",controlspec.new(0,1,"lin",0.1,0.9))
    params:hide("gparam2")
end
```