### PR TITLE
add offset (swing) parameter to clock.sync

### DIFF
--- a/lua/core/clock.lua
+++ b/lua/core/clock.lua
@@ -68,7 +68,7 @@ end
 clock.resume = function(coro_id, ...)
   local coro = clock.threads[coro_id]
 
-  local result, mode, time = coroutine.resume(coro, ...)
+  local result, mode, time, offset = coroutine.resume(coro, ...)
 
   if coroutine.status(coro) == "dead" then
     if result then
@@ -82,7 +82,7 @@ clock.resume = function(coro_id, ...)
       if mode == SLEEP then
         _norns.clock_schedule_sleep(coro_id, time)
       elseif mode == SYNC then
-        _norns.clock_schedule_sync(coro_id, time)
+        _norns.clock_schedule_sync(coro_id, time, offset)
       elseif mode == SUSPEND then
         -- nothing needed for SUSPEND
       end

--- a/matron/src/clocks/clock_scheduler.c
+++ b/matron/src/clocks/clock_scheduler.c
@@ -40,8 +40,17 @@ static void clock_scheduler_post_clock_resume_event(int thread_id, double value)
     event_post(ev);
 }
 
-static inline double clock_scheduler_next_clock_beat(double clock_beat, double sync_beat, double sync_beat_offset) {
-    return fmax(ceil((clock_beat + FLT_EPSILON) / sync_beat) * sync_beat + sync_beat_offset, 0);
+static double clock_scheduler_next_clock_beat(double clock_beat, double sync_beat, double sync_beat_offset) {
+    double next_beat;
+
+    next_beat = ceil((clock_beat + FLT_EPSILON) / sync_beat) * sync_beat;
+    next_beat = next_beat + sync_beat_offset;
+
+    while (next_beat < (clock_beat + FLT_EPSILON)) {
+        next_beat += sync_beat;
+    }
+
+    return fmax(next_beat, 0);
 }
 
 static void *clock_scheduler_tick_thread_run(void *p) {

--- a/matron/src/clocks/clock_scheduler.c
+++ b/matron/src/clocks/clock_scheduler.c
@@ -21,6 +21,7 @@ typedef struct {
     int thread_id;
 
     double sync_beat;
+    double sync_beat_offset;
     double sync_clock_beat;
 
     double sleep_time;
@@ -39,8 +40,8 @@ static void clock_scheduler_post_clock_resume_event(int thread_id, double value)
     event_post(ev);
 }
 
-static inline double clock_scheduler_next_clock_beat(double clock_beat, double sync_beat) {
-    return fmax(ceil((clock_beat + FLT_EPSILON) / sync_beat) * sync_beat, 0);
+static inline double clock_scheduler_next_clock_beat(double clock_beat, double sync_beat, double sync_beat_offset) {
+    return fmax(ceil((clock_beat + FLT_EPSILON) / sync_beat) * sync_beat + sync_beat_offset, 0);
 }
 
 static void *clock_scheduler_tick_thread_run(void *p) {
@@ -100,7 +101,7 @@ void clock_scheduler_start() {
     pthread_attr_destroy(&attr);
 }
 
-bool clock_scheduler_schedule_sync(int thread_id, double sync_beat) {
+bool clock_scheduler_schedule_sync(int thread_id, double sync_beat, double sync_beat_offset) {
     pthread_mutex_lock(&clock_scheduler_events_lock);
 
     double clock_beat = clock_get_beats();
@@ -110,12 +111,13 @@ bool clock_scheduler_schedule_sync(int thread_id, double sync_beat) {
             clock_scheduler_events[i].ready = true;
             clock_scheduler_events[i].thread_id = thread_id;
             clock_scheduler_events[i].sync_beat = sync_beat;
+            clock_scheduler_events[i].sync_beat_offset = sync_beat_offset;
 
             if (clock_scheduler_events[i].type == CLOCK_SCHEDULER_EVENT_SYNC) {
-                clock_scheduler_events[i].sync_clock_beat = clock_scheduler_next_clock_beat(clock_scheduler_events[i].sync_clock_beat, sync_beat);
+                clock_scheduler_events[i].sync_clock_beat = clock_scheduler_next_clock_beat(clock_scheduler_events[i].sync_clock_beat, sync_beat, sync_beat_offset);
             } else {
                 clock_scheduler_events[i].type = CLOCK_SCHEDULER_EVENT_SYNC;
-                clock_scheduler_events[i].sync_clock_beat = clock_scheduler_next_clock_beat(clock_beat, sync_beat);
+                clock_scheduler_events[i].sync_clock_beat = clock_scheduler_next_clock_beat(clock_beat, sync_beat, sync_beat_offset);
             }
 
             pthread_mutex_unlock(&clock_scheduler_events_lock);
@@ -128,7 +130,7 @@ bool clock_scheduler_schedule_sync(int thread_id, double sync_beat) {
             clock_scheduler_events[i].ready = true;
             clock_scheduler_events[i].thread_id = thread_id;
             clock_scheduler_events[i].sync_beat = sync_beat;
-            clock_scheduler_events[i].sync_clock_beat = clock_scheduler_next_clock_beat(clock_beat, sync_beat);
+            clock_scheduler_events[i].sync_clock_beat = clock_scheduler_next_clock_beat(clock_beat, sync_beat, sync_beat_offset);
             clock_scheduler_events[i].type = CLOCK_SCHEDULER_EVENT_SYNC;
 
             pthread_mutex_unlock(&clock_scheduler_events_lock);
@@ -197,7 +199,7 @@ void clock_scheduler_reschedule_sync_events() {
         scheduler_event = &clock_scheduler_events[i];
 
         if (scheduler_event->ready && scheduler_event->type == CLOCK_SCHEDULER_EVENT_SYNC) {
-            scheduler_event->sync_clock_beat = clock_scheduler_next_clock_beat(clock_beat, scheduler_event->sync_beat);
+            scheduler_event->sync_clock_beat = clock_scheduler_next_clock_beat(clock_beat, scheduler_event->sync_beat, scheduler_event->sync_beat_offset);
         }
     }
 

--- a/matron/src/clocks/clock_scheduler.h
+++ b/matron/src/clocks/clock_scheduler.h
@@ -6,7 +6,7 @@
 
 void clock_scheduler_init();
 void clock_scheduler_start();
-bool clock_scheduler_schedule_sync(int thread_id, double sync_beat);
+bool clock_scheduler_schedule_sync(int thread_id, double sync_beat, double sync_beat_offset);
 bool clock_scheduler_schedule_sleep(int thread_id, double seconds);
 void clock_scheduler_clear(int thread_id);
 void clock_scheduler_clear_all();

--- a/matron/src/weaver.c
+++ b/matron/src/weaver.c
@@ -1532,11 +1532,12 @@ int _clock_schedule_sync(lua_State *l) {
     lua_check_num_args(2);
     int coro_id = (int)luaL_checkinteger(l, 1);
     double sync_beat = luaL_checknumber(l, 2);
+    double offset = luaL_optnumber(l, 3, 0);
 
     if (sync_beat <= 0) {
         luaL_error(l, "invalid sync beat: %f", sync_beat);
     } else {
-        clock_scheduler_schedule_sync(coro_id, sync_beat);
+        clock_scheduler_schedule_sync(coro_id, sync_beat, offset);
     }
 
   return 0;

--- a/matron/src/weaver.c
+++ b/matron/src/weaver.c
@@ -1529,7 +1529,6 @@ int _clock_schedule_sleep(lua_State *l) {
 }
 
 int _clock_schedule_sync(lua_State *l) {
-    lua_check_num_args(2);
     int coro_id = (int)luaL_checkinteger(l, 1);
     double sync_beat = luaL_checknumber(l, 2);
     double offset = luaL_optnumber(l, 3, 0);


### PR DESCRIPTION
this change enables various swing styles in coroutines using clock.sync by adding an optional `offset` parameter for `sync`, which can be used as follows:

```lua
clock.sync(1) -- sync and resume as usual
clock.sync(1, 0.5) -- sync and resume with a half-beat delay
clock.sync(4, -2) -- sync and resume 2 beats earlier

-- create a swinging feel for the whole script
local beat = 1/4
local groove = 0

while true do
  local current_beat = clock.sync(beat, groove)
  local current_step = math.floor(current_beat / beat)
  if current_step % 2 == 0 then
    groove = beat / 2
  else
    groove = 0
  end
end

-- same as above, using XOR (~) for setting even/odd offset multiplier
local beat = 1/4
local offset = beat / 2
local swing = 0

while true do
  clock.sync(beat, offset * swing)
  swing = swing ~ 1
end

```