### PR TITLE
Fix void pointer param again

### DIFF
--- a/matron/src/oracle.c
+++ b/matron/src/oracle.c
@@ -77,44 +77,44 @@ static void o_set_num_desc(int *dst, int num);
 
 //--- OSC handlers
 static int handle_crone_ready(const char *path, const char *types, lo_arg **argv, int argc,
-			      void *data, void *user_data);
+			      struct lo_message_ *data, void *user_data);
 static int handle_engine_report_start(const char *path, const char *types, lo_arg **argv, int argc,
-				      void *data, void *user_data);
+				      struct lo_message_ *data, void *user_data);
 static int handle_engine_report_entry(const char *path, const char *types, lo_arg **argv, int argc,
-				      void *data, void *user_data);
+				      struct lo_message_ *data, void *user_data);
 static int handle_engine_report_end(const char *path, const char *types, lo_arg **argv, int argc,
-				    void *data, void *user_data);
+				    struct lo_message_ *data, void *user_data);
 static int handle_command_report_start(const char *path, const char *types, lo_arg **argv, int argc,
-				       void *data, void *user_data);
+				       struct lo_message_ *data, void *user_data);
 static int handle_command_report_entry(const char *path, const char *types, lo_arg **argv, int argc,
-				       void *data, void *user_data);
+				       struct lo_message_ *data, void *user_data);
 static int handle_command_report_end(const char *path, const char *types, lo_arg **argv, int argc,
-				     void *data, void *user_data);
+				     struct lo_message_ *data, void *user_data);
 static int handle_poll_report_start(const char *path, const char *types, lo_arg **argv, int argc,
-				    void *data, void *user_data);
+				    struct lo_message_ *data, void *user_data);
 static int handle_poll_report_entry(const char *path, const char *types, lo_arg **argv, int argc,
-				    void *data, void *user_data);
+				    struct lo_message_ *data, void *user_data);
 static int handle_poll_report_end(const char *path, const char *types, lo_arg **argv, int argc,
-				  void *data, void *user_data);
+				  struct lo_message_ *data, void *user_data);
 static int handle_poll_value(const char *path, const char *types, lo_arg **argv, int argc,
-			     void *data, void *user_data);
+			     struct lo_message_ *data, void *user_data);
 static int handle_poll_data(const char *path, const char *types, lo_arg **argv, int argc,
-			    void *data, void *user_data);
+			    struct lo_message_ *data, void *user_data);
 /* static int handle_poll_wave(const char *path, const char *types, */
 /*                              lo_arg **argv, int argc, */
 /*                              
-void *data, void *user_data); */
+struct lo_message_ *data, void *user_data); */
 static int handle_poll_io_levels(const char *path, const char *types, lo_arg **argv, int argc,
-				 void *data, void *user_data);
+				 struct lo_message_ *data, void *user_data);
 
 static int handle_poll_softcut_phase(const char *path, const char *types, lo_arg **argv, int argc,
-				     void *data, void *user_data);
+				     struct lo_message_ *data, void *user_data);
 
 static int handle_softcut_render(const char *path, const char *types, lo_arg **argv, int argc,
-				 void *data, void *user_data);
+				 struct lo_message_ *data, void *user_data);
 
 static int handle_tape_play_state(const char *path, const char *types, lo_arg **argv, int argc,
-				  void *data, void *user_data);
+				  struct lo_message_ *data, void *user_data);
 
 static void lo_error_handler(int num, const char *m, const char *path);
 
@@ -666,13 +666,13 @@ void o_set_comp_param(const char *name, float value) {
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 
 int handle_crone_ready(const char *path, const char *types, lo_arg **argv, int argc,
-		       void *data, void *user_data) {
+		       struct lo_message_ *data, void *user_data) {
     norns_hello_ok();
     return 0;
 }
 
 int handle_engine_report_start(const char *path, const char *types, lo_arg **argv, int argc,
-			       void *data, void *user_data) {
+			       struct lo_message_ *data, void *user_data) {
     assert(argc > 0);
     // arg 1: count of engines
     o_clear_engine_names();
@@ -681,7 +681,7 @@ int handle_engine_report_start(const char *path, const char *types, lo_arg **arg
 }
 
 int handle_engine_report_entry(const char *path, const char *types, lo_arg **argv, int argc,
-			       void *data, void *user_data) {
+			       struct lo_message_ *data, void *user_data) {
     assert(argc > 1);
     // arg 1: engine index
     // arg 2: engine
@@ -691,7 +691,7 @@ int handle_engine_report_entry(const char *path, const char *types, lo_arg **arg
 }
 
 int handle_engine_report_end(const char *path, const char *types, lo_arg **argv, int argc,
-			     void *data, void *user_data) {
+			     struct lo_message_ *data, void *user_data) {
     // no arguments; post event
     event_post(event_data_new(EVENT_ENGINE_REPORT));
     return 0;
@@ -701,7 +701,7 @@ int handle_engine_report_end(const char *path, const char *types, lo_arg **argv,
 //--- command report
 
 int handle_command_report_start(const char *path, const char *types, lo_arg **argv, int argc,
-				void *data, void *user_data) {
+				struct lo_message_ *data, void *user_data) {
     assert(argc > 0);
     o_clear_commands();
     o_set_num_desc(&num_commands, argv[0]->i);
@@ -709,14 +709,14 @@ int handle_command_report_start(const char *path, const char *types, lo_arg **ar
 }
 
 int handle_command_report_entry(const char *path, const char *types, lo_arg **argv, int argc,
-				void *data, void *user_data) {
+				struct lo_message_ *data, void *user_data) {
     assert(argc > 2);
     o_set_command(argv[0]->i, &argv[1]->s, &argv[2]->s);
     return 0;
 }
 
 int handle_command_report_end(const char *path, const char *types, lo_arg **argv, int argc,
-			      void *data, void *user_data) {
+			      struct lo_message_ *data, void *user_data) {
     needCommandReport = false;
     test_engine_load_done();
     return 0;
@@ -726,7 +726,7 @@ int handle_command_report_end(const char *path, const char *types, lo_arg **argv
 //--- poll report
 
 int handle_poll_report_start(const char *path, const char *types, lo_arg **argv, int argc,
-			     void *data, void *user_data) {
+			     struct lo_message_ *data, void *user_data) {
 
     assert(argc > 0);
     o_clear_polls();
@@ -735,7 +735,7 @@ int handle_poll_report_start(const char *path, const char *types, lo_arg **argv,
 }
 
 int handle_poll_report_entry(const char *path, const char *types, lo_arg **argv, int argc,
-			     void *data, void *user_data) {
+			     struct lo_message_ *data, void *user_data) {
 
     assert(argc > 2);
     fflush(stdout);
@@ -744,7 +744,7 @@ int handle_poll_report_entry(const char *path, const char *types, lo_arg **argv,
 }
 
 int handle_poll_report_end(const char *path, const char *types, lo_arg **argv, int argc,
-			   void *data, void *user_data) {
+			   struct lo_message_ *data, void *user_data) {
 
     // event_post( event_data_new(EVENT_POLL_REPORT) );
     needPollReport = false;
@@ -753,7 +753,7 @@ int handle_poll_report_end(const char *path, const char *types, lo_arg **argv, i
 }
 
 int handle_poll_value(const char *path, const char *types, lo_arg **argv, int argc,
-		      void *data, void *user_data) {
+		      struct lo_message_ *data, void *user_data) {
 
     assert(argc > 1);
     union event_data *ev = event_data_new(EVENT_POLL_VALUE);
@@ -764,7 +764,7 @@ int handle_poll_value(const char *path, const char *types, lo_arg **argv, int ar
 }
 
 int handle_poll_data(const char *path, const char *types, lo_arg **argv, int argc,
-		     void *data, void *user_data) {
+		     struct lo_message_ *data, void *user_data) {
 
     assert(argc > 1);
     union event_data *ev = event_data_new(EVENT_POLL_DATA);
@@ -779,7 +779,7 @@ int handle_poll_data(const char *path, const char *types, lo_arg **argv, int arg
 }
 
 int handle_poll_io_levels(const char *path, const char *types, lo_arg **argv, int argc,
-			  void *data, void *user_data) {
+			  struct lo_message_ *data, void *user_data) {
 
     assert(argc > 0);
     union event_data *ev = event_data_new(EVENT_POLL_IO_LEVELS);
@@ -793,7 +793,7 @@ int handle_poll_io_levels(const char *path, const char *types, lo_arg **argv, in
 }
 
 int handle_poll_softcut_phase(const char *path, const char *types, lo_arg **argv, int argc,
-			      void *data, void *user_data) {
+			      struct lo_message_ *data, void *user_data) {
 
     assert(argc > 1);
     union event_data *ev = event_data_new(EVENT_POLL_SOFTCUT_PHASE);
@@ -805,7 +805,7 @@ int handle_poll_softcut_phase(const char *path, const char *types, lo_arg **argv
 }
 
 int handle_tape_play_state(const char *path, const char *types, lo_arg **argv, int argc,
-			   void *data, void *user_data) {
+			   struct lo_message_ *data, void *user_data) {
 
     // assert(argc > 0);
     // fprintf(stderr, "tape_play_status %s\n", &argv[0]->s);
@@ -813,7 +813,7 @@ int handle_tape_play_state(const char *path, const char *types, lo_arg **argv, i
 }
 
 int handle_softcut_render(const char *path, const char *types, lo_arg **argv, int argc,
-			  void *data, void *user_data) {
+			  struct lo_message_ *data, void *user_data) {
     assert(argc > 2);
     union event_data *ev = event_data_new(EVENT_SOFTCUT_RENDER);
     ev->softcut_render.idx = argv[0]->i;

--- a/matron/src/oracle.c
+++ b/matron/src/oracle.c
@@ -15,7 +15,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "lo/lo.h"
+#include <lo/lo.h>
 
 #include "args.h"
 #include "events.h"
@@ -77,44 +77,44 @@ static void o_set_num_desc(int *dst, int num);
 
 //--- OSC handlers
 static int handle_crone_ready(const char *path, const char *types, lo_arg **argv, int argc,
-			      struct lo_message_ *data, void *user_data);
+			      lo_message data, void *user_data);
 static int handle_engine_report_start(const char *path, const char *types, lo_arg **argv, int argc,
-				      struct lo_message_ *data, void *user_data);
+				      lo_message data, void *user_data);
 static int handle_engine_report_entry(const char *path, const char *types, lo_arg **argv, int argc,
-				      struct lo_message_ *data, void *user_data);
+				      lo_message data, void *user_data);
 static int handle_engine_report_end(const char *path, const char *types, lo_arg **argv, int argc,
-				    struct lo_message_ *data, void *user_data);
+				    lo_message data, void *user_data);
 static int handle_command_report_start(const char *path, const char *types, lo_arg **argv, int argc,
-				       struct lo_message_ *data, void *user_data);
+				       lo_message data, void *user_data);
 static int handle_command_report_entry(const char *path, const char *types, lo_arg **argv, int argc,
-				       struct lo_message_ *data, void *user_data);
+				       lo_message data, void *user_data);
 static int handle_command_report_end(const char *path, const char *types, lo_arg **argv, int argc,
-				     struct lo_message_ *data, void *user_data);
+				     lo_message data, void *user_data);
 static int handle_poll_report_start(const char *path, const char *types, lo_arg **argv, int argc,
-				    struct lo_message_ *data, void *user_data);
+				    lo_message data, void *user_data);
 static int handle_poll_report_entry(const char *path, const char *types, lo_arg **argv, int argc,
-				    struct lo_message_ *data, void *user_data);
+				    lo_message data, void *user_data);
 static int handle_poll_report_end(const char *path, const char *types, lo_arg **argv, int argc,
-				  struct lo_message_ *data, void *user_data);
+				  lo_message data, void *user_data);
 static int handle_poll_value(const char *path, const char *types, lo_arg **argv, int argc,
-			     struct lo_message_ *data, void *user_data);
+			     lo_message data, void *user_data);
 static int handle_poll_data(const char *path, const char *types, lo_arg **argv, int argc,
-			    struct lo_message_ *data, void *user_data);
+			    lo_message data, void *user_data);
 /* static int handle_poll_wave(const char *path, const char *types, */
 /*                              lo_arg **argv, int argc, */
 /*                              
-struct lo_message_ *data, void *user_data); */
+lo_message data, void *user_data); */
 static int handle_poll_io_levels(const char *path, const char *types, lo_arg **argv, int argc,
-				 struct lo_message_ *data, void *user_data);
+				 lo_message data, void *user_data);
 
 static int handle_poll_softcut_phase(const char *path, const char *types, lo_arg **argv, int argc,
-				     struct lo_message_ *data, void *user_data);
+				     lo_message data, void *user_data);
 
 static int handle_softcut_render(const char *path, const char *types, lo_arg **argv, int argc,
-				 struct lo_message_ *data, void *user_data);
+				 lo_message data, void *user_data);
 
 static int handle_tape_play_state(const char *path, const char *types, lo_arg **argv, int argc,
-				  struct lo_message_ *data, void *user_data);
+				  lo_message data, void *user_data);
 
 static void lo_error_handler(int num, const char *m, const char *path);
 
@@ -666,13 +666,13 @@ void o_set_comp_param(const char *name, float value) {
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 
 int handle_crone_ready(const char *path, const char *types, lo_arg **argv, int argc,
-		       struct lo_message_ *data, void *user_data) {
+		       lo_message data, void *user_data) {
     norns_hello_ok();
     return 0;
 }
 
 int handle_engine_report_start(const char *path, const char *types, lo_arg **argv, int argc,
-			       struct lo_message_ *data, void *user_data) {
+			       lo_message data, void *user_data) {
     assert(argc > 0);
     // arg 1: count of engines
     o_clear_engine_names();
@@ -681,7 +681,7 @@ int handle_engine_report_start(const char *path, const char *types, lo_arg **arg
 }
 
 int handle_engine_report_entry(const char *path, const char *types, lo_arg **argv, int argc,
-			       struct lo_message_ *data, void *user_data) {
+			       lo_message data, void *user_data) {
     assert(argc > 1);
     // arg 1: engine index
     // arg 2: engine
@@ -691,7 +691,7 @@ int handle_engine_report_entry(const char *path, const char *types, lo_arg **arg
 }
 
 int handle_engine_report_end(const char *path, const char *types, lo_arg **argv, int argc,
-			     struct lo_message_ *data, void *user_data) {
+			     lo_message data, void *user_data) {
     // no arguments; post event
     event_post(event_data_new(EVENT_ENGINE_REPORT));
     return 0;
@@ -701,7 +701,7 @@ int handle_engine_report_end(const char *path, const char *types, lo_arg **argv,
 //--- command report
 
 int handle_command_report_start(const char *path, const char *types, lo_arg **argv, int argc,
-				struct lo_message_ *data, void *user_data) {
+				lo_message data, void *user_data) {
     assert(argc > 0);
     o_clear_commands();
     o_set_num_desc(&num_commands, argv[0]->i);
@@ -709,14 +709,14 @@ int handle_command_report_start(const char *path, const char *types, lo_arg **ar
 }
 
 int handle_command_report_entry(const char *path, const char *types, lo_arg **argv, int argc,
-				struct lo_message_ *data, void *user_data) {
+				lo_message data, void *user_data) {
     assert(argc > 2);
     o_set_command(argv[0]->i, &argv[1]->s, &argv[2]->s);
     return 0;
 }
 
 int handle_command_report_end(const char *path, const char *types, lo_arg **argv, int argc,
-			      struct lo_message_ *data, void *user_data) {
+			      lo_message data, void *user_data) {
     needCommandReport = false;
     test_engine_load_done();
     return 0;
@@ -726,7 +726,7 @@ int handle_command_report_end(const char *path, const char *types, lo_arg **argv
 //--- poll report
 
 int handle_poll_report_start(const char *path, const char *types, lo_arg **argv, int argc,
-			     struct lo_message_ *data, void *user_data) {
+			     lo_message data, void *user_data) {
 
     assert(argc > 0);
     o_clear_polls();
@@ -735,7 +735,7 @@ int handle_poll_report_start(const char *path, const char *types, lo_arg **argv,
 }
 
 int handle_poll_report_entry(const char *path, const char *types, lo_arg **argv, int argc,
-			     struct lo_message_ *data, void *user_data) {
+			     lo_message data, void *user_data) {
 
     assert(argc > 2);
     fflush(stdout);
@@ -744,7 +744,7 @@ int handle_poll_report_entry(const char *path, const char *types, lo_arg **argv,
 }
 
 int handle_poll_report_end(const char *path, const char *types, lo_arg **argv, int argc,
-			   struct lo_message_ *data, void *user_data) {
+			   lo_message data, void *user_data) {
 
     // event_post( event_data_new(EVENT_POLL_REPORT) );
     needPollReport = false;
@@ -753,7 +753,7 @@ int handle_poll_report_end(const char *path, const char *types, lo_arg **argv, i
 }
 
 int handle_poll_value(const char *path, const char *types, lo_arg **argv, int argc,
-		      struct lo_message_ *data, void *user_data) {
+		      lo_message data, void *user_data) {
 
     assert(argc > 1);
     union event_data *ev = event_data_new(EVENT_POLL_VALUE);
@@ -764,7 +764,7 @@ int handle_poll_value(const char *path, const char *types, lo_arg **argv, int ar
 }
 
 int handle_poll_data(const char *path, const char *types, lo_arg **argv, int argc,
-		     struct lo_message_ *data, void *user_data) {
+		     lo_message data, void *user_data) {
 
     assert(argc > 1);
     union event_data *ev = event_data_new(EVENT_POLL_DATA);
@@ -779,7 +779,7 @@ int handle_poll_data(const char *path, const char *types, lo_arg **argv, int arg
 }
 
 int handle_poll_io_levels(const char *path, const char *types, lo_arg **argv, int argc,
-			  struct lo_message_ *data, void *user_data) {
+			  lo_message data, void *user_data) {
 
     assert(argc > 0);
     union event_data *ev = event_data_new(EVENT_POLL_IO_LEVELS);
@@ -793,7 +793,7 @@ int handle_poll_io_levels(const char *path, const char *types, lo_arg **argv, in
 }
 
 int handle_poll_softcut_phase(const char *path, const char *types, lo_arg **argv, int argc,
-			      struct lo_message_ *data, void *user_data) {
+			      lo_message data, void *user_data) {
 
     assert(argc > 1);
     union event_data *ev = event_data_new(EVENT_POLL_SOFTCUT_PHASE);
@@ -805,7 +805,7 @@ int handle_poll_softcut_phase(const char *path, const char *types, lo_arg **argv
 }
 
 int handle_tape_play_state(const char *path, const char *types, lo_arg **argv, int argc,
-			   struct lo_message_ *data, void *user_data) {
+			   lo_message data, void *user_data) {
 
     // assert(argc > 0);
     // fprintf(stderr, "tape_play_status %s\n", &argv[0]->s);
@@ -813,7 +813,7 @@ int handle_tape_play_state(const char *path, const char *types, lo_arg **argv, i
 }
 
 int handle_softcut_render(const char *path, const char *types, lo_arg **argv, int argc,
-			  struct lo_message_ *data, void *user_data) {
+			  lo_message data, void *user_data) {
     assert(argc > 2);
     union event_data *ev = event_data_new(EVENT_SOFTCUT_RENDER);
     ev->softcut_render.idx = argv[0]->i;


### PR DESCRIPTION
like #1323, but better

see also #1328 

can now build with both these toolchains:

`gcc (Raspbian 6.3.0-18+rpi1+deb9u1) 6.3.0 20170516`

`gcc (Ubuntu 9.3.0-17ubuntu1~20.04) 9.3.0`