### PR TITLE
update OSC handler signatures

### DIFF
--- a/lua/core/menu/home.lua
+++ b/lua/core/menu/home.lua
@@ -61,22 +61,24 @@ m.redraw = function()
   else
     screen.level(1)
     if norns.is_norns then
-      screen.move(0,10)
-      screen.text("BAT " .. norns.battery_percent)
-      screen.move(36,10)
-      screen.text(norns.battery_current .. "mA")
+      screen.move(127,55)
+      screen.text_right(norns.battery_current.."mA @ ".. norns.battery_percent.."%")
+      --screen.move(36,10)
+      --screen.text(norns.battery_current .. "mA")
     end
+    screen.move(0,10) screen.text("cpu")
+    screen.move(30,10) screen.text_right(norns.cpu[1]..".")
+    screen.move(45,10) screen.text_right(norns.cpu[2]..".")
+    screen.move(60,10) screen.text_right(norns.cpu[3]..".")
+    screen.move(75,10) screen.text_right(norns.cpu[4]..".")
     screen.move(127,10)
-    screen.text_right("DISK " .. norns.disk .. "M")
+    screen.text_right(norns.temp .. "c")
+
     screen.move(0,20)
-    screen.text("CPU " .. norns.cpu .. "%")
-    screen.move(36,20)
-    screen.text(norns.temp .. "c")
+    screen.text("disk " .. norns.disk .. "M")
     screen.move(127,20)
     if wifi.state > 0 then
-      screen.text_right("IP "..wifi.ip)
-    else
-      screen.text_right("IP -")
+      screen.text_right(wifi.ip)
     end
     screen.move(127,45)
     screen.text_right(norns.version.update)

--- a/lua/core/norns.lua
+++ b/lua/core/norns.lua
@@ -109,11 +109,16 @@ _norns.power = function(present)
 end
 
 -- stat handler
-_norns.stat = function(disk, temp, cpu)
+_norns.stat = function(disk, temp, cpu, cpu1, cpu2, cpu3, cpu4)
   --print("stat",disk,temp,cpu)
   norns.disk = disk
   norns.temp = temp
-  norns.cpu = cpu
+  norns.cpu_avg = cpu
+  norns.cpu = {}
+  norns.cpu[1] = cpu1
+  norns.cpu[2] = cpu2
+  norns.cpu[3] = cpu3
+  norns.cpu[4] = cpu4
 end
 
 

--- a/matron/src/event_types.h
+++ b/matron/src/event_types.h
@@ -222,6 +222,10 @@ struct event_stat {
     uint16_t disk;
     uint8_t temp;
     uint8_t cpu;
+    uint8_t cpu1;
+    uint8_t cpu2;
+    uint8_t cpu3;
+    uint8_t cpu4;
 };
 
 struct event_enc {

--- a/matron/src/events.c
+++ b/matron/src/events.c
@@ -201,7 +201,8 @@ static void handle_event(union event_data *ev) {
         w_handle_power(ev->power.present);
         break;
     case EVENT_STAT:
-        w_handle_stat(ev->stat.disk, ev->stat.temp, ev->stat.cpu);
+        w_handle_stat(ev->stat.disk, ev->stat.temp, ev->stat.cpu, ev->stat.cpu1, ev->stat.cpu2,
+            ev->stat.cpu3, ev->stat.cpu4);
         break;
     case EVENT_MONOME_ADD:
         w_handle_monome_add(ev->monome_add.dev);

--- a/matron/src/oracle.c
+++ b/matron/src/oracle.c
@@ -76,43 +76,45 @@ static void o_set_command(int idx, const char *name, const char *format);
 static void o_set_num_desc(int *dst, int num);
 
 //--- OSC handlers
-
-static int handle_crone_ready(const char *path, const char *types, lo_arg **argv, int argc, void *data,
-                              void *user_data);
-static int handle_engine_report_start(const char *path, const char *types, lo_arg **argv, int argc, void *data,
-                                      void *user_data);
-static int handle_engine_report_entry(const char *path, const char *types, lo_arg **argv, int argc, void *data,
-                                      void *user_data);
-static int handle_engine_report_end(const char *path, const char *types, lo_arg **argv, int argc, void *data,
-                                    void *user_data);
-static int handle_command_report_start(const char *path, const char *types, lo_arg **argv, int argc, void *data,
-                                       void *user_data);
-static int handle_command_report_entry(const char *path, const char *types, lo_arg **argv, int argc, void *data,
-                                       void *user_data);
-static int handle_command_report_end(const char *path, const char *types, lo_arg **argv, int argc, void *data,
-                                     void *user_data);
-static int handle_poll_report_start(const char *path, const char *types, lo_arg **argv, int argc, void *data,
-                                    void *user_data);
-static int handle_poll_report_entry(const char *path, const char *types, lo_arg **argv, int argc, void *data,
-                                    void *user_data);
-static int handle_poll_report_end(const char *path, const char *types, lo_arg **argv, int argc, void *data,
-                                  void *user_data);
-static int handle_poll_value(const char *path, const char *types, lo_arg **argv, int argc, void *data, void *user_data);
-static int handle_poll_data(const char *path, const char *types, lo_arg **argv, int argc, void *data, void *user_data);
+static int handle_crone_ready(const char *path, const char *types, lo_arg **argv, int argc,
+			      struct lo_message_ *data, void *user_data);
+static int handle_engine_report_start(const char *path, const char *types, lo_arg **argv, int argc,
+				      struct lo_message_ *data, void *user_data);
+static int handle_engine_report_entry(const char *path, const char *types, lo_arg **argv, int argc,
+				      struct lo_message_ *data, void *user_data);
+static int handle_engine_report_end(const char *path, const char *types, lo_arg **argv, int argc,
+				    struct lo_message_ *data, void *user_data);
+static int handle_command_report_start(const char *path, const char *types, lo_arg **argv, int argc,
+				       struct lo_message_ *data, void *user_data);
+static int handle_command_report_entry(const char *path, const char *types, lo_arg **argv, int argc,
+				       struct lo_message_ *data, void *user_data);
+static int handle_command_report_end(const char *path, const char *types, lo_arg **argv, int argc,
+				     struct lo_message_ *data, void *user_data);
+static int handle_poll_report_start(const char *path, const char *types, lo_arg **argv, int argc,
+				    struct lo_message_ *data, void *user_data);
+static int handle_poll_report_entry(const char *path, const char *types, lo_arg **argv, int argc,
+				    struct lo_message_ *data, void *user_data);
+static int handle_poll_report_end(const char *path, const char *types, lo_arg **argv, int argc,
+				  struct lo_message_ *data, void *user_data);
+static int handle_poll_value(const char *path, const char *types, lo_arg **argv, int argc,
+			     struct lo_message_ *data, void *user_data);
+static int handle_poll_data(const char *path, const char *types, lo_arg **argv, int argc,
+			    struct lo_message_ *data, void *user_data);
 /* static int handle_poll_wave(const char *path, const char *types, */
 /*                              lo_arg **argv, int argc, */
-/*                              void *data, void *user_data); */
-static int handle_poll_io_levels(const char *path, const char *types, lo_arg **argv, int argc, void *data,
-                                 void *user_data);
+/*                              
+struct lo_message_ *data, void *user_data); */
+static int handle_poll_io_levels(const char *path, const char *types, lo_arg **argv, int argc,
+				 struct lo_message_ *data, void *user_data);
 
-static int handle_poll_softcut_phase(const char *path, const char *types, lo_arg **argv, int argc, void *data,
-                                     void *user_data);
+static int handle_poll_softcut_phase(const char *path, const char *types, lo_arg **argv, int argc,
+				     struct lo_message_ *data, void *user_data);
 
-static int handle_softcut_render(const char *path, const char *types, lo_arg **argv, int argc, void *data,
-                                 void *user_data);
+static int handle_softcut_render(const char *path, const char *types, lo_arg **argv, int argc,
+				 struct lo_message_ *data, void *user_data);
 
-static int handle_tape_play_state(const char *path, const char *types, lo_arg **argv, int argc, void *data,
-                                  void *user_data);
+static int handle_tape_play_state(const char *path, const char *types, lo_arg **argv, int argc,
+				  struct lo_message_ *data, void *user_data);
 
 static void lo_error_handler(int num, const char *m, const char *path);
 
@@ -663,13 +665,14 @@ void o_set_comp_param(const char *name, float value) {
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 
-int handle_crone_ready(const char *path, const char *types, lo_arg **argv, int argc, void *data, void *user_data) {
+int handle_crone_ready(const char *path, const char *types, lo_arg **argv, int argc,
+		       struct lo_message_ *data, void *user_data) {
     norns_hello_ok();
     return 0;
 }
 
-int handle_engine_report_start(const char *path, const char *types, lo_arg **argv, int argc, void *data,
-                               void *user_data) {
+int handle_engine_report_start(const char *path, const char *types, lo_arg **argv, int argc,
+			       struct lo_message_ *data, void *user_data) {
     assert(argc > 0);
     // arg 1: count of engines
     o_clear_engine_names();
@@ -677,8 +680,8 @@ int handle_engine_report_start(const char *path, const char *types, lo_arg **arg
     return 0;
 }
 
-int handle_engine_report_entry(const char *path, const char *types, lo_arg **argv, int argc, void *data,
-                               void *user_data) {
+int handle_engine_report_entry(const char *path, const char *types, lo_arg **argv, int argc,
+			       struct lo_message_ *data, void *user_data) {
     assert(argc > 1);
     // arg 1: engine index
     // arg 2: engine
@@ -687,8 +690,8 @@ int handle_engine_report_entry(const char *path, const char *types, lo_arg **arg
     return 0;
 }
 
-int handle_engine_report_end(const char *path, const char *types, lo_arg **argv, int argc, void *data,
-                             void *user_data) {
+int handle_engine_report_end(const char *path, const char *types, lo_arg **argv, int argc,
+			     struct lo_message_ *data, void *user_data) {
     // no arguments; post event
     event_post(event_data_new(EVENT_ENGINE_REPORT));
     return 0;
@@ -697,23 +700,23 @@ int handle_engine_report_end(const char *path, const char *types, lo_arg **argv,
 //---------------------
 //--- command report
 
-int handle_command_report_start(const char *path, const char *types, lo_arg **argv, int argc, void *data,
-                                void *user_data) {
+int handle_command_report_start(const char *path, const char *types, lo_arg **argv, int argc,
+				struct lo_message_ *data, void *user_data) {
     assert(argc > 0);
     o_clear_commands();
     o_set_num_desc(&num_commands, argv[0]->i);
     return 0;
 }
 
-int handle_command_report_entry(const char *path, const char *types, lo_arg **argv, int argc, void *data,
-                                void *user_data) {
+int handle_command_report_entry(const char *path, const char *types, lo_arg **argv, int argc,
+				struct lo_message_ *data, void *user_data) {
     assert(argc > 2);
     o_set_command(argv[0]->i, &argv[1]->s, &argv[2]->s);
     return 0;
 }
 
-int handle_command_report_end(const char *path, const char *types, lo_arg **argv, int argc, void *data,
-                              void *user_data) {
+int handle_command_report_end(const char *path, const char *types, lo_arg **argv, int argc,
+			      struct lo_message_ *data, void *user_data) {
     needCommandReport = false;
     test_engine_load_done();
     return 0;
@@ -722,8 +725,8 @@ int handle_command_report_end(const char *path, const char *types, lo_arg **argv
 //---------------------
 //--- poll report
 
-int handle_poll_report_start(const char *path, const char *types, lo_arg **argv, int argc, void *data,
-                             void *user_data) {
+int handle_poll_report_start(const char *path, const char *types, lo_arg **argv, int argc,
+			     struct lo_message_ *data, void *user_data) {
 
     assert(argc > 0);
     o_clear_polls();
@@ -731,8 +734,8 @@ int handle_poll_report_start(const char *path, const char *types, lo_arg **argv,
     return 0;
 }
 
-int handle_poll_report_entry(const char *path, const char *types, lo_arg **argv, int argc, void *data,
-                             void *user_data) {
+int handle_poll_report_entry(const char *path, const char *types, lo_arg **argv, int argc,
+			     struct lo_message_ *data, void *user_data) {
 
     assert(argc > 2);
     fflush(stdout);
@@ -740,7 +743,8 @@ int handle_poll_report_entry(const char *path, const char *types, lo_arg **argv,
     return 0;
 }
 
-int handle_poll_report_end(const char *path, const char *types, lo_arg **argv, int argc, void *data, void *user_data) {
+int handle_poll_report_end(const char *path, const char *types, lo_arg **argv, int argc,
+			   struct lo_message_ *data, void *user_data) {
 
     // event_post( event_data_new(EVENT_POLL_REPORT) );
     needPollReport = false;
@@ -748,7 +752,8 @@ int handle_poll_report_end(const char *path, const char *types, lo_arg **argv, i
     return 0;
 }
 
-int handle_poll_value(const char *path, const char *types, lo_arg **argv, int argc, void *data, void *user_data) {
+int handle_poll_value(const char *path, const char *types, lo_arg **argv, int argc,
+		      struct lo_message_ *data, void *user_data) {
 
     assert(argc > 1);
     union event_data *ev = event_data_new(EVENT_POLL_VALUE);
@@ -758,7 +763,8 @@ int handle_poll_value(const char *path, const char *types, lo_arg **argv, int ar
     return 0;
 }
 
-int handle_poll_data(const char *path, const char *types, lo_arg **argv, int argc, void *data, void *user_data) {
+int handle_poll_data(const char *path, const char *types, lo_arg **argv, int argc,
+		     struct lo_message_ *data, void *user_data) {
 
     assert(argc > 1);
     union event_data *ev = event_data_new(EVENT_POLL_DATA);
@@ -772,7 +778,8 @@ int handle_poll_data(const char *path, const char *types, lo_arg **argv, int arg
     return 0;
 }
 
-int handle_poll_io_levels(const char *path, const char *types, lo_arg **argv, int argc, void *data, void *user_data) {
+int handle_poll_io_levels(const char *path, const char *types, lo_arg **argv, int argc,
+			  struct lo_message_ *data, void *user_data) {
 
     assert(argc > 0);
     union event_data *ev = event_data_new(EVENT_POLL_IO_LEVELS);
@@ -785,8 +792,8 @@ int handle_poll_io_levels(const char *path, const char *types, lo_arg **argv, in
     return 0;
 }
 
-int handle_poll_softcut_phase(const char *path, const char *types, lo_arg **argv, int argc, void *data,
-                              void *user_data) {
+int handle_poll_softcut_phase(const char *path, const char *types, lo_arg **argv, int argc,
+			      struct lo_message_ *data, void *user_data) {
 
     assert(argc > 1);
     union event_data *ev = event_data_new(EVENT_POLL_SOFTCUT_PHASE);
@@ -797,14 +804,16 @@ int handle_poll_softcut_phase(const char *path, const char *types, lo_arg **argv
     return 0;
 }
 
-int handle_tape_play_state(const char *path, const char *types, lo_arg **argv, int argc, void *data, void *user_data) {
+int handle_tape_play_state(const char *path, const char *types, lo_arg **argv, int argc,
+			   struct lo_message_ *data, void *user_data) {
 
     // assert(argc > 0);
     // fprintf(stderr, "tape_play_status %s\n", &argv[0]->s);
     return 0;
 }
 
-int handle_softcut_render(const char *path, const char *types, lo_arg **argv, int argc, void *data, void *user_data) {
+int handle_softcut_render(const char *path, const char *types, lo_arg **argv, int argc,
+			  struct lo_message_ *data, void *user_data) {
     assert(argc > 2);
     union event_data *ev = event_data_new(EVENT_SOFTCUT_RENDER);
     ev->softcut_render.idx = argv[0]->i;

--- a/matron/src/weaver.c
+++ b/matron/src/weaver.c
@@ -1987,14 +1987,19 @@ void w_handle_power(const int present) {
 }
 
 // stat
-void w_handle_stat(const uint32_t disk, const uint16_t temp, const uint16_t cpu) {
+void w_handle_stat(const uint32_t disk, const uint16_t temp, const uint16_t cpu,
+    const uint16_t cpu1, const uint16_t cpu2, const uint16_t cpu3, const uint16_t cpu4) {
     lua_getglobal(lvm, "_norns");
     lua_getfield(lvm, -1, "stat");
     lua_remove(lvm, -2);
     lua_pushinteger(lvm, disk);
     lua_pushinteger(lvm, temp);
     lua_pushinteger(lvm, cpu);
-    l_report(lvm, l_docall(lvm, 3, 0));
+    lua_pushinteger(lvm, cpu1);
+    lua_pushinteger(lvm, cpu2);
+    lua_pushinteger(lvm, cpu3);
+    lua_pushinteger(lvm, cpu4);
+    l_report(lvm, l_docall(lvm, 7, 0));
 }
 
 void w_handle_poll_value(int idx, float val) {

--- a/matron/src/weaver.h
+++ b/matron/src/weaver.h
@@ -65,7 +65,8 @@ extern void w_handle_battery(const int percent, const int current);
 extern void w_handle_power(const int present);
 
 //--- system/stat
-extern void w_handle_stat(const uint32_t disk, const uint16_t temp, const uint16_t cpu);
+extern void w_handle_stat(const uint32_t disk, const uint16_t temp, const uint16_t cpu,
+    const uint16_t cpu1, const uint16_t cpu2, const uint16_t cpu3, const uint16_t cpu4);
 
 //--- metro bang handler
 extern void w_handle_metro(const int idx, const int stage);


### PR DESCRIPTION
this avoids a warning/error on some newer `gcc`s (`-Werror=incompatible-pointer-types`) for functions with `void*` parameters.