### PR TITLE
monitor individual cpu cores

### DIFF
--- a/lua/core/menu/home.lua
+++ b/lua/core/menu/home.lua
@@ -61,22 +61,24 @@ m.redraw = function()
   else
     screen.level(1)
     if norns.is_norns then
-      screen.move(0,10)
-      screen.text("BAT " .. norns.battery_percent)
-      screen.move(36,10)
-      screen.text(norns.battery_current .. "mA")
+      screen.move(127,55)
+      screen.text_right(norns.battery_current.."mA @ ".. norns.battery_percent.."%")
+      --screen.move(36,10)
+      --screen.text(norns.battery_current .. "mA")
     end
+    screen.move(0,10) screen.text("cpu")
+    screen.move(30,10) screen.text_right(norns.cpu[1]..".")
+    screen.move(45,10) screen.text_right(norns.cpu[2]..".")
+    screen.move(60,10) screen.text_right(norns.cpu[3]..".")
+    screen.move(75,10) screen.text_right(norns.cpu[4]..".")
     screen.move(127,10)
-    screen.text_right("DISK " .. norns.disk .. "M")
+    screen.text_right(norns.temp .. "c")
+
     screen.move(0,20)
-    screen.text("CPU " .. norns.cpu .. "%")
-    screen.move(36,20)
-    screen.text(norns.temp .. "c")
+    screen.text("disk " .. norns.disk .. "M")
     screen.move(127,20)
     if wifi.state > 0 then
-      screen.text_right("IP "..wifi.ip)
-    else
-      screen.text_right("IP -")
+      screen.text_right(wifi.ip)
     end
     screen.move(127,45)
     screen.text_right(norns.version.update)

--- a/lua/core/norns.lua
+++ b/lua/core/norns.lua
@@ -109,11 +109,16 @@ _norns.power = function(present)
 end
 
 -- stat handler
-_norns.stat = function(disk, temp, cpu)
+_norns.stat = function(disk, temp, cpu, cpu1, cpu2, cpu3, cpu4)
   --print("stat",disk,temp,cpu)
   norns.disk = disk
   norns.temp = temp
-  norns.cpu = cpu
+  norns.cpu_avg = cpu
+  norns.cpu = {}
+  norns.cpu[1] = cpu1
+  norns.cpu[2] = cpu2
+  norns.cpu[3] = cpu3
+  norns.cpu[4] = cpu4
 end
 
 

--- a/matron/src/event_types.h
+++ b/matron/src/event_types.h
@@ -222,6 +222,10 @@ struct event_stat {
     uint16_t disk;
     uint8_t temp;
     uint8_t cpu;
+    uint8_t cpu1;
+    uint8_t cpu2;
+    uint8_t cpu3;
+    uint8_t cpu4;
 };
 
 struct event_enc {

--- a/matron/src/events.c
+++ b/matron/src/events.c
@@ -201,7 +201,8 @@ static void handle_event(union event_data *ev) {
         w_handle_power(ev->power.present);
         break;
     case EVENT_STAT:
-        w_handle_stat(ev->stat.disk, ev->stat.temp, ev->stat.cpu);
+        w_handle_stat(ev->stat.disk, ev->stat.temp, ev->stat.cpu, ev->stat.cpu1, ev->stat.cpu2,
+            ev->stat.cpu3, ev->stat.cpu4);
         break;
     case EVENT_MONOME_ADD:
         w_handle_monome_add(ev->monome_add.dev);

--- a/matron/src/weaver.c
+++ b/matron/src/weaver.c
@@ -1987,14 +1987,19 @@ void w_handle_power(const int present) {
 }
 
 // stat
-void w_handle_stat(const uint32_t disk, const uint16_t temp, const uint16_t cpu) {
+void w_handle_stat(const uint32_t disk, const uint16_t temp, const uint16_t cpu,
+    const uint16_t cpu1, const uint16_t cpu2, const uint16_t cpu3, const uint16_t cpu4) {
     lua_getglobal(lvm, "_norns");
     lua_getfield(lvm, -1, "stat");
     lua_remove(lvm, -2);
     lua_pushinteger(lvm, disk);
     lua_pushinteger(lvm, temp);
     lua_pushinteger(lvm, cpu);
-    l_report(lvm, l_docall(lvm, 3, 0));
+    lua_pushinteger(lvm, cpu1);
+    lua_pushinteger(lvm, cpu2);
+    lua_pushinteger(lvm, cpu3);
+    lua_pushinteger(lvm, cpu4);
+    l_report(lvm, l_docall(lvm, 7, 0));
 }
 
 void w_handle_poll_value(int idx, float val) {

--- a/matron/src/weaver.h
+++ b/matron/src/weaver.h
@@ -65,7 +65,8 @@ extern void w_handle_battery(const int percent, const int current);
 extern void w_handle_power(const int present);
 
 //--- system/stat
-extern void w_handle_stat(const uint32_t disk, const uint16_t temp, const uint16_t cpu);
+extern void w_handle_stat(const uint32_t disk, const uint16_t temp, const uint16_t cpu,
+    const uint16_t cpu1, const uint16_t cpu2, const uint16_t cpu3, const uint16_t cpu4);
 
 //--- metro bang handler
 extern void w_handle_metro(const int idx, const int stage);


### PR DESCRIPTION
cpu monitoring was misleading ("it's only at 33%!") because it was an average of 4 cores

now the individual cores are shown. still has the average cpu available via `norns.cpu_avg` though the only place any of this is ever used is the alt-home screen.

![cpu](https://user-images.githubusercontent.com/246896/109900309-2937dc80-7c65-11eb-898c-7c23296d189e.png)

