### PR TITLE
script loads & calls norns.crow.init() instead of crow.init()

### DIFF
--- a/lua/core/script.lua
+++ b/lua/core/script.lua
@@ -59,7 +59,7 @@ Script.clear = function()
   init = norns.none
 
   -- clear crow functions
-  crow.init()
+  norns.crow.init()
 
   -- clear keyboard handlers
   keyboard.clear()


### PR DESCRIPTION
We broke the crow initialization with the namespace update -- when a script is loaded it now calls `norns.crow.init()`.