### PR TITLE
don't pass a nil param

### DIFF
--- a/lua/core/paramset.lua
+++ b/lua/core/paramset.lua
@@ -301,7 +301,9 @@ end
 -- @param index
 function ParamSet:t(index)
   local param = self:lookup_param(index)
-  return param.t
+  if param ~= nil then
+    return param.t
+  end
 end
 
 --- get range


### PR DESCRIPTION
solves for this edge case:
- start script + map a MIDI slider to a param
- reload script and send values from slider while script is starting
- incoming MIDI values cause (benign, but startling) script startup errors to be printed to matron as a nil param is passed