### PR TITLE
matron lifecycle hooks and system level mods.lua

### DIFF
--- a/lua/core/config.lua
+++ b/lua/core/config.lua
@@ -27,4 +27,5 @@ _path.audio = _path.dust..'audio/'
 _path.tape = _path.audio..'tape/'
 _path.data = _path.dust..'data/'
 _path.favorites = _path.data..'system.favorites'
+_path.enabled_mods = _path.data..'system.mods'
 

--- a/lua/core/hook.lua
+++ b/lua/core/hook.lua
@@ -34,6 +34,7 @@ local hooks = {
   script_pre_init = Hook.new(),
   script_post_cleanup = Hook.new(),
   system_post_startup = Hook.new(),
+  system_pre_shutdown = Hook.new(),
 }
 
 return tab.readonly{table = hooks}

--- a/lua/core/hook.lua
+++ b/lua/core/hook.lua
@@ -1,0 +1,39 @@
+local tab = require 'tabutil'
+
+local Hook = {}
+Hook.__index = Hook
+
+function Hook.new()
+  local this = {}
+  this.callbacks = {}
+  return setmetatable(this, Hook)
+end
+
+function Hook:register(name, func)
+  self.callbacks[name] = func
+end
+
+function Hook:deregister(name)
+  self.callbacks[name] = nil
+end
+
+function Hook:__call(...)
+  for k, func in pairs(self.callbacks) do
+    if func ~= nil then
+      print('calling: ' .. k)
+      local ok, error = pcall(func, arg)
+      if not ok then
+        print('hook: ' .. k .. ' failed, error: ' .. error)
+      end
+    end
+  end
+end
+
+-- define the hook types
+local hooks = {
+  script_pre_init = Hook.new(),
+  script_post_cleanup = Hook.new(),
+  system_post_startup = Hook.new(),
+}
+
+return tab.readonly{table = hooks}

--- a/lua/core/menu.lua
+++ b/lua/core/menu.lua
@@ -254,4 +254,5 @@ m["UPDATE"] = require 'core/menu/update'
 m["SLEEP"] = require 'core/menu/sleep'
 m["MIX"] = require 'core/menu/mix'
 m["TAPE"] = require 'core/menu/tape'
+m["MODS"] = require 'core/menu/mods'
 

--- a/lua/core/menu/mods.lua
+++ b/lua/core/menu/mods.lua
@@ -7,8 +7,12 @@ local m = {
   selected = ""
 }
 
+m.position_name = function(pos)
+  return m.list[pos+1]
+end
+
 m.select_position = function(pos)
-  m.selected = string.upper(m.list[pos+1])
+  m.selected = m.position_name(pos)
 end
 
 m.key = function(n,z)
@@ -48,10 +52,10 @@ m.redraw = function()
   else
     for i=1,6 do
       if (i > 2 - m.pos) and (i < m.len - m.pos + 3) then
-        local name = string.upper(m.list[i+m.pos-2])
+        local name = m.list[i+m.pos-2]
         local enabled = mods.is_enabled(name)
         local loaded = mods.is_loaded(name)
-        local line = name
+        local line = string.upper(name)
 
         local y = 10*i
         local line_level = 4
@@ -102,7 +106,8 @@ end
 m.deinit = function() end
 
 m.set_enabled = function(state)
-  if m.selected then mods.set_enabled(m.selected, state, true) end
+  local name = m.position_name(m.pos)
+  if name then mods.set_enabled(name, state, true) end
 end
 
 return m

--- a/lua/core/menu/mods.lua
+++ b/lua/core/menu/mods.lua
@@ -3,21 +3,33 @@ local mods = require 'core/mods'
 local m = {
   pos = 0,
   list = {},
+  selected = ""
 }
 
 m.key = function(n,z)
   -- back
   if n==2 and z==1 then
     _menu.set_page("SYSTEM")
-  else
-    print("do something", n, z)
+  elseif n==3 and z==1 and m.len > 0 then -- if there are mods
+    -- TODO: check if mod is enabled first!
+    if _menu.m[m.selected] then -- does the mod have a menu page
+      _menu.set_page(m.selected)
+    end
   end
 end
 
 m.enc = function(n,delta)
   if n==2 then
     m.pos = util.clamp(m.pos + delta, 0, m.len - 1)
+    m.selected = string.upper(m.list[m.pos+1])
     _menu.redraw()
+  elseif n==3 then
+    -- TODO
+    if d > 0 then
+      -- ENABLE MOD
+    else
+      -- DISABLE MOD
+    end
   end
 end
 
@@ -31,13 +43,14 @@ m.redraw = function()
     for i=1,6 do
       if (i > 2 - m.pos) and (i < m.len - m.pos + 3) then
         screen.move(0,10*i)
-        local line = m.list[i+m.pos-2]
+        local line = string.upper(m.list[i+m.pos-2])
         if(i==3) then
           screen.level(15)
         else
           screen.level(4)
         end
-        screen.text(string.upper(line))
+        if _menu.m[line] then line = line .. " >" end
+        screen.text(line)
       end
     end
   end
@@ -55,3 +68,4 @@ end
 m.deinit = function() end
 
 return m
+

--- a/lua/core/menu/mods.lua
+++ b/lua/core/menu/mods.lua
@@ -1,0 +1,57 @@
+local mods = require 'core/mods'
+
+local m = {
+  pos = 0,
+  list = {},
+}
+
+m.key = function(n,z)
+  -- back
+  if n==2 and z==1 then
+    _menu.set_page("SYSTEM")
+  else
+    print("do something", n, z)
+  end
+end
+
+m.enc = function(n,delta)
+  if n==2 then
+    m.pos = util.clamp(m.pos + delta, 0, m.len - 1)
+    _menu.redraw()
+  end
+end
+
+m.redraw = function()
+  screen.clear()
+  screen.level(15)
+  if m.len == 0 then
+    screen.move(64,40)
+    screen.text_center("no mods")
+  else
+    for i=1,6 do
+      if (i > 2 - m.pos) and (i < m.len - m.pos + 3) then
+        screen.move(0,10*i)
+        local line = m.list[i+m.pos-2]
+        if(i==3) then
+          screen.level(15)
+        else
+          screen.level(4)
+        end
+        screen.text(string.upper(line))
+      end
+    end
+  end
+  screen.update()
+end
+
+m.init = function()
+  m.list = {}
+  for k, _ in pairs(mods.scan() or {}) do
+    table.insert(m.list, k)
+  end
+  m.len = tab.count(m.list)
+end
+
+m.deinit = function() end
+
+return m

--- a/lua/core/menu/reset.lua
+++ b/lua/core/menu/reset.lua
@@ -11,10 +11,10 @@ m.key = function(n,z)
     os.execute("rm ~/dust/data/system.pset")
     os.execute("rm ~/dust/data/system.state")
     os.execute("rm "..paths.favorites)
+    os.execute("rm "..paths.enabled_mods)
     _norns.reset()
   end
 end
-
 
 m.enc = function(n,delta) end
 

--- a/lua/core/menu/system.lua
+++ b/lua/core/menu/system.lua
@@ -1,7 +1,7 @@
 local m = {
   pos = 1,
-  list = {"DEVICES > ", "WIFI >", "RESTART", "RESET", "UPDATE"},
-  pages = {"DEVICES", "WIFI", "RESTART", "RESET", "UPDATE"}
+  list = {"DEVICES > ", "WIFI >", "MODS >", "RESTART", "RESET", "UPDATE"},
+  pages = {"DEVICES", "WIFI", "MODS", "RESTART", "RESET", "UPDATE"}
 }
 
 m.key = function(n,z)

--- a/lua/core/menu/system.lua
+++ b/lua/core/menu/system.lua
@@ -23,7 +23,7 @@ m.redraw = function()
   screen.clear()
 
   for i=1,#m.list do
-    screen.move(0,10+10*i)
+    screen.move(0,10*i)
     if(i==m.pos) then
       screen.level(15)
     else

--- a/lua/core/mods.lua
+++ b/lua/core/mods.lua
@@ -19,11 +19,11 @@ function Mods.scan(root, pattern)
   if not matches then return nil end
 
   local mods = {}
-  local name_pattern = "^" .. r .. "(%w+)/"
+  local name_pattern = "^" .. r .. "([%w_-]+)/"
   for i, path in ipairs(matches) do
     -- strip off path root and trailing .lua
     local relative = string.gsub(string.gsub(path, r, ""), ".lua", "")
-    local _, _, mod_name = string.find(relative, "^(%w+)/")
+    local _, _, mod_name = string.find(relative, "^([%w_-]+)/")
     mods[mod_name] = {relative, path}
   end
 

--- a/lua/core/mods.lua
+++ b/lua/core/mods.lua
@@ -1,4 +1,13 @@
+local tabutil = require 'tabutil'
+
+local enabled_mods = {}
+local loaded_mods = {}
+
 local Mods = {}
+
+--
+-- loading support
+--
 
 Mods.search_pattern = "*/lib/mod.lua"
 
@@ -21,27 +30,36 @@ function Mods.scan(root, pattern)
   return mods
 end
 
-local function to_set(things)
+local function to_set(list)
   local s = {}
-  for _, v in ipairs(things) do
-    s[v] = true
+  if list ~= nil then
+    for _, v in ipairs(list) do s[v] = true end
   end
   return s
 end
 
-function Mods.load(scan, enabled)
+local function to_list(set)
+  local l = {}
+  if set ~= nil then
+    for k, bool in pairs(set) do
+      if bool then table.insert(l, k) end
+    end
+  end
+  return l
+end
+
+function Mods.load(scan, only_enabled)
   local _load = function(name, package_path)
+    Mods.this_name = name
     print('loading mod: ' .. name .. ' (' .. package_path ..')')
     require(package_path)
-  end
-
-  if enabled ~= nil then
-    enabled = to_set(enabled)
+    Mods.this_name = nil
+    loaded_mods[name] = true
   end
 
   for name, details in pairs(scan) do
-    if enabled then
-      if enabled[name] then
+    if only_enabled then
+      if Mods.is_enabled(name) then
         _load(name, details[1])
       end
     else
@@ -49,5 +67,76 @@ function Mods.load(scan, enabled)
     end
   end
 end
+
+function Mods.load_enabled()
+  enabled_mods = to_set(tabutil.load(paths.enabled_mods)) or {}
+  return enabled_mods
+end
+
+function Mods.save_enabled()
+  tabutil.save(to_list(enabled_mods), paths.enabled_mods)
+end
+
+function Mods.set_enabled(name, bool, autosave)
+  if enabled_mods[name] ~= bool then
+    -- it changed, record and save
+    enabled_mods[name] = bool
+    if autosave then
+      tabutil.save(to_list(enabled_mods), paths.enabled_mods)
+    end
+  end
+end
+
+function Mods.is_enabled(name)
+  return enabled_mods[name] or false
+end
+
+function Mods.enabled_mod_names()
+  return to_list(enabled_mods)
+end
+
+function Mods.is_loaded(name)
+  return loaded_mods[name] or false
+end
+
+function Mods.loaded_mod_names()
+  return to_list(loaded_mods)
+end
+
+--
+-- menu support
+--
+
+Mods.menu = {
+  redraw = function()
+    _menu.redraw()
+  end,
+
+  exit = function()
+    _menu.set_page("MODS")
+  end,
+
+  register = function(name, m)
+    _menu.m[name] = m
+  end,
+}
+
+--
+-- hook support, provide function (as opposed to method) interface to pair with
+-- menu support.
+--
+
+local hooks = require 'core/hook'
+
+Mods.hook = {
+  register = function(which, name, func)
+    hooks[which]:register(name, func)
+  end,
+
+  deregister = function(which, name)
+    hooks[which]:deregister(name)
+  end,
+}
+
 
 return Mods

--- a/lua/core/mods.lua
+++ b/lua/core/mods.lua
@@ -1,0 +1,53 @@
+local Mods = {}
+
+Mods.search_pattern = "*/lib/mod.lua"
+
+function Mods.scan(root, pattern)
+  local r = root or paths.code
+  local p = pattern or Mods.search_pattern
+
+  local matches, error = norns.system_glob(r .. p)
+  if not matches then return nil end
+
+  local mods = {}
+  local name_pattern = "^" .. r .. "(%w+)/"
+  for i, path in ipairs(matches) do
+    -- strip off path root and trailing .lua
+    local relative = string.gsub(string.gsub(path, r, ""), ".lua", "")
+    local _, _, mod_name = string.find(relative, "^(%w+)/")
+    mods[mod_name] = {relative, path}
+  end
+
+  return mods
+end
+
+local function to_set(things)
+  local s = {}
+  for _, v in ipairs(things) do
+    s[v] = true
+  end
+  return s
+end
+
+function Mods.load(scan, enabled)
+  local _load = function(name, package_path)
+    print('loading mod: ' .. name .. ' (' .. package_path ..')')
+    require(package_path)
+  end
+
+  if enabled ~= nil then
+    enabled = to_set(enabled)
+  end
+
+  for name, details in pairs(scan) do
+    if enabled then
+      if enabled[name] then
+        _load(name, details[1])
+      end
+    else
+      _load(name, details[1])
+    end
+  end
+end
+
+return Mods

--- a/lua/core/norns.lua
+++ b/lua/core/norns.lua
@@ -221,6 +221,8 @@ _norns.system_cmd_capture = function(cap)
   end
 end
 
+norns.system_glob = _norns.system_glob
+
 -- audio reset
 _norns.reset = function()
   os.execute("sudo systemctl restart norns-sclang.service")

--- a/lua/core/norns.lua
+++ b/lua/core/norns.lua
@@ -10,6 +10,7 @@ local engine = require 'core/engine'
 local poll = require 'core/poll'
 local tab = require 'tabutil'
 local util = require 'util'
+local hook = require 'core/hook'
 
 -- Global Functions.
 
@@ -177,6 +178,7 @@ end
 
 -- shutdown
 norns.shutdown = function()
+  hook.system_pre_shutdown()
   print("SLEEP")
   --TODO fade out screen then run the shutdown script
   norns.state.clean_shutdown = true

--- a/lua/core/script.lua
+++ b/lua/core/script.lua
@@ -1,6 +1,8 @@
 --- Script class
 -- @module script
 
+local hook = require 'core/hook'
+
 local Script = {}
 
 --- reset script environment.
@@ -122,7 +124,6 @@ Script.load = function(filename)
     filename = string.sub(filename,1,1) == "/" and filename or _path["dust"]..filename
     path, scriptname = filename:match("^(.*)/([^.]*).*$")
     name = string.sub(path, string.len(_path["code"]) + 1)
-    
     -- append scriptname to the name if it doesn't match directory name in case multiple scripts reside in the same directory
     -- ex: we/study/study1, we/study/study2, ...
     if string.sub(name, -#scriptname) ~= scriptname then
@@ -145,6 +146,9 @@ Script.load = function(filename)
     else
       print("### cleanup failed with error: "..err)
     end
+
+    -- allow mods to do cleanup
+    hook.script_post_cleanup()
 
     -- unload asl package entry so `require 'asl'` works
     -- todo(pq): why is this not needed generally (e.g., for 'ui', 'util', etc.)?
@@ -198,6 +202,9 @@ end
 
 --- load engine, execute script-specified init (if present).
 Script.run = function()
+  -- allow mods to do initialization
+  hook.script_pre_init()
+
   print("# script run")
   if engine.name ~= nil then
     print("loading engine: " .. engine.name)

--- a/lua/core/startup.lua
+++ b/lua/core/startup.lua
@@ -29,6 +29,8 @@ paramset = require 'core/paramset'
 params = paramset.new()
 norns.pmap = require 'core/pmap'
 
+-- load, initialize hooks
+local hook = require 'core/hook'
 
 -- load menu
 require 'core/menu'
@@ -106,4 +108,4 @@ print("start_audio(): ")
 -- start the process of syncing with crone boot
 _norns.start_audio()
 
-
+hook.system_post_startup()

--- a/lua/core/startup.lua
+++ b/lua/core/startup.lua
@@ -109,17 +109,9 @@ print("start_audio(): ")
 _norns.start_audio()
 
 -- load matron mods and invoke system hooks
--- local mods_path = paths.data .. "/mods.lua"
--- if util.file_exists(mods_path) then
---   print("loading mods")
---   dofile(mods_path)
--- end
-
--- load matron mods and invoke system hooks
 local mods = require 'core/mods'
-local scan = mods.scan()
-if scan then
-  mods.load(scan)
-end
+mods.load_enabled()
+mods.load(mods.scan(), true) -- only load enabled mods
+
 
 hook.system_post_startup()

--- a/lua/core/startup.lua
+++ b/lua/core/startup.lua
@@ -109,10 +109,17 @@ print("start_audio(): ")
 _norns.start_audio()
 
 -- load matron mods and invoke system hooks
-local mods_path = paths.data .. "/mods.lua"
-if util.file_exists(mods_path) then
-  print("loading mods")
-  dofile(mods_path)
+-- local mods_path = paths.data .. "/mods.lua"
+-- if util.file_exists(mods_path) then
+--   print("loading mods")
+--   dofile(mods_path)
+-- end
+
+-- load matron mods and invoke system hooks
+local mods = require 'core/mods'
+local scan = mods.scan()
+if scan then
+  mods.load(scan)
 end
 
 hook.system_post_startup()

--- a/lua/core/startup.lua
+++ b/lua/core/startup.lua
@@ -108,4 +108,11 @@ print("start_audio(): ")
 -- start the process of syncing with crone boot
 _norns.start_audio()
 
+-- load matron mods and invoke system hooks
+local mods_path = paths.data .. "/mods.lua"
+if util.file_exists(mods_path) then
+  print("loading mods")
+  dofile(mods_path)
+end
+
 hook.system_post_startup()

--- a/matron/src/weaver.c
+++ b/matron/src/weaver.c
@@ -2574,7 +2574,7 @@ int _system_glob(lua_State *l) {
     const char *pattern = luaL_checkstring(l, 1);
 
     int glob_status = 0;
-    int glob_flags = GLOB_MARK | GLOB_TILDE;
+    int glob_flags = GLOB_MARK | GLOB_TILDE | GLOB_BRACE;
     glob_t g;
 
     unsigned int i;


### PR DESCRIPTION
this is a proof of concept which implements much of the functionality i proposed for #1384

this does not provide any ui or dynamic discovery of "mods". for demonstration purposes the `startup.lua` code was extended to look for `dust/data/mods.lua` and load that file at the end of matron's startup process. within `mods.lua` one can place code or call `require '<script_dir>/lib/<blah>'` to load files from the normal script/project area.