### PR TITLE
redraw menu when rebuilding only if in menu

### DIFF
--- a/lua/core/menu/params.lua
+++ b/lua/core/menu/params.lua
@@ -636,9 +636,10 @@ _menu.rebuild_params = function()
   if m.mode == mEDIT or m.mode == mMAP then 
     if m.group then
       build_sub(m.groupid)
-      _menu.redraw()
     else
       build_page()
+    end
+    if _menu.mode then
       _menu.redraw()
     end
   end


### PR DESCRIPTION
I have a little bug when using the `_menu.rebuild_params()` function:

In supertonic I use this to show/hide a bunch of track specific parameters. the function works perfectly well when I'm in a menu. but when I'm back in the main screen, if I use `_menu.rebuild_params()` then it will cause the screen to "flash" the menu quickly while it redraws and before it goes back to redrawing the main screen. I do want to rebuild the parameters, so that pressing K1 goes back into the parameters menu with the correctly shown/hidden parameters, but I don't want the menu to be redrawn. 

this pr fixes this - by checking if `_menu.mode` and then redrawing if so. 