### PR TITLE
add callbacks for reading/writing parameters

### DIFF
--- a/lua/core/paramset.lua
+++ b/lua/core/paramset.lua
@@ -453,6 +453,8 @@ function ParamSet:clear()
   self.name = ""
   self.params = {}
   self.count = 0
+  self.action_read = nil 
+  self.action_write = nil
 end
 
 return ParamSet

--- a/lua/core/paramset.lua
+++ b/lua/core/paramset.lua
@@ -40,6 +40,8 @@ function ParamSet.new(id, name)
   ps.hidden = {}
   ps.lookup = {}
   ps.group = 0
+  ps.callback_write = nil
+  ps.callback_read = nil
   ParamSet.sets[ps.id] = ps
   return ps
 end
@@ -379,6 +381,9 @@ function ParamSet:write(filename, name)
       end
     end
     io.close(fd)
+    if self.callback_write ~= nil then 
+      self.callback_write(filename,name)
+    end
   else print("pset: BAD FILENAME") end
 end
 
@@ -420,9 +425,22 @@ function ParamSet:read(filename, silent)
         end
       end
     end
+    if self.callback_read ~= nil then 
+      self.callback_read(filename,silent)
+    end
   else
     print("pset :: "..filename.." not read.")
   end
+end
+
+-- set callback for after reading parameters
+function ParamSet:set_callback_read(func)
+  self.callback_read=func
+end
+
+-- set callback for after writing parameters
+function ParamSet:set_callback_write(func)
+  self.callback_write=func
 end
 
 --- read default pset if present.

--- a/lua/core/paramset.lua
+++ b/lua/core/paramset.lua
@@ -40,8 +40,8 @@ function ParamSet.new(id, name)
   ps.hidden = {}
   ps.lookup = {}
   ps.group = 0
-  ps.callback_write = nil
-  ps.callback_read = nil
+  ps.action_write = nil
+  ps.action_read = nil
   ParamSet.sets[ps.id] = ps
   return ps
 end
@@ -381,8 +381,8 @@ function ParamSet:write(filename, name)
       end
     end
     io.close(fd)
-    if self.callback_write ~= nil then 
-      self.callback_write(filename,name)
+    if self.action_write ~= nil then 
+      self.action_write(filename,name)
     end
   else print("pset: BAD FILENAME") end
 end
@@ -425,22 +425,12 @@ function ParamSet:read(filename, silent)
         end
       end
     end
-    if self.callback_read ~= nil then 
-      self.callback_read(filename,silent)
+    if self.action_read ~= nil then 
+      self.action_read(filename,silent)
     end
   else
     print("pset :: "..filename.." not read.")
   end
-end
-
--- set callback for after reading parameters
-function ParamSet:set_callback_read(func)
-  self.callback_read=func
-end
-
--- set callback for after writing parameters
-function ParamSet:set_callback_write(func)
-  self.callback_write=func
 end
 
 --- read default pset if present.


### PR DESCRIPTION
this PR addresses https://github.com/monome/norns/issues/1325

test code:

```lua
-- test
-- PSET read/write callbacks
-- press k2/k3 to write/read
-- try write/read with PSET menu

function init()
	params:set_callback_read(function(filename)
		print("finished reading '"..filename.."'")
	end)
	params:set_callback_write(function(filename,name)
		print("finished writing '"..filename.."'")
	end)
end

function key(k,z)
	if z==1 and k==2 then
		params:write("/tmp/parameters")
	elseif z==1 and k==3 then
		params:read("/tmp/parameters")
	end
end
```

i'm not attached to the api names, lmk if i can improve it.