### PR TITLE
add hard restart to lattice

### DIFF
--- a/lua/lib/lattice.lua
+++ b/lua/lib/lattice.lua
@@ -1,8 +1,8 @@
 --- module for creating a lattice of patterns based on a single fast "superclock"
 --
 -- @module Lattice
--- @release v1.0.0
--- @author tyleretters & ezra
+-- @release v1.1.0
+-- @author tyleretters & ezra & zack
 
 local Lattice, Pattern = {}, {}
 
@@ -28,10 +28,26 @@ end
 
 --- start running the lattice
 function Lattice:start()
+  self.enabled = true
   if self.auto and self.superclock_id == nil then
     self.superclock_id = clock.run(self.auto_pulse, self)
   end
-  self.enabled = true
+end
+
+--- reset the norns clock and restart lattice
+function Lattice:hard_restart()
+  -- destroy clock, but not the patterns
+  self:stop()
+  if self.superclock_id ~= nil then 
+    clock.cancel(self.superclock_id)
+    self.superclock_id = nil 
+  end
+  for i, pattern in pairs(self.patterns) do
+    self.patterns[i].phase = self.patterns[i].phase_end
+  end
+  self.transport = 0
+  params:set("clock_reset",1)
+  self:start()
 end
 
 --- stop the lattice
@@ -115,6 +131,7 @@ function Pattern:new(args)
   p.action = args.action
   p.enabled = args.enabled
   p.phase = args.phase_end
+  p.phase_end = args.phase_end
   p.flag = false
   return p
 end


### PR DESCRIPTION
this adds an api to do a "hard restart" in the lattice lib. this fixes a prospective problem if you stop and start a lattice. right now if you do `:stop()` followed by a `:start()`, you will most likely miss the first beat. here's an example with quarter notes at 120 bpm from running example code below:

```
start 232.149251708
qn1     232.149551916 <- first one starts on time
...
stop 234.389011044
start 236.568941924
qn1     237.323161172 <- after stopping this "restart" is delayed
```

one way around this is to do a "restart" which resets the clock, the transports, the patterns, etc. i call it a "hard restart" because it resets the clock. resetting the clock has the benefit to allow you to sync multiple scripts with multiple lattices on the same clock. but it does reset the clock so maybe that might not be for everyone, hence the "hard restart".

here is the example (same script below):

```
stop 3.0351133740005
qn1     0.00037551799869107 <- within 1 ms of restart
restarted 0.00065281000024697 
```

i already use a forked version of lattice with this in several scripts (kolor, oooooo) and its starting to be used in others (initenere) so it might be good to incorporate some idea of this (but not necessarily this implementation!).

pinging @tyleretters who initiated this brilliant and amazing lib

test code:

```lua
-- lattice wip

lattice = include("lib/lattice")
-- lattice = include("lattice/lib/lattice")

function init()
  -- basic lattice usage (uses defaults)
  my_lattice = lattice:new()
  my_lattice2 = lattice:new()

  pattern_a = my_lattice:new_pattern{
    action = function(t) print("qn1", clock.get_beats()) end,
    division = 1/4
  }

  pattern_b = my_lattice2:new_pattern{
    action = function(t) print("qn2", clock.get_beats()) end,
    division = 1/4
  }

  -- demo stuff
  screen_dirty = true
  redraw_clock_id = clock.run(redraw_clock)
end

function key(k, z)
  if z == 0 then return end
  if k == 2 then
    print("start "..clock.get_beats())
    my_lattice:start()
    my_lattice2:start()
  elseif k == 3 then
    print("stop "..clock.get_beats())
    my_lattice:stop()
    my_lattice2:stop()
  elseif k == 1 then
    print("restart "..clock.get_beats())
    my_lattice:hard_restart()
    my_lattice2:hard_restart()
    print("restarted "..clock.get_beats())
  end
end

function enc(e, d)
  params:set("clock_tempo", params:get("clock_tempo") + d)
  screen_dirty = true
end

function cleanup()
  my_lattice:destroy()
end

-- screen stuff

function redraw_clock()
  while true do
    clock.sleep(1/15)
    if screen_dirty then
      redraw()
      screen_dirty = false
    end
  end
end

function redraw()
  screen.clear()
  screen.level(15)
  screen.aa(0)
  screen.font_size(8)
  screen.font_face(0)
  screen.move(1, 8)
  screen.text(params:get("clock_tempo") .. " BPM")
  screen.update()
end

function rerun()
  norns.script.load(norns.state.script)
end
```