### PR TITLE
add 'connected' state to midi vports

### DIFF
--- a/lua/core/midi.lua
+++ b/lua/core/midi.lua
@@ -13,7 +13,7 @@ for i=1,16 do
   Midi.vports[i] = {
     name = "none",
     device = nil,
-    device_connected = false,
+    connected = false,
     event = nil,
 
     send = function(self, ...) if self.device then self.device:send(...) end end,
@@ -374,15 +374,15 @@ function Midi.update_devices()
       end
     end
   end
-  Midi.update_device_connected_state()
+  Midi.update_connected_state()
 end
 
-function Midi.update_device_connected_state()
+function Midi.update_connected_state()
   for i=1,16 do
     if Midi.vports[i].device ~= nil then
-      Midi.vports[i].device_connected = true
+      Midi.vports[i].connected = true
     else
-      Midi.vports[i].device_connected = false
+      Midi.vports[i].connected = false
     end
   end
 end

--- a/lua/core/midi.lua
+++ b/lua/core/midi.lua
@@ -13,6 +13,7 @@ for i=1,16 do
   Midi.vports[i] = {
     name = "none",
     device = nil,
+    device_connected = false,
     event = nil,
 
     send = function(self, ...) if self.device then self.device:send(...) end end,
@@ -371,6 +372,17 @@ function Midi.update_devices()
         Midi.vports[i].device = device
         device.port = i
       end
+    end
+  end
+  Midi.update_device_connected_state()
+end
+
+function Midi.update_device_connected_state()
+  for i=1,16 do
+    if Midi.vports[i].device ~= nil then
+      Midi.vports[i].device_connected = true
+    else
+      Midi.vports[i].device_connected = false
     end
   end
 end


### PR DESCRIPTION
spun this up while working on a MIDI study, when I realized that it was a little wonky for authors to check whether a vport-stored MIDI device is _currently_ physically connected to norns. a niche gap, but one that's easy to fill :)

without this helper flag, connected state is only reflected by the presence of a `device` table in the MIDI vport's table or as a cross-reference to `midi.devices`. by piggybacking a `Midi.update_device_connected_state()` function to the end of `Midi.update_devices()`, the `midi.vports[x].device_connected` flag updates any time a MIDI device is connected or removed.