### PR TITLE
grid-st

### DIFF
--- a/matron/src/device/device.c
+++ b/matron/src/device/device.c
@@ -71,8 +71,6 @@ err_init:
 
 void dev_delete(union dev *d) {
     int ret;
-    // fprintf(stderr, "dev_delete(): removing device %d\n", d->base.id);
-
     if (pthread_kill(d->base.tid, 0) == 0) {
         // device i/o thread still running
         ret = pthread_cancel(d->base.tid);

--- a/matron/src/device/device_common.h
+++ b/matron/src/device/device_common.h
@@ -2,6 +2,8 @@
 
 #include <stdint.h>
 
+
+
 typedef enum {
     // libmonome devices
     DEV_TYPE_MONOME = 0,
@@ -17,9 +19,6 @@ typedef enum {
     DEV_TYPE_COUNT,
     DEV_TYPE_INVALID
 } device_t;
-
-// maximum device_t value for devices which have corresponding device files
-#define DEV_TYPE_COUNT_PHYSICAL 4
 
 struct dev_common {
     // device type

--- a/matron/src/device/device_monome.c
+++ b/matron/src/device/device_monome.c
@@ -46,8 +46,11 @@ int dev_monome_init(void *self) {
     memset(md->dirty, 0, sizeof(md->dirty));
 
     if (monome_get_rows(md->m) == 0 && monome_get_cols(md->m) == 0) {
+	fprintf(stderr, "monome device reporing zero rows/cols; assuming arc\n");
         md->type = DEVICE_MONOME_TYPE_ARC;
+	
     } else {
+	fprintf(stderr, "monome device appears to be a grid\n");
         md->type = DEVICE_MONOME_TYPE_GRID;
     }
 

--- a/matron/src/device/device_monome.c
+++ b/matron/src/device/device_monome.c
@@ -53,9 +53,10 @@ int dev_monome_init(void *self) {
         md->type = DEVICE_MONOME_TYPE_ARC;
 	
     } else {
-	fprintf(stderr, "monome device appears to be a grid\n");
         md->type = DEVICE_MONOME_TYPE_GRID;
-	md->quads = (md->rows * md->cols) / 16;
+	md->quads = (md->rows * md->cols) / 64;
+	fprintf(stderr, "monome device appears to be a grid; rows=%d; cols=%d; quads=%d\n",
+		md->rows, md->cols, md->quads);
     }
 
     monome_register_handler(m, MONOME_BUTTON_DOWN, dev_monome_handle_press, md);
@@ -107,7 +108,7 @@ void dev_monome_arc_set_led(struct dev_monome *md, uint8_t n, uint8_t x, uint8_t
 
 // set all LEDs to value
 void dev_monome_all_led(struct dev_monome *md, uint8_t val) {
-    for (uint8_t q = 0; q < 4; q++) {
+    for (uint8_t q = 0; q < md->quads; q++) {
         for (uint8_t i = 0; i < 64; i++) {
             md->data[q][i] = val;
         }

--- a/matron/src/device/device_monome.c
+++ b/matron/src/device/device_monome.c
@@ -45,13 +45,17 @@ int dev_monome_init(void *self) {
     memset(md->data, 0, sizeof(md->data));
     memset(md->dirty, 0, sizeof(md->dirty));
 
-    if (monome_get_rows(md->m) == 0 && monome_get_cols(md->m) == 0) {
+    md->rows = monome_get_rows(md->m);
+    md->cols = monome_get_cols(md->m);
+	
+    if (md->rows == 0 && md->cols == 0) {
 	fprintf(stderr, "monome device reporing zero rows/cols; assuming arc\n");
         md->type = DEVICE_MONOME_TYPE_ARC;
 	
     } else {
 	fprintf(stderr, "monome device appears to be a grid\n");
         md->type = DEVICE_MONOME_TYPE_GRID;
+	md->quads = (md->rows * md->cols) / 16;
     }
 
     monome_register_handler(m, MONOME_BUTTON_DOWN, dev_monome_handle_press, md);
@@ -120,7 +124,7 @@ void dev_monome_refresh(struct dev_monome *md) {
         return;
     }
 
-    for (int quad = 0; quad < 4; quad++) {
+    for (int quad = 0; quad < md->quads; quad++) {
         if (md->dirty[quad]) {
             if (md->type == DEVICE_MONOME_TYPE_ARC) {
                 monome_led_ring_map(md->m, quad, md->data[quad]);

--- a/matron/src/device/device_monome.h
+++ b/matron/src/device/device_monome.h
@@ -19,6 +19,9 @@ struct dev_monome {
     monome_t *m;
     uint8_t data[4][64]; // led data by quad
     bool dirty[4];       // quad-dirty flags
+    int cols;
+    int rows;
+    int quads;
 };
 
 // set a single grid led


### PR DESCRIPTION
support for new grids based on stm32.

-----

this requires that `matron` be linked against `libmonome` built from the `grid-st` branch.

steps i had to take:

- clone `libmonome` and build the testing branch
```
git clone https://github.com/monome/libmonome
cd libmonome
git checkout grid-st
./waf configure && ./waf && sudo ./waf install
```

this will result in `libmonome` being installed at `usr/local/include`, `/usr/local/lib`.

however the norns image also has libmonome installed directly under `/usr`. (i'm not sure how.)

- so i had to change the runtime link behavior:

```
echo '/usr/local/lib' | sudo tee /etc/ld.so.conf.d/libmonome.conf
sudo ldconfig
```

(i also nuked the installation under `/usr` but probably not necessary.)