### PR TITLE
focus/defocus callbacks

### DIFF
--- a/lua/core/menu.lua
+++ b/lua/core/menu.lua
@@ -147,6 +147,7 @@ _menu.set_mode = function(mode)
   if mode == false then -- ACTIVATE PLAY MODE
     if _menu.mode == true then _norns.screen_restore() end
     _menu.mode = false
+    norns.focus_lib = false
     m[_menu.page].deinit()
     screen.clear()
     screen.update()
@@ -155,7 +156,7 @@ _menu.set_mode = function(mode)
     norns.encoders.callback = enc
     norns.enc.resume()
     redraw()
-  elseif mode == true then -- ACTIVATE MENu MODE
+  elseif mode == true then -- ACTIVATE MENU MODE
     if _menu.mode == false then _norns.screen_save() end
     _menu.mode = true
     _menu.alt = false
@@ -172,6 +173,7 @@ _menu.set_mode = function(mode)
     norns.encoders.set_sens(3,2)
     _menu.set_page(_menu.page)
   end
+  norns.focus_change()
 end
 
 -- set page
@@ -254,4 +256,5 @@ m["UPDATE"] = require 'core/menu/update'
 m["SLEEP"] = require 'core/menu/sleep'
 m["MIX"] = require 'core/menu/mix'
 m["TAPE"] = require 'core/menu/tape'
+
 

--- a/lua/core/norns.lua
+++ b/lua/core/norns.lua
@@ -228,6 +228,26 @@ _norns.reset = function()
   os.execute("sudo systemctl restart norns-matron.service")
 end
 
+-- focus
+norns.focus_lib = false
+norns.focus_prev = false
+
+function norns.focus()
+  return not (_menu.mode or norns.focus_lib)
+end
+
+function norns.focus_change()
+  local f = norns.focus()
+  if f ~= norns.focus_prev then
+    if not (_menu.mode or norns.focus_lib) then
+      if focus then focus() end
+    else
+      if defocus then defocus() end
+    end
+  end
+  norns.focus_prev = f
+end
+
 -- startup function will be run after I/O subsystems are initialized,
 -- but before I/O event loop starts ticking (see readme-script.md)
 _startup = function()

--- a/lua/lib/fileselect.lua
+++ b/lua/lib/fileselect.lua
@@ -37,6 +37,8 @@ function fs.enter(folder, callback)
     norns.menu.set(fs.enc, fs.key, fs.redraw)
   end
   fs.redraw()
+  norns.focus_lib = true
+  norns.focus_change()
 end
 
 function fs.exit()
@@ -50,6 +52,8 @@ function fs.exit()
   end
   if fs.path then fs.callback(fs.path)
   else fs.callback("cancel") end
+  norns.focus_lib = false
+  norns.focus_change()
 end
 
 function fs.pushd(dir)

--- a/lua/lib/listselect.lua
+++ b/lua/lib/listselect.lua
@@ -28,6 +28,8 @@ function ls.enter(list, callback)
     norns.menu.set(ls.enc, ls.key, ls.redraw)
   end
   ls.redraw()
+  norns.focus_lib = true
+  norns.focus_change()
 end
 
 function ls.exit()
@@ -41,6 +43,8 @@ function ls.exit()
   end
   if ls.selection then ls.callback(ls.selection)
   else ls.callback("cancel") end
+  norns.focus_lib = false
+  norns.focus_change()
 end
 
 

--- a/lua/lib/textentry.lua
+++ b/lua/lib/textentry.lua
@@ -29,6 +29,8 @@ te.enter = function(callback, default, heading, check)
     norns.menu.set(te.enc, te.key, te.redraw)
   end
   te.redraw()
+  norns.focus_lib = true
+  norns.focus_change()
 end
 
 te.exit = function()
@@ -42,6 +44,8 @@ te.exit = function()
   end
   if te.txt then te.callback(te.txt)
   else te.callback(nil) end
+  norns.focus_lib = false
+  norns.focus_change()
 end
 
 


### PR DESCRIPTION
implemented user-definable callbacks, for example:

```
focus = function() print("FOCUS") end;
defocus = function() print("DEFOCUS") end
```

which are called when menu is toggled or a UI lib (fileselect, textentry, listselect)

also:

```
norns.focus()  -- returns true (script UI is focus) or false (menu/lib-ui)
```

fixes #1272