### PR TITLE
simplified internal clock implementation

### DIFF
--- a/matron/src/clocks/clock_internal.c
+++ b/matron/src/clocks/clock_internal.c
@@ -7,6 +7,7 @@
 #include <time.h>
 
 #include "clock.h"
+#include "clock_scheduler.h"
 #include "clock_internal.h"
 
 #define CLOCK_INTERNAL_TICKS_PER_BEAT 24
@@ -79,8 +80,13 @@ void clock_internal_set_tempo(double bpm) {
 }
 
 void clock_internal_restart() {
+    pthread_mutex_lock(&clock_internal_tempo_lock);
+
     clock_internal_counter = -1;
+    clock_scheduler_reset_sync_events();
     clock_start_from_source(CLOCK_SOURCE_INTERNAL);
+
+    pthread_mutex_unlock(&clock_internal_tempo_lock);
 }
 
 void clock_internal_stop() {

--- a/matron/src/clocks/clock_internal.c
+++ b/matron/src/clocks/clock_internal.c
@@ -82,9 +82,9 @@ void clock_internal_set_tempo(double bpm) {
 void clock_internal_restart() {
     pthread_mutex_lock(&clock_internal_tempo_lock);
 
+    clock_start_from_source(CLOCK_SOURCE_INTERNAL);
     clock_internal_counter = -1;
     clock_scheduler_reset_sync_events();
-    clock_start_from_source(CLOCK_SOURCE_INTERNAL);
 
     pthread_mutex_unlock(&clock_internal_tempo_lock);
 }

--- a/matron/src/clocks/clock_internal.c
+++ b/matron/src/clocks/clock_internal.c
@@ -1,3 +1,4 @@
+#include <math.h>
 #include <pthread.h>
 #include <stdbool.h>
 #include <stdint.h>
@@ -8,68 +9,78 @@
 #include "clock.h"
 #include "clock_internal.h"
 
+#define CLOCK_INTERNAL_TICKS_PER_BEAT 24
+
+typedef struct {
+    double beat_duration;
+    double tick_duration;
+    struct timespec tick_ts;
+} clock_internal_tempo_t;
+
 static pthread_t clock_internal_thread;
 static clock_reference_t clock_internal_reference;
-static bool clock_internal_thread_running;
-static double interval_seconds;
-static uint64_t interval_nseconds;
-static double reference_beat;
+static int clock_internal_counter;
 
-static void *clock_internal_run(void *p) {
+static clock_internal_tempo_t clock_internal_tempo;
+static pthread_mutex_t clock_internal_tempo_lock;
+
+static void *clock_internal_thread_run(void *p) {
     (void)p;
-    struct timespec req;
+    struct timespec ts;
+    double beat_duration;
+    double reference_beat;
 
     while (true) {
-        clock_gettime(CLOCK_MONOTONIC, &req);
+        pthread_mutex_lock(&clock_internal_tempo_lock);
 
-        uint64_t current_time = (1000000000 * (uint64_t)req.tv_sec) + (uint64_t)req.tv_nsec;
-        uint64_t new_time = current_time + interval_nseconds;
+        beat_duration = clock_internal_tempo.beat_duration;
+        ts.tv_sec = clock_internal_tempo.tick_ts.tv_sec;
+        ts.tv_nsec = clock_internal_tempo.tick_ts.tv_nsec;
 
-        req.tv_sec = new_time / 1000000000;
-        req.tv_nsec = new_time % 1000000000;
+        pthread_mutex_unlock(&clock_internal_tempo_lock);
 
-        clock_nanosleep(CLOCK_MONOTONIC, TIMER_ABSTIME, &req, NULL);
+        clock_nanosleep(CLOCK_MONOTONIC, 0, &ts, NULL);
 
-        reference_beat += 1.0;
-        clock_update_source_reference(&clock_internal_reference, reference_beat, interval_seconds);
+        clock_internal_counter++;
+        reference_beat = (double) clock_internal_counter / CLOCK_INTERNAL_TICKS_PER_BEAT;
+        clock_update_source_reference(&clock_internal_reference, reference_beat, beat_duration);
     }
 
     return NULL;
 }
 
-void clock_internal_init() {
-    clock_internal_thread_running = false;
-    clock_internal_set_tempo(120);
-    clock_reference_init(&clock_internal_reference);
-    clock_internal_start(0.0, true);
-}
-
-void clock_internal_set_tempo(double bpm) {
-    interval_seconds = 60.0 / bpm;
-    interval_nseconds = (uint64_t)(interval_seconds * 1000000000);
-
-    clock_internal_start(reference_beat, false);
-}
-
-void clock_internal_start(double new_beat, bool transport_start) {
+static void clock_internal_start() {
     pthread_attr_t attr;
 
-    if (clock_internal_thread_running) {
-        pthread_cancel(clock_internal_thread);
-        pthread_join(clock_internal_thread, NULL);
-    }
-
-    reference_beat = new_beat;
-    clock_update_source_reference(&clock_internal_reference, reference_beat, interval_seconds);
-
-    if (transport_start) {
-        clock_start_from_source(CLOCK_SOURCE_INTERNAL);
-    }
-
     pthread_attr_init(&attr);
-    pthread_create(&clock_internal_thread, &attr, &clock_internal_run, NULL);
-    clock_internal_thread_running = true;
+    pthread_create(&clock_internal_thread, &attr, &clock_internal_thread_run, NULL);
     pthread_attr_destroy(&attr);
+}
+
+void clock_internal_init() {
+    pthread_mutex_init(&clock_internal_tempo_lock, NULL);
+    clock_reference_init(&clock_internal_reference);
+    clock_internal_counter = -1;
+    clock_internal_start();
+}
+
+
+void clock_internal_set_tempo(double bpm) {
+    pthread_mutex_lock(&clock_internal_tempo_lock);
+
+    clock_internal_tempo.beat_duration = 60.0 / bpm;
+    clock_internal_tempo.tick_duration = clock_internal_tempo.beat_duration / CLOCK_INTERNAL_TICKS_PER_BEAT;
+
+    clock_internal_tempo.tick_ts.tv_sec = clock_internal_tempo.tick_duration;
+    clock_internal_tempo.tick_ts.tv_nsec = (clock_internal_tempo.tick_duration - floor(clock_internal_tempo.tick_duration)) * 1000000000;
+
+    pthread_mutex_unlock(&clock_internal_tempo_lock);
+
+}
+
+void clock_internal_restart() {
+    clock_internal_counter = -1;
+    clock_start_from_source(CLOCK_SOURCE_INTERNAL);
 }
 
 void clock_internal_stop() {

--- a/matron/src/clocks/clock_internal.h
+++ b/matron/src/clocks/clock_internal.h
@@ -2,7 +2,7 @@
 
 void clock_internal_init();
 void clock_internal_set_tempo(double bpm);
-void clock_internal_start(double new_beat, bool transport_start);
+void clock_internal_restart();
 void clock_internal_stop();
 double clock_internal_get_beat();
 double clock_internal_get_tempo();

--- a/matron/src/clocks/clock_scheduler.c
+++ b/matron/src/clocks/clock_scheduler.c
@@ -180,3 +180,19 @@ void clock_scheduler_reschedule_sync_events() {
 
     pthread_mutex_unlock(&clock_scheduler_events_lock);
 }
+
+void clock_scheduler_reset_sync_events() {
+    clock_scheduler_event_t *scheduler_event;
+
+    pthread_mutex_lock(&clock_scheduler_events_lock);
+
+    for (int i = 0; i < NUM_CLOCK_SCHEDULER_EVENTS; i++) {
+        scheduler_event = &clock_scheduler_events[i];
+
+        if (scheduler_event->thread_id > -1 && scheduler_event->type == CLOCK_SCHEDULER_EVENT_SYNC) {
+            scheduler_event->sync_clock_beat = 0;
+        }
+    }
+
+    pthread_mutex_unlock(&clock_scheduler_events_lock);
+}

--- a/matron/src/clocks/clock_scheduler.h
+++ b/matron/src/clocks/clock_scheduler.h
@@ -11,3 +11,4 @@ bool clock_scheduler_schedule_sleep(int thread_id, double seconds);
 void clock_scheduler_cancel(int thread_id);
 void clock_scheduler_cancel_all();
 void clock_scheduler_reschedule_sync_events();
+void clock_scheduler_reset_sync_events();

--- a/matron/src/weaver.c
+++ b/matron/src/weaver.c
@@ -1555,9 +1555,7 @@ int _clock_internal_set_tempo(lua_State *l) {
 }
 
 int _clock_internal_start(lua_State *l) {
-    lua_check_num_args(1);
-    double new_beat = luaL_checknumber(l, 1);
-    clock_internal_start(new_beat, true);
+    clock_internal_restart();
     return 0;
 }
 


### PR DESCRIPTION
this is a simplified version of the internal clock that doesn't restart the tick thread when tempo is changed, providing smooth tempo changes with the new scheduler proposed in #1338

this implementation doesn't allow restarting the internal clock from a specific beat, as ticking happens in a constantly running thread, so it's only possible to reset the transport to beat zero (not that this feature was heavily used), so `clock.internal.start` in clock.lua has to be updated accordingly.