### PR TITLE
fix update process

### DIFF
--- a/lua/core/menu/update.lua
+++ b/lua/core/menu/update.lua
@@ -38,7 +38,9 @@ local function get_update()
   norns.script.clear()
   _menu.locked = true
   print("shutting down audio...")
-  os.execute("sudo systemctl stop norns-jack.service") -- disable audio
+  --os.execute("sudo systemctl stop norns-jack.service") -- disable audio
+  os.execute("sudo systemctl stop norns-crone.service") -- disable audio
+  os.execute("sudo systemctl stop norns-sclang.service") -- disable audio
   print("clearing old updates...")
   os.execute("sudo rm -rf /home/we/update/*") -- clear old updates
   m.message = "downloading..."


### PR DESCRIPTION
the matron service now depends on jack, and shutting down jack now kills matron, so had to change the update process which was trying to shut down audio to save CPU during update