### PR TITLE
Fix metro running state

### DIFF
--- a/lua/core/metro.lua
+++ b/lua/core/metro.lua
@@ -156,17 +156,17 @@ for i=1,Metro.num_script_metros do
   Metro.assigned[i] = false
 end
 
-
-
 -- callback on metro tick from C.
 _norns.metro = function(idx, stage)
   local m = Metro.metros[idx]
   if m then
-    if Metro.metros[idx].event then
-      Metro.metros[idx].event(stage)
+    if m.event then
+      m.event(stage)
     end
     if m.count > -1 then
-      
+      if (stage > m.count) then
+        m.is_running = false
+      end
     end
   end
 end

--- a/lua/core/metro.lua
+++ b/lua/core/metro.lua
@@ -160,9 +160,13 @@ end
 
 -- callback on metro tick from C.
 _norns.metro = function(idx, stage)
-  if Metro.metros[idx] then
+  local m = Metro.metros[idx]
+  if m then
     if Metro.metros[idx].event then
       Metro.metros[idx].event(stage)
+    end
+    if m.count > -1 then
+      
     end
   end
 end


### PR DESCRIPTION
realized that `metro.is_running` variable is dead/useless for non-infinite metros when someone tried to use it in a script. (actually a crow script which uses the same lua code, fwiw)

this change causes that state to be updated after firing a metro's event callback, if the stage count exceeds the metro's count. 

i think this is the behavior we want, but haven't actually tried it so not totally sure.

of course we could also just remove that field.