### PR TITLE
softcut feature: query position

### DIFF
--- a/crone/src/OscInterface.cpp
+++ b/crone/src/OscInterface.cpp
@@ -782,11 +782,11 @@ void OscInterface::addServerMethods() {
                                      });
     });
 
-    addServerMethod("/softcut/request/positions", "fi", [](lo_arg **argv, int argc) {
-      int size = softCutClient->getNumVoices(); 
-      float* positions = softCutClient->getPositions();
-      lo_blob bl = lo_blob_new(size * sizeof(float), positions);
-      lo_send(matronAddress, "/softcut/query/positions_callback", "fb", size, bl);
+    addServerMethod("/softcut/query/position", "i", [](lo_arg **argv, int argc) {
+      if(argc < 1) return;
+      int idx = argv[0]->i;
+      float pos = softCutClient->getPosition(idx);
+      lo_send(matronAddress, "/poll/softcut/position", "if", idx, pos);
     });
 
     addServerMethod("/softcut/reset", "", [](lo_arg **argv, int argc) {

--- a/crone/src/OscInterface.cpp
+++ b/crone/src/OscInterface.cpp
@@ -782,6 +782,10 @@ void OscInterface::addServerMethods() {
                                      });
     });
 
+    addServerMethod("/softcut/request/positions", "fi", [](lo_arg **argv, int argc) {
+
+    });
+
     addServerMethod("/softcut/reset", "", [](lo_arg **argv, int argc) {
         (void) argv;
         (void) argc;

--- a/crone/src/OscInterface.cpp
+++ b/crone/src/OscInterface.cpp
@@ -783,7 +783,10 @@ void OscInterface::addServerMethods() {
     });
 
     addServerMethod("/softcut/request/positions", "fi", [](lo_arg **argv, int argc) {
-
+      int size = softCutClient->getNumVoices(); 
+      float* positions = softCutClient->getPositions();
+      lo_blob bl = lo_blob_new(size * sizeof(float), positions);
+      lo_send(matronAddress, "/softcut/query/positions_callback", "fb", size, bl);
     });
 
     addServerMethod("/softcut/reset", "", [](lo_arg **argv, int argc) {

--- a/crone/src/SoftcutClient.h
+++ b/crone/src/SoftcutClient.h
@@ -133,12 +133,8 @@ namespace crone {
 
         int getNumVoices() const { return NumVoices; }
 
-        float *getPositions() {
-          float p[NumVoices];
-          for(int i=0;i<NumVoices;i++) {
-            p[i] = cut.getPosition(i);
-          }
-          return *p;
+        float getPosition(int i) {
+           return cut.getPosition(i);
         }
 
 	void reset();

--- a/crone/src/SoftcutClient.h
+++ b/crone/src/SoftcutClient.h
@@ -133,10 +133,10 @@ namespace crone {
 
         int getNumVoices() const { return NumVoices; }
 
-        float * getPositions() {
+        float *getPositions() {
           float p[NumVoices];
           for(int i=0;i<NumVoices;i++) {
-            p[i] = cut.getPos(i);
+            p[i] = cut.getPosition(i);
           }
           return *p;
         }

--- a/crone/src/SoftcutClient.h
+++ b/crone/src/SoftcutClient.h
@@ -59,8 +59,6 @@ namespace crone {
         }
 
     public:
-        /// FIXME: the "commands" structure shouldn't really be necessary.
-        /// should be able to refactor most/all parameters for atomic access.
         // called from audio thread
         void handleCommand(Commands::CommandPacket *p) override;
 
@@ -112,7 +110,6 @@ namespace crone {
         }
 
         // check if quantized phase has changed for a given voice
-        // returns true
         bool checkVoiceQuantPhase(int i) {
             if (quantPhase[i] != cut.getQuantPhase(i)) {
                 quantPhase[i] = cut.getQuantPhase(i);
@@ -121,20 +118,23 @@ namespace crone {
                 return false;
             }
         }
+	
         softcut::phase_t getQuantPhase(int i) {
             return cut.getQuantPhase(i);
         }
-        void setPhaseQuant(int i, softcut::phase_t q) {
+
+	void setPhaseQuant(int i, softcut::phase_t q) {
             cut.setPhaseQuant(i, q);
         }
-        void setPhaseOffset(int i, float sec) {
+
+	void setPhaseOffset(int i, float sec) {
             cut.setPhaseOffset(i, sec);
         }
 
         int getNumVoices() const { return NumVoices; }
 
         float getPosition(int i) {
-           return cut.getPosition(i);
+           return cut.getSavedPosition(i);
         }
 
 	void reset();

--- a/crone/src/SoftcutClient.h
+++ b/crone/src/SoftcutClient.h
@@ -133,6 +133,14 @@ namespace crone {
 
         int getNumVoices() const { return NumVoices; }
 
+        float * getPositions() {
+          float p[NumVoices];
+          for(int i=0;i<NumVoices;i++) {
+            p[i] = cut.getPos(i);
+          }
+          return *p;
+        }
+
 	void reset();
 
     private:

--- a/lua/core/norns.lua
+++ b/lua/core/norns.lua
@@ -85,6 +85,7 @@ _norns.vu = function(in1, in2, out1, out2) end
 _norns.softcut_phase = function(id, value) end
 
 _norns.softcut_render = function(ch, start, sec_per_sample, samples) end
+_norns.softcut_positions = function(positions) end
 
 -- default readings for battery
 norns.battery_percent = 0

--- a/lua/core/norns.lua
+++ b/lua/core/norns.lua
@@ -85,7 +85,7 @@ _norns.vu = function(in1, in2, out1, out2) end
 _norns.softcut_phase = function(id, value) end
 
 _norns.softcut_render = function(ch, start, sec_per_sample, samples) end
-_norns.softcut_positions = function(positions) end
+_norns.softcut_position = function(i,pos) end
 
 -- default readings for battery
 norns.battery_percent = 0

--- a/lua/core/softcut.lua
+++ b/lua/core/softcut.lua
@@ -267,6 +267,7 @@ SC.poll_start_phase = function() _norns.poll_start_cut_phase() end
 --- stop phase poll
 SC.poll_stop_phase = function() _norns.poll_stop_cut_phase() end
 
+
 --- set voice enable
 -- disabled voices have no effect and consume basically zero CPU
 -- @tparam int voice : voice number (1-?)
@@ -379,6 +380,15 @@ end
 -- @tparam function func : called when buffer content is ready. args: (ch, start, sec_per_sample, samples)
 SC.event_render = function(func)
   _norns.softcut_render = func
+end
+
+--- query playback positions
+SC.query_positions = function() _norns.query_cut_positions() end
+
+--- set function for query callback. use query_positions to request contents.
+-- @tparam function func : called when positions are returned
+SC.event_positions = function(func)
+  _norns.softcut_positions = func
 end
 
 

--- a/lua/core/softcut.lua
+++ b/lua/core/softcut.lua
@@ -382,13 +382,14 @@ SC.event_render = function(func)
   _norns.softcut_render = func
 end
 
---- query playback positions
-SC.query_positions = function() _norns.query_cut_positions() end
+--- query playback position
+-- @tparam integer i : which softcut voice
+SC.query_position = function(i) _norns.cut_query_position(i) end
 
---- set function for query callback. use query_positions to request contents.
--- @tparam function func : called when positions are returned
-SC.event_positions = function(func)
-  _norns.softcut_positions = func
+--- set function for query callback. use query_position to request contents.
+-- @tparam function func : called when index and position is returned
+SC.event_position = function(func)
+  _norns.softcut_position = func
 end
 
 

--- a/matron/src/event_types.h
+++ b/matron/src/event_types.h
@@ -83,8 +83,8 @@ typedef enum {
     EVENT_CROW_EVENT,
     // softcut buffer content callback
     EVENT_SOFTCUT_RENDER,
-    // softcut positions callback
-    EVENT_SOFTCUT_POSITIONS,
+    // softcut position callback
+    EVENT_SOFTCUT_POSITION,
 } event_t;
 
 // a packed data structure for four volume levels
@@ -306,10 +306,10 @@ struct event_softcut_render {
     float* data;
 };
 
-struct event_softcut_positions {
+struct event_softcut_position {
     struct event_common common;
-    size_t size;
-    float* data;
+    int idx;
+    float pos;
 };
 
 union event_data {
@@ -346,5 +346,5 @@ union event_data {
     struct event_crow_event crow_event;
     struct event_system_cmd system_cmd;
     struct event_softcut_render softcut_render;
-    struct event_softcut_positions softcut_positions;
+    struct event_softcut_position softcut_position;
 };

--- a/matron/src/event_types.h
+++ b/matron/src/event_types.h
@@ -83,6 +83,8 @@ typedef enum {
     EVENT_CROW_EVENT,
     // softcut buffer content callback
     EVENT_SOFTCUT_RENDER,
+    // softcut positions callback
+    EVENT_SOFTCUT_POSITIONS,
 } event_t;
 
 // a packed data structure for four volume levels
@@ -304,6 +306,12 @@ struct event_softcut_render {
     float* data;
 };
 
+struct event_softcut_positions {
+    struct event_common common;
+    size_t size;
+    float* data;
+};
+
 union event_data {
     uint32_t type;
     struct event_exec_code_line exec_code_line;
@@ -338,4 +346,5 @@ union event_data {
     struct event_crow_event crow_event;
     struct event_system_cmd system_cmd;
     struct event_softcut_render softcut_render;
+    struct event_softcut_positions softcut_positions;
 };

--- a/matron/src/events.c
+++ b/matron/src/events.c
@@ -291,6 +291,9 @@ static void handle_event(union event_data *ev) {
     case EVENT_SOFTCUT_RENDER:
         w_handle_softcut_render(ev->softcut_render.idx, ev->softcut_render.sec_per_sample, ev->softcut_render.start, ev->softcut_render.size, ev->softcut_render.data);
         break;
+    case EVENT_SOFTCUT_POSITION:
+        w_handle_softcut_position(ev->softcut_position.idx, ev->softcut_position.pos);
+        break;
     } /* switch */
 
     event_data_free(ev);

--- a/matron/src/oracle.c
+++ b/matron/src/oracle.c
@@ -113,6 +113,9 @@ static int handle_poll_softcut_phase(const char *path, const char *types, lo_arg
 static int handle_softcut_render(const char *path, const char *types, lo_arg **argv, int argc,
 				 lo_message data, void *user_data);
 
+static int handle_softcut_positions(const char *path, const char *types, lo_arg **argv, int argc,
+				 lo_message data, void *user_data);
+
 static int handle_tape_play_state(const char *path, const char *types, lo_arg **argv, int argc,
 				  lo_message data, void *user_data);
 
@@ -181,6 +184,7 @@ void o_init(void) {
 
     // softcut buffer content
     lo_server_thread_add_method(st, "/softcut/buffer/render_callback", "iffb", handle_softcut_render, NULL);
+    lo_server_thread_add_method(st, "/softcut/buffer/positions_callback", "fb", handle_softcut_positions, NULL);
 
     lo_server_thread_start(st);
 }
@@ -601,6 +605,10 @@ void o_cut_buffer_render(int ch, float start, float dur, int samples) {
     lo_send(crone_addr, "/softcut/buffer/render", "iffi", ch, start, dur, samples);
 }
 
+void o_cut_query_positions() {
+    lo_send(crone_addr, "/softcut/query/positions", "");
+}
+
 void o_cut_reset() {
     lo_send(crone_addr, "/softcut/reset", "");
 }
@@ -822,6 +830,19 @@ int handle_softcut_render(const char *path, const char *types, lo_arg **argv, in
     ev->softcut_render.size = sz / sizeof(float);
     ev->softcut_render.data = calloc(1, sz);
     memcpy(ev->softcut_render.data, samples, sz);
+    event_post(ev);
+    return 0;
+}
+
+int handle_softcut_positions(const char *path, const char *types, lo_arg **argv, int argc,
+			  lo_message data, void *user_data) {
+    //assert(argc > 2);
+    union event_data *ev = event_data_new(EVENT_SOFTCUT_RENDER);
+    int sz = lo_blob_datasize((lo_blob)argv[0]);
+    float *samples = (float*)lo_blob_dataptr((lo_blob)argv[1]);
+    ev->softcut_positions.size = sz / sizeof(float);
+    ev->softcut_positions.data = calloc(1, sz);
+    memcpy(ev->softcut_positions.data, samples, sz);
     event_post(ev);
     return 0;
 }

--- a/matron/src/oracle.c
+++ b/matron/src/oracle.c
@@ -837,7 +837,7 @@ int handle_softcut_render(const char *path, const char *types, lo_arg **argv, in
 int handle_softcut_positions(const char *path, const char *types, lo_arg **argv, int argc,
 			  lo_message data, void *user_data) {
     //assert(argc > 2);
-    union event_data *ev = event_data_new(EVENT_SOFTCUT_RENDER);
+    union event_data *ev = event_data_new(EVENT_SOFTCUT_POSITIONS);
     int sz = lo_blob_datasize((lo_blob)argv[0]);
     float *samples = (float*)lo_blob_dataptr((lo_blob)argv[1]);
     ev->softcut_positions.size = sz / sizeof(float);

--- a/matron/src/oracle.c
+++ b/matron/src/oracle.c
@@ -184,7 +184,7 @@ void o_init(void) {
 
     // softcut buffer content
     lo_server_thread_add_method(st, "/softcut/buffer/render_callback", "iffb", handle_softcut_render, NULL);
-    lo_server_thread_add_method(st, "/softcut/buffer/positions_callback", "fb", handle_softcut_positions, NULL);
+    lo_server_thread_add_method(st, "/softcut/query/positions_callback", "fb", handle_softcut_positions, NULL);
 
     lo_server_thread_start(st);
 }

--- a/matron/src/oracle.h
+++ b/matron/src/oracle.h
@@ -144,7 +144,7 @@ extern void o_cut_buffer_read_stereo(char *file, float start_src, float start_ds
 extern void o_cut_buffer_write_mono(char *file, float start, float dur, int ch);
 extern void o_cut_buffer_write_stereo(char *file, float start, float dur);
 extern void o_cut_buffer_render(int ch, float start, float dur, int samples);
-extern void o_cut_query_positions();
+extern void o_cut_query_position(int i);
 extern void o_cut_reset();
 // most softcut parameter changs take single voice index...
 extern void o_set_cut_param(const char *name, int voice, float value);

--- a/matron/src/oracle.h
+++ b/matron/src/oracle.h
@@ -144,6 +144,7 @@ extern void o_cut_buffer_read_stereo(char *file, float start_src, float start_ds
 extern void o_cut_buffer_write_mono(char *file, float start, float dur, int ch);
 extern void o_cut_buffer_write_stereo(char *file, float start, float dur);
 extern void o_cut_buffer_render(int ch, float start, float dur, int samples);
+extern void o_cut_query_positions();
 extern void o_cut_reset();
 // most softcut parameter changs take single voice index...
 extern void o_set_cut_param(const char *name, int voice, float value);

--- a/matron/src/weaver.c
+++ b/matron/src/weaver.c
@@ -193,7 +193,7 @@ static int _cut_buffer_read_stereo(lua_State *l);
 static int _cut_buffer_write_mono(lua_State *l);
 static int _cut_buffer_write_stereo(lua_State *l);
 static int _cut_buffer_render(lua_State *l);
-static int _cut_query_positions(lua_State *l);
+static int _cut_query_position(lua_State *l);
 static int _cut_reset(lua_State *l);
 static int _set_cut_param(lua_State *l);
 static int _set_cut_param_ii(lua_State *l);
@@ -334,7 +334,7 @@ void w_init(void) {
     lua_register_norns("cut_buffer_write_mono", &_cut_buffer_write_mono);
     lua_register_norns("cut_buffer_write_stereo", &_cut_buffer_write_stereo);
     lua_register_norns("cut_buffer_render", &_cut_buffer_render);
-    lua_register_norns("cut_query_positions", &_cut_query_positions);
+    lua_register_norns("cut_query_position", &_cut_query_position);
     lua_register_norns("cut_reset", &_cut_reset);
     lua_register_norns("cut_param", &_set_cut_param);
     lua_register_norns("cut_param_ii", &_set_cut_param_ii);
@@ -2068,15 +2068,12 @@ void w_handle_softcut_render(int idx, float sec_per_sample, float start, size_t 
     l_report(lvm, l_docall(lvm, 4, 0));
 }
 
-void w_handle_softcut_positions(size_t size, float* data) {
+void w_handle_softcut_position(int idx, float pos) {
     lua_getglobal(lvm, "_norns");
-    lua_getfield(lvm, -1, "softcut_positions");
+    lua_getfield(lvm, -1, "softcut_position");
     lua_remove(lvm, -2);
-    lua_createtable(lvm, size, 0);
-    for (size_t i = 0; i < size; ++i) {
-        lua_pushnumber(lvm, data[i]);
-        lua_rawseti(lvm, -2, i + 1);
-    }
+    lua_pushinteger(lvm, idx + 1);
+    lua_pushnumber(lvm, pos);
     l_report(lvm, l_docall(lvm, 2, 0));
 }
 
@@ -2418,8 +2415,10 @@ int _cut_buffer_render(lua_State *l) {
     return 0;
 }
 
-int _cut_query_positions(lua_State *l) {
-    o_cut_query_positions();
+int _cut_query_position(lua_State *l) {
+    lua_check_num_args(1);
+    int i = (int)luaL_checkinteger(l, 1) - 1;
+    o_cut_query_position(i);
     return 0;
 }
 

--- a/matron/src/weaver.c
+++ b/matron/src/weaver.c
@@ -193,6 +193,7 @@ static int _cut_buffer_read_stereo(lua_State *l);
 static int _cut_buffer_write_mono(lua_State *l);
 static int _cut_buffer_write_stereo(lua_State *l);
 static int _cut_buffer_render(lua_State *l);
+static int _cut_query_positions(lua_State *l);
 static int _cut_reset(lua_State *l);
 static int _set_cut_param(lua_State *l);
 static int _set_cut_param_ii(lua_State *l);
@@ -333,6 +334,7 @@ void w_init(void) {
     lua_register_norns("cut_buffer_write_mono", &_cut_buffer_write_mono);
     lua_register_norns("cut_buffer_write_stereo", &_cut_buffer_write_stereo);
     lua_register_norns("cut_buffer_render", &_cut_buffer_render);
+    lua_register_norns("cut_query_positions", &_cut_query_positions);
     lua_register_norns("cut_reset", &_cut_reset);
     lua_register_norns("cut_param", &_set_cut_param);
     lua_register_norns("cut_param_ii", &_set_cut_param_ii);
@@ -2066,6 +2068,18 @@ void w_handle_softcut_render(int idx, float sec_per_sample, float start, size_t 
     l_report(lvm, l_docall(lvm, 4, 0));
 }
 
+void w_handle_softcut_positions(size_t size, float* data) {
+    lua_getglobal(lvm, "_norns");
+    lua_getfield(lvm, -1, "softcut_positions");
+    lua_remove(lvm, -2);
+    lua_createtable(lvm, size, 0);
+    for (size_t i = 0; i < size; ++i) {
+        lua_pushnumber(lvm, data[i]);
+        lua_rawseti(lvm, -2, i + 1);
+    }
+    l_report(lvm, l_docall(lvm, 2, 0));
+}
+
 // handle system command capture
 void w_handle_system_cmd(char *capture) {
     lua_getglobal(lvm, "_norns");
@@ -2401,6 +2415,11 @@ int _cut_buffer_render(lua_State *l) {
     float dur = (float)luaL_checknumber(l, 3);
     int samples = (int)luaL_checknumber(l, 4);
     o_cut_buffer_render(ch, start, dur, samples);
+    return 0;
+}
+
+int _cut_query_positions(lua_State *l) {
+    o_cut_query_positions();
     return 0;
 }
 

--- a/matron/src/weaver.h
+++ b/matron/src/weaver.h
@@ -83,6 +83,7 @@ extern void w_handle_poll_wave(int idx, uint8_t *data);
 extern void w_handle_poll_io_levels(uint8_t *levels);
 extern void w_handle_poll_softcut_phase(int idx, float val);
 extern void w_handle_softcut_render(int idx, float sec_per_sample, float start, size_t size, float* data);
+extern void w_handle_softcut_positions(size_t size, float* data);
 
 extern void w_handle_engine_loaded();
 

--- a/matron/src/weaver.h
+++ b/matron/src/weaver.h
@@ -83,7 +83,7 @@ extern void w_handle_poll_wave(int idx, uint8_t *data);
 extern void w_handle_poll_io_levels(uint8_t *levels);
 extern void w_handle_poll_softcut_phase(int idx, float val);
 extern void w_handle_softcut_render(int idx, float sec_per_sample, float start, size_t size, float* data);
-extern void w_handle_softcut_positions(size_t size, float* data);
+extern void w_handle_softcut_position(int idx, float pos);
 
 extern void w_handle_engine_loaded();
 


### PR DESCRIPTION
softcut voice now stores position per processing block, and i've added a query function to get the (accurate to block size) position of a voice.

i wanted to add this a different method to async check positions without throwing away a phase poll--- ie, being able to save a playback position "now" via a keypress

```
-- create simple print report callback
cb = function(idx,pos) print(idx,pos) end

-- arg is callback function
softcut.event_position(cb)

-- arg is which voice
softcut.query_position(1)
```

plumbing, wow.
