### PR TITLE
TAPE records into nested folders + add util.file_size

### DIFF
--- a/lua/lib/util.lua
+++ b/lua/lib/util.lua
@@ -46,6 +46,26 @@ util.file_exists = function(name)
   end
 end
 
+--- query file size.
+-- @tparam string name filepath
+-- @treturn number filesize in mb
+util.file_size = function(path)
+  if path ~= nil then
+    local f = io.open(path,"r")
+    if f~=nil then
+      local c = f:seek()      -- get current position
+      local s = f:seek("end") -- get file size
+      f:seek("set", c)        -- restore position
+      io.close(f)
+      return s/1000000
+    else
+      print("no file found at "..path)
+    end
+  else
+    print("util.file_size requires a path")
+  end
+end
+
 --- make directory (with parents as needed).
 -- @tparam string path
 util.make_dir = function(path)


### PR DESCRIPTION
fulfills a feature request from the norns study group for improved default filename and location.

### new: util.file_size
- added a `util` function which returns a file's size in megabytes:
```lua
> util.file_size(_path.code.."awake/awake.lua")
0.013152
> util.file_size(_path.audio.."tape/0000.wav")
71.710508
```
- if provided filepath isn't found:
```lua
> util.file_size(_path.audio.."tape/blahblah.wav")
no file found at /home/we/dust/audio/tape/blahblah.wav
<ok>
```
- if no path is provided:
```lua
> util.file_size()
util.file_size requires a path
<ok>
```

### TAPE changes
- when a user initiates `REC`, their recording is nested into a folder for the loaded script's `shortname`, eg. `tape/awake`
  - if no script is loaded, recording is nested into `tape/no_script`
- the default filename appends the current clock bpm to the `index`, as that is often forgotten when a user revisits their recordings, eg. `0109_120bpm`
  - if bpm is float, eg. 120.85: `0109_120-85bpm`
- if the user queues up a recording but changes their mind before pressing `START`, they can now hold K1 to call up a `CLEAR` action, which is selectable with K3
  - `CLEAR` will validate that the `0109_120bpm.wav` file has no data using `util.filesize` (rounding to nearest KB)
    - if it has no data, then the placeholder file will be deleted
    - if the placeholder file is deleted, the index (and `index.txt`) is reset to the prior state

by frontloading the index, we retain a sense of timeline across recordings, but by placing everything in named folders then a user can easily export all of their `compass` recordings in one move :)