### PR TITLE
fileselect: treat symlinks to directories like directories

### DIFF
--- a/lua/lib/util.lua
+++ b/lua/lib/util.lua
@@ -24,7 +24,7 @@ end
 -- @treturn table
 util.scandir = function(directory)
   local i, t, popen = 0, {}, io.popen
-  local pfile = popen('ls -p --group-directories-first "'..directory..'"')
+  local pfile = popen('ls -pL --group-directories-first "'..directory..'"')
   for filename in pfile:lines() do
     i = i + 1
     t[i] = filename


### PR DESCRIPTION
With `-L`, the `ls` command will treat symlinks to directories the same as "real" directories. Previously they did not get listed with the other directories and did not end in `/`, so the menu code would try to open them like files and error. This allows the user to e.g. `ln -s /media/usb /home/we/dust/audio/usb` and then play tape files / load samples from a USB disk.