### PR TITLE
return beat from clock.sync

### DIFF
--- a/matron/src/clocks/clock_scheduler.c
+++ b/matron/src/clocks/clock_scheduler.c
@@ -32,9 +32,10 @@ static pthread_t clock_scheduler_tick_thread;
 static clock_scheduler_event_t clock_scheduler_events[NUM_CLOCK_SCHEDULER_EVENTS];
 static pthread_mutex_t clock_scheduler_events_lock;
 
-static void clock_scheduler_post_clock_resume_event(int thread_id) {
+static void clock_scheduler_post_clock_resume_event(int thread_id, double value) {
     union event_data *ev = event_data_new(EVENT_CLOCK_RESUME);
     ev->clock_resume.thread_id = thread_id;
+    ev->clock_resume.value = value;
     event_post(ev);
 }
 
@@ -60,12 +61,12 @@ static void *clock_scheduler_tick_thread_run(void *p) {
             if (scheduler_event->ready) {
                 if (scheduler_event->type == CLOCK_SCHEDULER_EVENT_SYNC) {
                     if (clock_beat > scheduler_event->sync_clock_beat) {
-                        clock_scheduler_post_clock_resume_event(scheduler_event->thread_id);
+                        clock_scheduler_post_clock_resume_event(scheduler_event->thread_id, clock_beat);
                         scheduler_event->ready = false;
                     }
                 } else {
                     if (clock_time >= scheduler_event->sleep_clock_time) {
-                        clock_scheduler_post_clock_resume_event(scheduler_event->thread_id);
+                        clock_scheduler_post_clock_resume_event(scheduler_event->thread_id, clock_time);
                         scheduler_event->ready = false;
                         scheduler_event->thread_id = -1;
                     }

--- a/matron/src/event_types.h
+++ b/matron/src/event_types.h
@@ -192,6 +192,7 @@ struct event_metro {
 struct event_clock_resume {
     struct event_common common;
     uint32_t thread_id;
+    double value;
 };
 
 struct event_clock_start {

--- a/matron/src/events.c
+++ b/matron/src/events.c
@@ -180,7 +180,7 @@ static void handle_event(union event_data *ev) {
         w_handle_metro(ev->metro.id, ev->metro.stage);
         break;
     case EVENT_CLOCK_RESUME:
-        w_handle_clock_resume(ev->clock_resume.thread_id);
+        w_handle_clock_resume(ev->clock_resume.thread_id, ev->clock_resume.value);
         break;
     case EVENT_CLOCK_START:
         w_handle_clock_start();

--- a/matron/src/weaver.c
+++ b/matron/src/weaver.c
@@ -1519,11 +1519,11 @@ int _clock_schedule_sleep(lua_State *l) {
     int coro_id = (int)luaL_checkinteger(l, 1);
     double seconds = luaL_checknumber(l, 2);
 
-    if (seconds <= 0) {
-        w_handle_clock_resume(coro_id, 0); // TODO: event
-    } else {
-        clock_scheduler_schedule_sleep(coro_id, seconds);
+    if (seconds < 0) {
+        seconds = 0;
     }
+
+    clock_scheduler_schedule_sleep(coro_id, seconds);
 
     return 0;
 }
@@ -1534,7 +1534,7 @@ int _clock_schedule_sync(lua_State *l) {
     double sync_beat = luaL_checknumber(l, 2);
 
     if (sync_beat <= 0) {
-        w_handle_clock_resume(coro_id, 0); // TODO: event
+        luaL_error(l, "invalid sync beat: %f", sync_beat);
     } else {
         clock_scheduler_schedule_sync(coro_id, sync_beat);
     }

--- a/matron/src/weaver.c
+++ b/matron/src/weaver.c
@@ -1520,7 +1520,7 @@ int _clock_schedule_sleep(lua_State *l) {
     double seconds = luaL_checknumber(l, 2);
 
     if (seconds <= 0) {
-        w_handle_clock_resume(coro_id);
+        w_handle_clock_resume(coro_id, 0); // TODO: event
     } else {
         clock_scheduler_schedule_sleep(coro_id, seconds);
     }
@@ -1534,7 +1534,7 @@ int _clock_schedule_sync(lua_State *l) {
     double sync_beat = luaL_checknumber(l, 2);
 
     if (sync_beat <= 0) {
-        w_handle_clock_resume(coro_id);
+        w_handle_clock_resume(coro_id, 0); // TODO: event
     } else {
         clock_scheduler_schedule_sync(coro_id, sync_beat);
     }
@@ -1930,12 +1930,13 @@ void w_handle_metro(const int idx, const int stage) {
 }
 
 // clock handlers
-void w_handle_clock_resume(const int coro_id) {
+void w_handle_clock_resume(const int coro_id, double value) {
     lua_getglobal(lvm, "clock");
     lua_getfield(lvm, -1, "resume");
     lua_remove(lvm, -2);
     lua_pushinteger(lvm, coro_id);
-    l_report(lvm, l_docall(lvm, 1, 0));
+    lua_pushnumber(lvm, value);
+    l_report(lvm, l_docall(lvm, 2, 0));
 }
 
 void w_handle_clock_start() {

--- a/matron/src/weaver.h
+++ b/matron/src/weaver.h
@@ -72,7 +72,7 @@ extern void w_handle_stat(const uint32_t disk, const uint16_t temp, const uint16
 extern void w_handle_metro(const int idx, const int stage);
 
 //--- clock
-extern void w_handle_clock_resume(const int thread_id);
+extern void w_handle_clock_resume(const int thread_id, double value);
 extern void w_handle_clock_start();
 extern void w_handle_clock_stop();
 


### PR DESCRIPTION
this PR changes the clock API to return current beat from `clock.sync` calls as follows:

```
clock.run(function()
    local div = 1/4

    for i=1,4 do
        local beat = clock.sync(div)
        local step = math.floor(beat / div)
        print('beat', beat, 'get_beats', clock.get_beats(), 'step', step)
    end
end)
```

so the above code would print

```
beat	0.25134		get_beats	0.25143		step	1
beat	0.50106		get_beats	0.50106		step	2
beat	0.75134		get_beats	0.75137		step	3
beat	1.00103		get_beats	1.00109		step	4
```

this basically allows tracking time in beat-synced coroutines without external counters and additional transport restart handlers, as current beat will be always returned from `clock.sync` and it will be naturally synced to the source transport too.

with this change `clock.sleep` calls will also return elapsed system (currently jack) time.

`clock.sync` called with any value less than or equal to zero will result in an error.

`clock.sleep` called with any value less than or equal to zero will schedule the coroutine to resume immediately on next scheduler tick.