### PR TITLE
single threaded coroutine wakeup scheduler

### DIFF
--- a/matron/src/clock.c
+++ b/matron/src/clock.c
@@ -111,14 +111,14 @@ void clock_update_source_reference(clock_reference_t *reference, double beat, do
     pthread_mutex_unlock(&(reference->lock));
 }
 
-void clock_start_from(clock_source_t source) {
+void clock_start_from_source(clock_source_t source) {
     if (clock_source == source) {
         union event_data *ev = event_data_new(EVENT_CLOCK_START);
         event_post(ev);
     }
 }
 
-void clock_stop_from(clock_source_t source) {
+void clock_stop_from_source(clock_source_t source) {
     if (clock_source == source) {
         union event_data *ev = event_data_new(EVENT_CLOCK_STOP);
         event_post(ev);

--- a/matron/src/clock.c
+++ b/matron/src/clock.c
@@ -18,80 +18,14 @@ struct clock_reference_t {
     pthread_mutex_t lock;
 };
 
-struct clock_thread_t {
-    pthread_t thread;
-    bool running;
-    int coro_id;
-};
-
 static struct clock_reference_t reference;
 static clock_source_t clock_source;
 
-#define NUM_THREADS 100
-static struct clock_thread_t clock_thread_pool[NUM_THREADS];
-
-struct clock_thread_arg {
-    int thread_index; // thread pool index
-    int coro_id;
-    double seconds;
-};
-
 void clock_init() {
-    for (int i = 0; i < NUM_THREADS; i++) {
-        clock_thread_pool[i].running = false;
-    }
-
     pthread_mutex_init(&reference.lock, NULL);
 
     clock_set_source(CLOCK_SOURCE_INTERNAL);
     clock_update_reference(0, 0.5);
-}
-
-static void *clock_schedule_resume_run(void *p) {
-    struct clock_thread_arg *arg = p;
-    int coro_id = arg->coro_id;
-    double seconds = arg->seconds;
-
-    struct timespec req = {
-        .tv_sec = (time_t)seconds,
-        .tv_nsec = (long)((seconds - req.tv_sec) * 1e+9),
-    };
-
-    clock_nanosleep(CLOCK_MONOTONIC, 0, &req, NULL);
-
-    union event_data *ev = event_data_new(EVENT_CLOCK_RESUME);
-    ev->clock_resume.thread_id = coro_id;
-    event_post(ev);
-
-    clock_thread_pool[arg->thread_index].coro_id = -1;
-    clock_thread_pool[arg->thread_index].running = false;
-    free(p);
-
-    return NULL;
-}
-
-bool clock_schedule_resume_sleep(int coro_id, double seconds) {
-    pthread_attr_t attr;
-    pthread_attr_init(&attr);
-    pthread_attr_setstacksize(&attr, PTHREAD_STACK_MIN);
-    pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED);
-
-    for (int i = 0; i < NUM_THREADS; i++) {
-        if (!clock_thread_pool[i].running) {
-            struct clock_thread_arg *arg = malloc(sizeof(struct clock_thread_arg));
-            arg->thread_index = i;
-            arg->coro_id = coro_id;
-            arg->seconds = seconds;
-
-            clock_thread_pool[i].running = true;
-            clock_thread_pool[i].coro_id = coro_id;
-            pthread_create(&clock_thread_pool[i].thread, &attr, &clock_schedule_resume_run, arg);
-
-            return true;
-        }
-    }
-
-    return false;
 }
 
 double clock_gettime_secondsf() {
@@ -121,31 +55,6 @@ double clock_get_tempo() {
     pthread_mutex_unlock(&reference.lock);
 
     return tempo;
-}
-
-bool clock_schedule_resume_sync(int coro_id, double beats) {
-    double zero_beat_time;
-    double this_beat;
-    double next_beat;
-    double next_beat_time;
-    int next_beat_multiplier = 0;
-
-    pthread_mutex_lock(&reference.lock);
-
-    double current_time = clock_gettime_secondsf();
-    zero_beat_time = reference.last_beat_time - (reference.beat_duration * reference.beat);
-    this_beat = (current_time - zero_beat_time) / reference.beat_duration;
-
-    do {
-        next_beat_multiplier += 1;
-
-        next_beat = (floor(this_beat / beats) + next_beat_multiplier) * beats;
-        next_beat_time = zero_beat_time + (next_beat * reference.beat_duration);
-    } while (next_beat_time - current_time < reference.beat_duration * beats / 100);
-
-    pthread_mutex_unlock(&reference.lock);
-
-    return clock_schedule_resume_sleep(coro_id, next_beat_time - current_time);
 }
 
 void clock_update_reference(double beats, double beat_duration) {
@@ -181,25 +90,4 @@ void clock_stop_from(clock_source_t source) {
 
 void clock_set_source(clock_source_t source) {
     clock_source = source;
-}
-
-void clock_cancel_coro(int coro_id) {
-    for (int i = 0; i < NUM_THREADS; i++) {
-        if (clock_thread_pool[i].coro_id == coro_id) {
-            clock_cancel(i);
-        }
-    }
-}
-
-void clock_cancel(int index) {
-    pthread_cancel(clock_thread_pool[index].thread);
-    pthread_join(clock_thread_pool[index].thread, NULL);
-    clock_thread_pool[index].running = false;
-    clock_thread_pool[index].coro_id = -1;
-}
-
-void clock_cancel_all() {
-    for (int i = 0; i < NUM_THREADS; i++) {
-        clock_cancel(i);
-    }
 }

--- a/matron/src/clock.c
+++ b/matron/src/clock.c
@@ -10,6 +10,7 @@
 #include "clocks/clock_internal.h"
 #include "clocks/clock_link.h"
 #include "clocks/clock_midi.h"
+#include "clocks/clock_scheduler.h"
 #include "events.h"
 
 static clock_source_t clock_source;
@@ -127,4 +128,5 @@ void clock_stop_from(clock_source_t source) {
 
 void clock_set_source(clock_source_t source) {
     clock_source = source;
+    clock_scheduler_reschedule_sync_events();
 }

--- a/matron/src/clock.c
+++ b/matron/src/clock.c
@@ -23,7 +23,7 @@ void clock_reference_init(clock_reference_t *reference) {
     clock_update_source_reference(reference, 0, 0.5);
 }
 
-double clock_gettime_secondsf() {
+double clock_gettime_seconds() {
     struct timespec spec;
     clock_gettime(CLOCK_MONOTONIC, &spec);
 
@@ -57,7 +57,7 @@ double clock_gettime_beats() {
 double clock_get_reference_beat(clock_reference_t *reference) {
     pthread_mutex_lock(&(reference->lock));
 
-    double current_time = clock_gettime_secondsf();
+    double current_time = clock_gettime_seconds();
     double zero_beat_time = reference->last_beat_time - (reference->beat_duration * reference->beat);
     double beat = (current_time - zero_beat_time) / reference->beat_duration;
 
@@ -103,7 +103,7 @@ double clock_get_reference_tempo(clock_reference_t *reference) {
 void clock_update_source_reference(clock_reference_t *reference, double beat, double beat_duration) {
     pthread_mutex_lock(&(reference->lock));
 
-    double current_time = clock_gettime_secondsf();
+    double current_time = clock_gettime_seconds();
     reference->beat_duration = beat_duration;
     reference->last_beat_time = current_time;
     reference->beat = beat;

--- a/matron/src/clock.c
+++ b/matron/src/clock.c
@@ -31,39 +31,39 @@ double clock_gettime_secondsf() {
 }
 
 double clock_gettime_beats() {
-    double beats;
+    double beat;
 
     switch (clock_source) {
     case CLOCK_SOURCE_INTERNAL:
-        beats = clock_internal_get_beats();
+        beat = clock_internal_get_beat();
         break;
     case CLOCK_SOURCE_MIDI:
-        beats = clock_midi_get_beats();
+        beat = clock_midi_get_beat();
         break;
     case CLOCK_SOURCE_LINK:
-        beats = clock_link_get_beats();
+        beat = clock_link_get_beat();
         break;
     case CLOCK_SOURCE_CROW:
-        beats = clock_crow_get_beats();
+        beat = clock_crow_get_beat();
         break;
     default:
-        beats = 0;
+        beat = 0;
         break;
     }
 
-    return beats;
+    return beat;
 }
 
-double clock_get_beats_with_reference(clock_reference_t *reference) {
+double clock_get_reference_beat(clock_reference_t *reference) {
     pthread_mutex_lock(&(reference->lock));
 
     double current_time = clock_gettime_secondsf();
     double zero_beat_time = reference->last_beat_time - (reference->beat_duration * reference->beat);
-    double beats = (current_time - zero_beat_time) / reference->beat_duration;
+    double beat = (current_time - zero_beat_time) / reference->beat_duration;
 
     pthread_mutex_unlock(&(reference->lock));
 
-    return beats;
+    return beat;
 }
 
 double clock_get_tempo() {
@@ -90,7 +90,7 @@ double clock_get_tempo() {
     return tempo;
 }
 
-double clock_get_tempo_with_reference(clock_reference_t *reference) {
+double clock_get_reference_tempo(clock_reference_t *reference) {
     pthread_mutex_lock(&(reference->lock));
 
     double tempo = 60.0 / reference->beat_duration;
@@ -100,13 +100,13 @@ double clock_get_tempo_with_reference(clock_reference_t *reference) {
     return tempo;
 }
 
-void clock_update_source_reference(clock_reference_t *reference, double beats, double beat_duration) {
+void clock_update_source_reference(clock_reference_t *reference, double beat, double beat_duration) {
     pthread_mutex_lock(&(reference->lock));
 
     double current_time = clock_gettime_secondsf();
     reference->beat_duration = beat_duration;
     reference->last_beat_time = current_time;
-    reference->beat = beats;
+    reference->beat = beat;
 
     pthread_mutex_unlock(&(reference->lock));
 }

--- a/matron/src/clock.c
+++ b/matron/src/clock.c
@@ -10,7 +10,6 @@
 #include "clocks/clock_internal.h"
 #include "clocks/clock_link.h"
 #include "clocks/clock_midi.h"
-#include "clocks/clock_scheduler.h"
 #include "events.h"
 
 static clock_source_t clock_source;
@@ -128,5 +127,4 @@ void clock_stop_from(clock_source_t source) {
 
 void clock_set_source(clock_source_t source) {
     clock_source = source;
-    clock_scheduler_reschedule_sync_events();
 }

--- a/matron/src/clock.c
+++ b/matron/src/clock.c
@@ -11,14 +11,7 @@
 #include <lauxlib.h>
 #include <lua.h>
 
-struct clock_reference_t {
-    double beat;
-    double beat_duration;
-    double last_beat_time;
-    pthread_mutex_t lock;
-};
-
-static struct clock_reference_t reference;
+static clock_reference_t reference;
 static clock_source_t clock_source;
 
 void clock_init() {

--- a/matron/src/clock.h
+++ b/matron/src/clock.h
@@ -18,8 +18,7 @@ typedef struct {
 } clock_reference_t;
 
 void clock_init();
-void clock_update_reference(double beats, double beat_duration);
-void clock_update_reference_from(double beats, double beat_duration, clock_source_t source);
+void clock_reference_init(clock_reference_t *reference);
 void clock_update_source_reference(clock_reference_t *reference, double beats, double beat_duration);
 double clock_get_beats_with_reference(clock_reference_t *reference);
 double clock_get_tempo_with_reference(clock_reference_t *reference);

--- a/matron/src/clock.h
+++ b/matron/src/clock.h
@@ -22,8 +22,8 @@ void clock_reference_init(clock_reference_t *reference);
 void clock_update_source_reference(clock_reference_t *reference, double beats, double beat_duration);
 double clock_get_reference_beat(clock_reference_t *reference);
 double clock_get_reference_tempo(clock_reference_t *reference);
-void clock_start_from(clock_source_t source);
-void clock_stop_from(clock_source_t source);
+void clock_start_from_source(clock_source_t source);
+void clock_stop_from_source(clock_source_t source);
 void clock_set_source(clock_source_t source);
 
 double clock_gettime_beats();

--- a/matron/src/clock.h
+++ b/matron/src/clock.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <pthread.h>
 #include <stdbool.h>
 
 typedef enum {
@@ -8,6 +9,13 @@ typedef enum {
     CLOCK_SOURCE_LINK = 2,
     CLOCK_SOURCE_CROW = 3,
 } clock_source_t;
+
+typedef struct {
+    double beat;
+    double beat_duration;
+    double last_beat_time;
+    pthread_mutex_t lock;
+} clock_reference_t;
 
 void clock_init();
 void clock_update_reference(double beats, double beat_duration);

--- a/matron/src/clock.h
+++ b/matron/src/clock.h
@@ -10,18 +10,12 @@ typedef enum {
 } clock_source_t;
 
 void clock_init();
-bool clock_schedule_resume_sleep(int thread_id, double seconds);
-bool clock_schedule_resume_sync(int thread_id, double beats);
 void clock_update_reference(double beats, double beat_duration);
 void clock_update_reference_from(double beats, double beat_duration, clock_source_t source);
 void clock_start_from(clock_source_t source);
 void clock_stop_from(clock_source_t source);
 void clock_set_source(clock_source_t source);
-void clock_cancel_all();
 
 double clock_gettime_beats();
 double clock_gettime_secondsf();
 double clock_get_tempo();
-
-void clock_cancel(int);
-void clock_cancel_coro(int);

--- a/matron/src/clock.h
+++ b/matron/src/clock.h
@@ -20,6 +20,9 @@ typedef struct {
 void clock_init();
 void clock_update_reference(double beats, double beat_duration);
 void clock_update_reference_from(double beats, double beat_duration, clock_source_t source);
+void clock_update_source_reference(clock_reference_t *reference, double beats, double beat_duration);
+double clock_get_beats_with_reference(clock_reference_t *reference);
+double clock_get_tempo_with_reference(clock_reference_t *reference);
 void clock_start_from(clock_source_t source);
 void clock_stop_from(clock_source_t source);
 void clock_set_source(clock_source_t source);

--- a/matron/src/clock.h
+++ b/matron/src/clock.h
@@ -20,8 +20,8 @@ typedef struct {
 void clock_init();
 void clock_reference_init(clock_reference_t *reference);
 void clock_update_source_reference(clock_reference_t *reference, double beats, double beat_duration);
-double clock_get_beats_with_reference(clock_reference_t *reference);
-double clock_get_tempo_with_reference(clock_reference_t *reference);
+double clock_get_reference_beat(clock_reference_t *reference);
+double clock_get_reference_tempo(clock_reference_t *reference);
 void clock_start_from(clock_source_t source);
 void clock_stop_from(clock_source_t source);
 void clock_set_source(clock_source_t source);

--- a/matron/src/clock.h
+++ b/matron/src/clock.h
@@ -27,5 +27,5 @@ void clock_stop_from(clock_source_t source);
 void clock_set_source(clock_source_t source);
 
 double clock_gettime_beats();
-double clock_gettime_secondsf();
+double clock_gettime_seconds();
 double clock_get_tempo();

--- a/matron/src/clocks/clock_crow.c
+++ b/matron/src/clocks/clock_crow.c
@@ -34,7 +34,7 @@ void clock_crow_init() {
 
 void clock_crow_handle_clock() {
     double beat_duration;
-    double current_time = clock_gettime_secondsf();
+    double current_time = clock_gettime_seconds();
 
     if (clock_crow_last_time_set == false) {
         clock_crow_last_time_set = true;

--- a/matron/src/clocks/clock_crow.c
+++ b/matron/src/clocks/clock_crow.c
@@ -69,10 +69,10 @@ void clock_crow_handle_clock() {
     }
 }
 
-double clock_crow_get_beats() {
-    return clock_get_beats_with_reference(&clock_crow_reference);
+double clock_crow_get_beat() {
+    return clock_get_reference_beat(&clock_crow_reference);
 }
 
 double clock_crow_get_tempo() {
-    return clock_get_tempo_with_reference(&clock_crow_reference);
+    return clock_get_reference_tempo(&clock_crow_reference);
 }

--- a/matron/src/clocks/clock_crow.c
+++ b/matron/src/clocks/clock_crow.c
@@ -61,8 +61,8 @@ void clock_crow_handle_clock() {
             clock_crow_counter++;
             clock_crow_last_time = current_time;
 
-            double beat = clock_crow_counter / crow_in_div;
-            clock_update_source_reference(&clock_crow_reference, beat, mean_sum);
+            double reference_beat = clock_crow_counter / crow_in_div;
+            clock_update_source_reference(&clock_crow_reference, reference_beat, mean_sum);
         }
 
         pthread_mutex_unlock(&crow_in_div_lock);

--- a/matron/src/clocks/clock_crow.c
+++ b/matron/src/clocks/clock_crow.c
@@ -6,6 +6,7 @@
 static bool clock_crow_last_time_set;
 static int clock_crow_counter;
 static double clock_crow_last_time;
+static clock_reference_t clock_crow_reference;
 
 #define DURATION_BUFFER_LENGTH 4
 
@@ -28,6 +29,7 @@ void clock_crow_init() {
     clock_crow_counter = 0;
     clock_crow_last_time_set = false;
     mean_sum = 0;
+    clock_reference_init(&clock_crow_reference);
 }
 
 void clock_crow_handle_clock() {
@@ -60,9 +62,17 @@ void clock_crow_handle_clock() {
             clock_crow_last_time = current_time;
 
             double beat = clock_crow_counter / crow_in_div;
-            clock_update_reference_from(beat, mean_sum, CLOCK_SOURCE_CROW);
+            clock_update_source_reference(&clock_crow_reference, beat, mean_sum);
         }
 
         pthread_mutex_unlock(&crow_in_div_lock);
     }
+}
+
+double clock_crow_get_beats() {
+    return clock_get_beats_with_reference(&clock_crow_reference);
+}
+
+double clock_crow_get_tempo() {
+    return clock_get_tempo_with_reference(&clock_crow_reference);
 }

--- a/matron/src/clocks/clock_crow.h
+++ b/matron/src/clocks/clock_crow.h
@@ -5,5 +5,5 @@
 void clock_crow_init();
 void clock_crow_handle_clock();
 void clock_crow_in_div(int div);
-double clock_crow_get_beats();
+double clock_crow_get_beat();
 double clock_crow_get_tempo();

--- a/matron/src/clocks/clock_crow.h
+++ b/matron/src/clocks/clock_crow.h
@@ -5,3 +5,5 @@
 void clock_crow_init();
 void clock_crow_handle_clock();
 void clock_crow_in_div(int div);
+double clock_crow_get_beats();
+double clock_crow_get_tempo();

--- a/matron/src/clocks/clock_internal.c
+++ b/matron/src/clocks/clock_internal.c
@@ -13,7 +13,7 @@ static clock_reference_t clock_internal_reference;
 static bool clock_internal_thread_running;
 static double interval_seconds;
 static uint64_t interval_nseconds;
-static double beat;
+static double reference_beat;
 
 static void *clock_internal_run(void *p) {
     (void)p;
@@ -30,8 +30,8 @@ static void *clock_internal_run(void *p) {
 
         clock_nanosleep(CLOCK_MONOTONIC, TIMER_ABSTIME, &req, NULL);
 
-        beat += 1.0;
-        clock_update_source_reference(&clock_internal_reference, beat, interval_seconds);
+        reference_beat += 1.0;
+        clock_update_source_reference(&clock_internal_reference, reference_beat, interval_seconds);
     }
 
     return NULL;
@@ -48,7 +48,7 @@ void clock_internal_set_tempo(double bpm) {
     interval_seconds = 60.0 / bpm;
     interval_nseconds = (uint64_t)(interval_seconds * 1000000000);
 
-    clock_internal_start(beat, false);
+    clock_internal_start(reference_beat, false);
 }
 
 void clock_internal_start(double new_beat, bool transport_start) {
@@ -59,8 +59,8 @@ void clock_internal_start(double new_beat, bool transport_start) {
         pthread_join(clock_internal_thread, NULL);
     }
 
-    beat = new_beat;
-    clock_update_source_reference(&clock_internal_reference, beat, interval_seconds);
+    reference_beat = new_beat;
+    clock_update_source_reference(&clock_internal_reference, reference_beat, interval_seconds);
 
     if (transport_start) {
         clock_start_from(CLOCK_SOURCE_INTERNAL);

--- a/matron/src/clocks/clock_internal.c
+++ b/matron/src/clocks/clock_internal.c
@@ -63,7 +63,7 @@ void clock_internal_start(double new_beat, bool transport_start) {
     clock_update_source_reference(&clock_internal_reference, reference_beat, interval_seconds);
 
     if (transport_start) {
-        clock_start_from(CLOCK_SOURCE_INTERNAL);
+        clock_start_from_source(CLOCK_SOURCE_INTERNAL);
     }
 
     pthread_attr_init(&attr);
@@ -73,7 +73,7 @@ void clock_internal_start(double new_beat, bool transport_start) {
 }
 
 void clock_internal_stop() {
-    clock_stop_from(CLOCK_SOURCE_INTERNAL);
+    clock_stop_from_source(CLOCK_SOURCE_INTERNAL);
 }
 
 double clock_internal_get_beat() {

--- a/matron/src/clocks/clock_internal.c
+++ b/matron/src/clocks/clock_internal.c
@@ -76,10 +76,10 @@ void clock_internal_stop() {
     clock_stop_from(CLOCK_SOURCE_INTERNAL);
 }
 
-double clock_internal_get_beats() {
-    return clock_get_beats_with_reference(&clock_internal_reference);
+double clock_internal_get_beat() {
+    return clock_get_reference_beat(&clock_internal_reference);
 }
 
 double clock_internal_get_tempo() {
-    return clock_get_tempo_with_reference(&clock_internal_reference);
+    return clock_get_reference_tempo(&clock_internal_reference);
 }

--- a/matron/src/clocks/clock_internal.h
+++ b/matron/src/clocks/clock_internal.h
@@ -4,3 +4,5 @@ void clock_internal_init();
 void clock_internal_set_tempo(double bpm);
 void clock_internal_start(double new_beat, bool transport_start);
 void clock_internal_stop();
+double clock_internal_get_beats();
+double clock_internal_get_tempo();

--- a/matron/src/clocks/clock_internal.h
+++ b/matron/src/clocks/clock_internal.h
@@ -4,5 +4,5 @@ void clock_internal_init();
 void clock_internal_set_tempo(double bpm);
 void clock_internal_start(double new_beat, bool transport_start);
 void clock_internal_stop();
-double clock_internal_get_beats();
+double clock_internal_get_beat();
 double clock_internal_get_tempo();

--- a/matron/src/clocks/clock_link.c
+++ b/matron/src/clocks/clock_link.c
@@ -92,10 +92,10 @@ void clock_link_set_tempo(double tempo) {
     pthread_mutex_unlock(&clock_link_shared_data.lock);
 }
 
-double clock_link_get_beats() {
-    return clock_get_beats_with_reference(&clock_link_reference);
+double clock_link_get_beat() {
+    return clock_get_reference_beat(&clock_link_reference);
 }
 
 double clock_link_get_tempo() {
-    return clock_get_tempo_with_reference(&clock_link_reference);
+    return clock_get_reference_tempo(&clock_link_reference);
 }

--- a/matron/src/clocks/clock_link.c
+++ b/matron/src/clocks/clock_link.c
@@ -44,10 +44,10 @@ static void *clock_link_run(void *p) {
 
             if (!clock_link_shared_data.playing && link_playing) {
                 clock_link_shared_data.playing = true;
-                clock_start_from(CLOCK_SOURCE_LINK);
+                clock_start_from_source(CLOCK_SOURCE_LINK);
             } else if (clock_link_shared_data.playing && !link_playing) {
                 clock_link_shared_data.playing = false;
-                clock_stop_from(CLOCK_SOURCE_LINK);
+                clock_stop_from_source(CLOCK_SOURCE_LINK);
             }
 
             if (clock_link_shared_data.requested_tempo > 0) {

--- a/matron/src/clocks/clock_link.h
+++ b/matron/src/clocks/clock_link.h
@@ -1,5 +1,8 @@
 #pragma once
 
+void clock_link_init();
 void clock_link_start();
 void clock_link_set_quantum(double quantum);
 void clock_link_set_tempo(double tempo);
+double clock_link_get_beats();
+double clock_link_get_tempo();

--- a/matron/src/clocks/clock_link.h
+++ b/matron/src/clocks/clock_link.h
@@ -4,5 +4,5 @@ void clock_link_init();
 void clock_link_start();
 void clock_link_set_quantum(double quantum);
 void clock_link_set_tempo(double tempo);
-double clock_link_get_beats();
+double clock_link_get_beat();
 double clock_link_get_tempo();

--- a/matron/src/clocks/clock_midi.c
+++ b/matron/src/clocks/clock_midi.c
@@ -81,10 +81,10 @@ void clock_midi_handle_message(uint8_t message) {
     }
 }
 
-double clock_midi_get_beats() {
-    return clock_get_beats_with_reference(&clock_midi_reference);
+double clock_midi_get_beat() {
+    return clock_get_reference_beat(&clock_midi_reference);
 }
 
 double clock_midi_get_tempo() {
-    return clock_get_tempo_with_reference(&clock_midi_reference);
+    return clock_get_reference_tempo(&clock_midi_reference);
 }

--- a/matron/src/clocks/clock_midi.c
+++ b/matron/src/clocks/clock_midi.c
@@ -52,8 +52,8 @@ static void clock_midi_handle_clock() {
             clock_midi_counter++;
             clock_midi_last_tick_time = current_time;
 
-            double beat = clock_midi_counter / 24.0;
-            clock_update_source_reference(&clock_midi_reference, beat, mean_sum);
+            double reference_beat = clock_midi_counter / 24.0;
+            clock_update_source_reference(&clock_midi_reference, reference_beat, mean_sum);
         }
     }
 }

--- a/matron/src/clocks/clock_midi.c
+++ b/matron/src/clocks/clock_midi.c
@@ -26,7 +26,7 @@ void clock_midi_init() {
 
 static void clock_midi_handle_clock() {
     double beat_duration;
-    double current_time = clock_gettime_secondsf();
+    double current_time = clock_gettime_seconds();
 
     if (clock_midi_last_tick_time_set == false) {
         clock_midi_last_tick_time_set = true;

--- a/matron/src/clocks/clock_midi.c
+++ b/matron/src/clocks/clock_midi.c
@@ -60,11 +60,11 @@ static void clock_midi_handle_clock() {
 
 static void clock_midi_handle_start() {
     clock_midi_counter = -1;
-    clock_start_from(CLOCK_SOURCE_MIDI);
+    clock_start_from_source(CLOCK_SOURCE_MIDI);
 }
 
 static void clock_midi_handle_stop() {
-    clock_stop_from(CLOCK_SOURCE_MIDI);
+    clock_stop_from_source(CLOCK_SOURCE_MIDI);
 }
 
 void clock_midi_handle_message(uint8_t message) {

--- a/matron/src/clocks/clock_midi.c
+++ b/matron/src/clocks/clock_midi.c
@@ -5,6 +5,7 @@
 static int clock_midi_counter;
 static bool clock_midi_last_tick_time_set;
 static double clock_midi_last_tick_time;
+static clock_reference_t clock_midi_reference;
 
 #define DURATION_BUFFER_LENGTH 24
 
@@ -20,6 +21,7 @@ void clock_midi_init() {
     clock_midi_last_tick_time_set = false;
     mean_sum = 0;
     mean_scale = 1;
+    clock_reference_init(&clock_midi_reference);
 }
 
 static void clock_midi_handle_clock() {
@@ -51,7 +53,7 @@ static void clock_midi_handle_clock() {
             clock_midi_last_tick_time = current_time;
 
             double beat = clock_midi_counter / 24.0;
-            clock_update_reference_from(beat, mean_sum, CLOCK_SOURCE_MIDI);
+            clock_update_source_reference(&clock_midi_reference, beat, mean_sum);
         }
     }
 }
@@ -77,4 +79,12 @@ void clock_midi_handle_message(uint8_t message) {
         clock_midi_handle_stop();
         break;
     }
+}
+
+double clock_midi_get_beats() {
+    return clock_get_beats_with_reference(&clock_midi_reference);
+}
+
+double clock_midi_get_tempo() {
+    return clock_get_tempo_with_reference(&clock_midi_reference);
 }

--- a/matron/src/clocks/clock_midi.h
+++ b/matron/src/clocks/clock_midi.h
@@ -4,5 +4,5 @@
 
 void clock_midi_init();
 void clock_midi_handle_message(uint8_t message);
-double clock_midi_get_beats();
+double clock_midi_get_beat();
 double clock_midi_get_tempo();

--- a/matron/src/clocks/clock_midi.h
+++ b/matron/src/clocks/clock_midi.h
@@ -4,3 +4,5 @@
 
 void clock_midi_init();
 void clock_midi_handle_message(uint8_t message);
+double clock_midi_get_beats();
+double clock_midi_get_tempo();

--- a/matron/src/clocks/clock_scheduler.c
+++ b/matron/src/clocks/clock_scheduler.c
@@ -48,7 +48,7 @@ static void *clock_scheduler_tick_thread_run(void *p) {
 
     while (true) {
         clock_beat = clock_gettime_beats();
-        clock_time = clock_gettime_secondsf();
+        clock_time = clock_gettime_seconds();
 
         pthread_mutex_lock(&clock_scheduler_events_lock);
 
@@ -122,7 +122,7 @@ bool clock_scheduler_schedule_sync(int thread_id, double sync_beat) {
 }
 
 bool clock_scheduler_schedule_sleep(int thread_id, double seconds) {
-    double clock_time = clock_gettime_secondsf();
+    double clock_time = clock_gettime_seconds();
 
     pthread_mutex_lock(&clock_scheduler_events_lock);
 

--- a/matron/src/clocks/clock_scheduler.c
+++ b/matron/src/clocks/clock_scheduler.c
@@ -165,7 +165,8 @@ void clock_scheduler_reschedule_sync_events() {
         scheduler_event = &clock_scheduler_events[i];
 
         if (scheduler_event->thread_id > -1 && scheduler_event->type == CLOCK_SCHEDULER_EVENT_SYNC) {
-            scheduler_event->sync_beat_clock = ceil(clock_beats / scheduler_event->sync_beat) * scheduler_event->sync_beat;
+            scheduler_event->sync_beat_clock =
+                ceil(clock_beats / scheduler_event->sync_beat) * scheduler_event->sync_beat;
         }
     }
 

--- a/matron/src/clocks/clock_scheduler.c
+++ b/matron/src/clocks/clock_scheduler.c
@@ -30,6 +30,12 @@ typedef struct {
 
 static clock_scheduler_event_t clock_scheduler_events[NUM_CLOCK_SCHEDULER_EVENTS];
 
+static void clock_scheduler_post_clock_resume_event(int thread_id) {
+    union event_data *ev = event_data_new(EVENT_CLOCK_RESUME);
+    ev->clock_resume.thread_id = thread_id;
+    event_post(ev);
+}
+
 static void *clock_scheduler_tick_thread_run(void *p) {
     (void)p;
     clock_scheduler_event_t *scheduler_event;
@@ -48,18 +54,12 @@ static void *clock_scheduler_tick_thread_run(void *p) {
             if (scheduler_event->thread_id > -1) {
                 if (scheduler_event->type == CLOCK_SCHEDULER_EVENT_SYNC) {
                     if (clock_beats >= scheduler_event->sync_beat_clock) {
-                        union event_data *ev = event_data_new(EVENT_CLOCK_RESUME);
-                        ev->clock_resume.thread_id = scheduler_event->thread_id;
-                        event_post(ev);
-
+                        clock_scheduler_post_clock_resume_event(scheduler_event->thread_id);
                         scheduler_event->thread_id = -1;
                     }
                 } else {
                     if (clock_seconds >= scheduler_event->sleep_seconds_clock) {
-                        union event_data *ev = event_data_new(EVENT_CLOCK_RESUME);
-                        ev->clock_resume.thread_id = scheduler_event->thread_id;
-                        event_post(ev);
-
+                        clock_scheduler_post_clock_resume_event(scheduler_event->thread_id);
                         scheduler_event->thread_id = -1;
                     }
                 }

--- a/matron/src/clocks/clock_scheduler.c
+++ b/matron/src/clocks/clock_scheduler.c
@@ -1,0 +1,149 @@
+#include <math.h>
+#include <pthread.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <unistd.h>
+
+#include "../clock.h"
+#include "../events.h"
+
+#include "clock_scheduler.h"
+
+static pthread_t clock_scheduler_tick_thread;
+static pthread_mutex_t clock_scheduler_events_lock;
+
+typedef enum {
+    CLOCK_SCHEDULER_EVENT_SYNC,
+    CLOCK_SCHEDULER_EVENT_SLEEP,
+} clock_scheduler_event_type_t;
+
+typedef struct {
+    clock_scheduler_event_type_t type;
+    int thread_id;
+
+    double sync_beat;
+    double sync_beat_clock;
+
+    double sleep_seconds;
+    double sleep_seconds_clock;
+} clock_scheduler_event_t;
+
+static clock_scheduler_event_t clock_scheduler_events[NUM_CLOCK_SCHEDULER_EVENTS];
+
+static void *clock_scheduler_tick_thread_run(void *p) {
+    (void)p;
+    clock_scheduler_event_t *scheduler_event;
+    double clock_beats;
+    double clock_seconds;
+
+    while (true) {
+        clock_beats = clock_gettime_beats();
+        clock_seconds = clock_gettime_secondsf();
+
+        pthread_mutex_lock(&clock_scheduler_events_lock);
+
+        for (int i = 0; i < NUM_CLOCK_SCHEDULER_EVENTS; i++) {
+            scheduler_event = &clock_scheduler_events[i];
+
+            if (scheduler_event->thread_id > -1) {
+                if (scheduler_event->type == CLOCK_SCHEDULER_EVENT_SYNC) {
+                    if (clock_beats >= scheduler_event->sync_beat_clock) {
+                        union event_data *ev = event_data_new(EVENT_CLOCK_RESUME);
+                        ev->clock_resume.thread_id = scheduler_event->thread_id;
+                        event_post(ev);
+
+                        scheduler_event->thread_id = -1;
+                    }
+                } else {
+                    if (clock_seconds >= scheduler_event->sleep_seconds_clock) {
+                        union event_data *ev = event_data_new(EVENT_CLOCK_RESUME);
+                        ev->clock_resume.thread_id = scheduler_event->thread_id;
+                        event_post(ev);
+
+                        scheduler_event->thread_id = -1;
+                    }
+                }
+            };
+        }
+
+        pthread_mutex_unlock(&clock_scheduler_events_lock);
+        usleep(1000);
+    }
+
+    return NULL;
+}
+
+void clock_scheduler_init() {
+    for (int i = 0; i < NUM_CLOCK_SCHEDULER_EVENTS; i++) {
+        clock_scheduler_events[i].thread_id = -1;
+    }
+
+    clock_scheduler_start();
+}
+
+void clock_scheduler_start() {
+    pthread_attr_t attr;
+
+    pthread_attr_init(&attr);
+    pthread_create(&clock_scheduler_tick_thread, &attr, &clock_scheduler_tick_thread_run, NULL);
+    pthread_attr_destroy(&attr);
+}
+
+bool clock_scheduler_schedule_sync(int thread_id, double beat) {
+    double clock_beats = clock_gettime_beats();
+
+    pthread_mutex_lock(&clock_scheduler_events_lock);
+
+    for (int i = 0; i < NUM_CLOCK_SCHEDULER_EVENTS; i++) {
+        if (clock_scheduler_events[i].thread_id == -1) {
+            clock_scheduler_events[i].thread_id = thread_id;
+            clock_scheduler_events[i].type = CLOCK_SCHEDULER_EVENT_SYNC;
+            clock_scheduler_events[i].sync_beat = beat;
+            clock_scheduler_events[i].sync_beat_clock = ceil(clock_beats / beat) * beat;
+
+            pthread_mutex_unlock(&clock_scheduler_events_lock);
+            return true;
+        }
+    }
+
+    pthread_mutex_unlock(&clock_scheduler_events_lock);
+    return false;
+}
+
+bool clock_scheduler_schedule_sleep(int thread_id, double seconds) {
+    double clock_seconds = clock_gettime_secondsf();
+
+    pthread_mutex_lock(&clock_scheduler_events_lock);
+
+    for (int i = 0; i < NUM_CLOCK_SCHEDULER_EVENTS; i++) {
+        if (clock_scheduler_events[i].thread_id == -1) {
+            clock_scheduler_events[i].thread_id = thread_id;
+            clock_scheduler_events[i].type = CLOCK_SCHEDULER_EVENT_SLEEP;
+            clock_scheduler_events[i].sleep_seconds = seconds;
+            clock_scheduler_events[i].sleep_seconds_clock = clock_seconds + seconds;
+
+            pthread_mutex_unlock(&clock_scheduler_events_lock);
+            return true;
+        }
+    }
+
+    pthread_mutex_unlock(&clock_scheduler_events_lock);
+    return false;
+}
+
+void clock_scheduler_reschedule_sync_events() {
+    clock_scheduler_event_t *scheduler_event;
+    double clock_beats = clock_gettime_beats();
+
+    pthread_mutex_lock(&clock_scheduler_events_lock);
+
+    for (int i = 0; i < NUM_CLOCK_SCHEDULER_EVENTS; i++) {
+        scheduler_event = &clock_scheduler_events[i];
+
+        if (scheduler_event.thread_id > -1 && scheduler_event.type == CLOCK_SCHEDULER_EVENT_SYNC) {
+            scheduler_event.sync_beat_clock = ceil(clock_beats / scheduler_event.beat) * scheduler_event.beat;
+        }
+    }
+
+    pthread_mutex_unlock(&clock_scheduler_events_lock);
+}

--- a/matron/src/clocks/clock_scheduler.c
+++ b/matron/src/clocks/clock_scheduler.c
@@ -61,7 +61,7 @@ static void *clock_scheduler_tick_thread_run(void *p) {
                         clock_scheduler_post_clock_resume_event(scheduler_event->thread_id);
                         scheduler_event->thread_id = -1;
                     } else {
-                        if (clock_beats - scheduler_event->sync_beat_clock > scheduler_event->sync_beat) {
+                        if (scheduler_event->sync_beat_clock - clock_beats > scheduler_event->sync_beat) {
                             scheduler_event->sync_beat_clock = clock_scheduler_next_clock_beat(clock_beats, scheduler_event->sync_beat);
                         }
                     }

--- a/matron/src/clocks/clock_scheduler.c
+++ b/matron/src/clocks/clock_scheduler.c
@@ -140,8 +140,8 @@ void clock_scheduler_reschedule_sync_events() {
     for (int i = 0; i < NUM_CLOCK_SCHEDULER_EVENTS; i++) {
         scheduler_event = &clock_scheduler_events[i];
 
-        if (scheduler_event.thread_id > -1 && scheduler_event.type == CLOCK_SCHEDULER_EVENT_SYNC) {
-            scheduler_event.sync_beat_clock = ceil(clock_beats / scheduler_event.beat) * scheduler_event.beat;
+        if (scheduler_event->thread_id > -1 && scheduler_event->type == CLOCK_SCHEDULER_EVENT_SYNC) {
+            scheduler_event->sync_beat_clock = ceil(clock_beats / scheduler_event->sync_beat) * scheduler_event->sync_beat;
         }
     }
 

--- a/matron/src/clocks/clock_scheduler.c
+++ b/matron/src/clocks/clock_scheduler.c
@@ -131,6 +131,28 @@ bool clock_scheduler_schedule_sleep(int thread_id, double seconds) {
     return false;
 }
 
+void clock_scheduler_cancel(int thread_id) {
+    pthread_mutex_lock(&clock_scheduler_events_lock);
+
+    for (int i = 0; i < NUM_CLOCK_SCHEDULER_EVENTS; i++) {
+        if (clock_scheduler_events[i].thread_id == thread_id) {
+            clock_scheduler_events[i].thread_id = -1;
+        }
+    }
+
+    pthread_mutex_unlock(&clock_scheduler_events_lock);
+}
+
+void clock_scheduler_cancel_all() {
+    pthread_mutex_lock(&clock_scheduler_events_lock);
+
+    for (int i = 0; i < NUM_CLOCK_SCHEDULER_EVENTS; i++) {
+        clock_scheduler_events[i].thread_id = -1;
+    }
+
+    pthread_mutex_unlock(&clock_scheduler_events_lock);
+}
+
 void clock_scheduler_reschedule_sync_events() {
     clock_scheduler_event_t *scheduler_event;
     double clock_beats = clock_gettime_beats();

--- a/matron/src/clocks/clock_scheduler.c
+++ b/matron/src/clocks/clock_scheduler.c
@@ -74,6 +74,8 @@ static void *clock_scheduler_tick_thread_run(void *p) {
 }
 
 void clock_scheduler_init() {
+    pthread_mutex_init(&clock_scheduler_events_lock, NULL);
+
     for (int i = 0; i < NUM_CLOCK_SCHEDULER_EVENTS; i++) {
         clock_scheduler_events[i].thread_id = -1;
     }

--- a/matron/src/clocks/clock_scheduler.h
+++ b/matron/src/clocks/clock_scheduler.h
@@ -6,7 +6,7 @@
 
 void clock_scheduler_init();
 void clock_scheduler_start();
-bool clock_scheduler_schedule_sync(int thread_id, double beats);
+bool clock_scheduler_schedule_sync(int thread_id, double sync_beat);
 bool clock_scheduler_schedule_sleep(int thread_id, double seconds);
 void clock_scheduler_cancel(int thread_id);
 void clock_scheduler_cancel_all();

--- a/matron/src/clocks/clock_scheduler.h
+++ b/matron/src/clocks/clock_scheduler.h
@@ -8,4 +8,6 @@ void clock_scheduler_init();
 void clock_scheduler_start();
 bool clock_scheduler_schedule_sync(int thread_id, double beats);
 bool clock_scheduler_schedule_sleep(int thread_id, double seconds);
+void clock_scheduler_cancel(int thread_id);
+void clock_scheduler_cancel_all();
 void clock_scheduler_reschedule_sync_events();

--- a/matron/src/clocks/clock_scheduler.h
+++ b/matron/src/clocks/clock_scheduler.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <stdbool.h>
+
+#define NUM_CLOCK_SCHEDULER_EVENTS 100
+
+void clock_scheduler_init();
+void clock_scheduler_start();
+bool clock_scheduler_schedule_sync(int thread_id, double beats);
+bool clock_scheduler_schedule_sleep(int thread_id, double seconds);
+void clock_scheduler_reschedule_sync_events();

--- a/matron/src/main.c
+++ b/matron/src/main.c
@@ -12,6 +12,7 @@
 #include "clocks/clock_internal.h"
 #include "clocks/clock_link.h"
 #include "clocks/clock_midi.h"
+#include "clocks/clock_scheduler.h"
 #include "device.h"
 #include "device_hid.h"
 #include "device_list.h"
@@ -72,6 +73,7 @@ int main(int argc, char **argv) {
     i2c_init();
     osc_init();
     clock_init();
+    clock_scheduler_init();
     clock_internal_init();
     clock_midi_init();
     clock_crow_init();

--- a/matron/src/main.c
+++ b/matron/src/main.c
@@ -78,6 +78,7 @@ int main(int argc, char **argv) {
     clock_midi_init();
     clock_crow_init();
 #if HAVE_ABLETON_LINK
+    clock_link_init();
     clock_link_start();
 #endif
 

--- a/matron/src/weaver.c
+++ b/matron/src/weaver.c
@@ -26,6 +26,7 @@
 #include "clocks/clock_crow.h"
 #include "clocks/clock_internal.h"
 #include "clocks/clock_link.h"
+#include "clocks/clock_scheduler.h"
 #include "device_crow.h"
 #include "device_hid.h"
 #include "device_midi.h"
@@ -1519,7 +1520,7 @@ int _clock_schedule_sleep(lua_State *l) {
     if (seconds <= 0) {
         w_handle_clock_resume(coro_id);
     } else {
-        clock_schedule_resume_sleep(coro_id, seconds);
+        clock_scheduler_schedule_sleep(coro_id, seconds);
     }
 
     return 0;
@@ -1528,12 +1529,12 @@ int _clock_schedule_sleep(lua_State *l) {
 int _clock_schedule_sync(lua_State *l) {
     lua_check_num_args(2);
     int coro_id = (int)luaL_checkinteger(l, 1);
-    double beats = luaL_checknumber(l, 2);
+    double beat = luaL_checknumber(l, 2);
 
-    if (beats <= 0) {
+    if (beat <= 0) {
         w_handle_clock_resume(coro_id);
     } else {
-        clock_schedule_resume_sync(coro_id, beats);
+        clock_scheduler_schedule_sync(coro_id, beat);
     }
 
   return 0;

--- a/matron/src/weaver.c
+++ b/matron/src/weaver.c
@@ -1543,7 +1543,7 @@ int _clock_schedule_sync(lua_State *l) {
 int _clock_cancel(lua_State *l) {
     lua_check_num_args(1);
     int coro_id = (int)luaL_checkinteger(l, 1);
-    clock_cancel_coro(coro_id);
+    clock_scheduler_cancel(coro_id);
     return 0;
 }
 

--- a/matron/src/weaver.c
+++ b/matron/src/weaver.c
@@ -1529,12 +1529,12 @@ int _clock_schedule_sleep(lua_State *l) {
 int _clock_schedule_sync(lua_State *l) {
     lua_check_num_args(2);
     int coro_id = (int)luaL_checkinteger(l, 1);
-    double beat = luaL_checknumber(l, 2);
+    double sync_beat = luaL_checknumber(l, 2);
 
-    if (beat <= 0) {
+    if (sync_beat <= 0) {
         w_handle_clock_resume(coro_id);
     } else {
-        clock_scheduler_schedule_sync(coro_id, beat);
+        clock_scheduler_schedule_sync(coro_id, sync_beat);
     }
 
   return 0;

--- a/matron/wscript
+++ b/matron/wscript
@@ -31,6 +31,7 @@ def build(bld):
         'src/clocks/clock_internal.c',
         'src/clocks/clock_midi.c',
         'src/clocks/clock_crow.c',
+        'src/clocks/clock_scheduler.c',
     ]
 
     matron_includes = [


### PR DESCRIPTION
this PR replaces the multi-threaded coroutine resume event scheduler with a single-threaded implementation, where a single scheduler thread is constantly tracking scheduled sync and sleep wakeups with ~1 millisecond resolution and sending clock resume events when necessary.

effectively, this enables smooth(er) midi and crow beat tracking and smooth switching between clock sources when using the clock lib and fixes #1273.

i haven't done any proper benchmarking, but matron CPU usage seems to be roughly the same with this PR (with a few coroutines running concurrently), occasionally there's an increase from 4% to 5%, but it doesn't seem like a huge issue.