### PR TITLE
clock sync chaining improvements

### DIFF
--- a/matron/src/clock.c
+++ b/matron/src/clock.c
@@ -136,4 +136,5 @@ void clock_reschedule_sync_events_from_source(clock_source_t source) {
 
 void clock_set_source(clock_source_t source) {
     clock_source = source;
+    clock_scheduler_reschedule_sync_events();
 }

--- a/matron/src/clock.c
+++ b/matron/src/clock.c
@@ -128,6 +128,12 @@ void clock_stop_from_source(clock_source_t source) {
     }
 }
 
+void clock_reschedule_sync_events_from_source(clock_source_t source) {
+    if (clock_source == source) {
+        clock_scheduler_reschedule_sync_events();
+    }
+}
+
 void clock_set_source(clock_source_t source) {
     clock_source = source;
 }

--- a/matron/src/clock.h
+++ b/matron/src/clock.h
@@ -24,6 +24,7 @@ double clock_get_reference_beat(clock_reference_t *reference);
 double clock_get_reference_tempo(clock_reference_t *reference);
 void clock_start_from_source(clock_source_t source);
 void clock_stop_from_source(clock_source_t source);
+void clock_reschedule_sync_events_from_source(clock_source_t source);
 void clock_set_source(clock_source_t source);
 
 double clock_gettime_beats();

--- a/matron/src/clocks/clock_crow.c
+++ b/matron/src/clocks/clock_crow.c
@@ -17,11 +17,13 @@ static double mean_sum;
 static double mean_scale;
 
 static double crow_in_div = 4.0;
+static bool crow_in_div_changed = false;
 static pthread_mutex_t crow_in_div_lock;
 
 void clock_crow_in_div(int div) {
     pthread_mutex_lock(&crow_in_div_lock);
     crow_in_div = (double)div;
+    crow_in_div_changed = true;
     pthread_mutex_unlock(&crow_in_div_lock);
 }
 
@@ -63,6 +65,11 @@ void clock_crow_handle_clock() {
 
             double reference_beat = clock_crow_counter / crow_in_div;
             clock_update_source_reference(&clock_crow_reference, reference_beat, mean_sum);
+
+            if (crow_in_div_changed) {
+                clock_reschedule_sync_events_from_source(CLOCK_SOURCE_CROW);
+                crow_in_div_changed = false;
+            }
         }
 
         pthread_mutex_unlock(&crow_in_div_lock);

--- a/matron/src/clocks/clock_scheduler.c
+++ b/matron/src/clocks/clock_scheduler.c
@@ -62,10 +62,6 @@ static void *clock_scheduler_tick_thread_run(void *p) {
                     if (clock_beat > scheduler_event->sync_clock_beat) {
                         clock_scheduler_post_clock_resume_event(scheduler_event->thread_id);
                         scheduler_event->ready = false;
-                    } else {
-                        if (scheduler_event->sync_clock_beat - clock_beat > scheduler_event->sync_beat) {
-                            scheduler_event->sync_clock_beat = clock_scheduler_next_clock_beat(clock_beat, scheduler_event->sync_beat);
-                        }
                     }
                 } else {
                     if (clock_time >= scheduler_event->sleep_clock_time) {


### PR DESCRIPTION
remove automatic sync events rescheduling logic in favor of explicitly rescheduling sync events to avoid the beat drifting away from hi-res sync-based counters.