### PR TITLE
hotfix crow clock input handling with new crow namespace

### DIFF
--- a/lua/core/crow.lua
+++ b/lua/core/crow.lua
@@ -127,6 +127,7 @@ function norns.crow.reset_events()
     pub      = norns.crow.public.add,
     pupdate  = norns.crow.public.update,
     pubview  = norns.crow.public.view,
+    change   = function() end, -- ignore clock event
   },{
     __index = function(self, ix)
       return function(...) print("unused event: ^^"..ix.."(".. quote(...) ..")") end
@@ -158,10 +159,13 @@ end
 
 --- helper functions for common crow actions from norns
 norns.crow.clock_enable = function()
--- TODO confirm that the new system denecessitates reset_events as we dynamically reassign the fn
-  norns.crow.send("input[1]:reset_events()") -- ensure crow's callback has not been redefined
-  crow.input[1].change = function() end
-  crow.input[1].mode("change",2,0.1,"rising")
+  -- directly set the change event on crow so it conforms to old-style event names
+  norns.crow.send[[
+    input[1].change = function()
+      tell('change',1,1)
+    end
+    input[1].mode('change',2,0.1,'rising')
+  ]]
 end
 
 


### PR DESCRIPTION
crow as a clock input source was broken because the clock C layer expects a magic string from crow (which was changed to a dynamic string with the crow namespace update).

this change forces crow to send the old-style event string so that it will match (without having to change the clock C layer to something more complex).