### PR TITLE
skip binary trigger in params:bang()

### DIFF
--- a/lua/core/paramset.lua
+++ b/lua/core/paramset.lua
@@ -434,7 +434,7 @@ end
 --- bang all params.
 function ParamSet:bang()
   for _,v in pairs(self.params) do
-    if v.t ~= self.tTRIGGER then
+    if v.t ~= self.tTRIGGER and not (v.t == self.tBINARY and v.behavior == 'trigger') then
       v:bang()
     end
   end


### PR DESCRIPTION
very small bug - skipping `binary` params with `trigger` behavior in the `params:bang()` loop, same behavior from the older trigger type