### PR TITLE
fix clock syncing after sleep from the same coroutine

### DIFF
--- a/matron/src/clocks/clock_scheduler.c
+++ b/matron/src/clocks/clock_scheduler.c
@@ -101,7 +101,6 @@ static void *clock_scheduler_tick_thread_run(void *p) {
                     if (clock_time >= event->sleep_clock_time) {
                         clock_scheduler_post_clock_resume_event(event->thread_id, clock_time);
                         event->ready = false;
-                        event->thread_id = -1;
                     }
                 }
             };

--- a/matron/src/clocks/clock_scheduler.c
+++ b/matron/src/clocks/clock_scheduler.c
@@ -53,9 +53,32 @@ static double clock_scheduler_next_clock_beat(double clock_beat, double sync_bea
     return fmax(next_beat, 0);
 }
 
+static clock_scheduler_event_t *clock_scheduler_find_event(int thread_id) {
+    int result = -1;
+
+    for (int i = 0; i < NUM_CLOCK_SCHEDULER_EVENTS; i++) {
+        if (clock_scheduler_events[i].thread_id == thread_id) {
+            result = i;
+            break;
+        }
+
+        // if an event for the given thread_id was not found,
+        // return the index for the first available event
+        if (clock_scheduler_events[i].thread_id == -1 && result < 0) {
+            result = i;
+        }
+    }
+
+    if (result > -1) {
+        return &clock_scheduler_events[result];
+    }
+
+    return NULL;
+}
+
 static void *clock_scheduler_tick_thread_run(void *p) {
     (void)p;
-    clock_scheduler_event_t *scheduler_event;
+    clock_scheduler_event_t *event;
     double clock_beat;
     double clock_time;
 
@@ -66,19 +89,19 @@ static void *clock_scheduler_tick_thread_run(void *p) {
         clock_beat = clock_get_beats();
 
         for (int i = 0; i < NUM_CLOCK_SCHEDULER_EVENTS; i++) {
-            scheduler_event = &clock_scheduler_events[i];
+            event = &clock_scheduler_events[i];
 
-            if (scheduler_event->ready) {
-                if (scheduler_event->type == CLOCK_SCHEDULER_EVENT_SYNC) {
-                    if (clock_beat > scheduler_event->sync_clock_beat) {
-                        clock_scheduler_post_clock_resume_event(scheduler_event->thread_id, clock_beat);
-                        scheduler_event->ready = false;
+            if (event->ready) {
+                if (event->type == CLOCK_SCHEDULER_EVENT_SYNC) {
+                    if (clock_beat > event->sync_clock_beat) {
+                        clock_scheduler_post_clock_resume_event(event->thread_id, clock_beat);
+                        event->ready = false;
                     }
                 } else {
-                    if (clock_time >= scheduler_event->sleep_clock_time) {
-                        clock_scheduler_post_clock_resume_event(scheduler_event->thread_id, clock_time);
-                        scheduler_event->ready = false;
-                        scheduler_event->thread_id = -1;
+                    if (clock_time >= event->sleep_clock_time) {
+                        clock_scheduler_post_clock_resume_event(event->thread_id, clock_time);
+                        event->ready = false;
+                        event->thread_id = -1;
                     }
                 }
             };
@@ -114,36 +137,31 @@ bool clock_scheduler_schedule_sync(int thread_id, double sync_beat, double sync_
     pthread_mutex_lock(&clock_scheduler_events_lock);
 
     double clock_beat = clock_get_beats();
+    clock_scheduler_event_t *event = clock_scheduler_find_event(thread_id);
 
-    for (int i = 0; i < NUM_CLOCK_SCHEDULER_EVENTS; i++) {
-        if (clock_scheduler_events[i].thread_id == thread_id) {
-            clock_scheduler_events[i].ready = true;
-            clock_scheduler_events[i].sync_beat = sync_beat;
-            clock_scheduler_events[i].sync_beat_offset = sync_beat_offset;
+    if (event != NULL) {
+        if (event->thread_id == thread_id) {
+            event->ready = true;
+            event->sync_beat = sync_beat;
+            event->sync_beat_offset = sync_beat_offset;
 
-            if (clock_scheduler_events[i].type == CLOCK_SCHEDULER_EVENT_SYNC) {
-                clock_scheduler_events[i].sync_clock_beat = clock_scheduler_next_clock_beat(clock_scheduler_events[i].sync_clock_beat, sync_beat, sync_beat_offset);
+            // count from the stored sync_clock_beat when syncing the same coroutine
+            if (event->type == CLOCK_SCHEDULER_EVENT_SYNC) {
+                event->sync_clock_beat = clock_scheduler_next_clock_beat(event->sync_clock_beat, sync_beat, sync_beat_offset);
             } else {
-                clock_scheduler_events[i].type = CLOCK_SCHEDULER_EVENT_SYNC;
-                clock_scheduler_events[i].sync_clock_beat = clock_scheduler_next_clock_beat(clock_beat, sync_beat, sync_beat_offset);
+                event->sync_clock_beat = clock_scheduler_next_clock_beat(clock_beat, sync_beat, sync_beat_offset);
+                event->type = CLOCK_SCHEDULER_EVENT_SYNC;
             }
-
-            pthread_mutex_unlock(&clock_scheduler_events_lock);
-            return true;
+        } else {
+            event->thread_id = thread_id;
+            event->ready = true;
+            event->sync_beat = sync_beat;
+            event->sync_clock_beat = clock_scheduler_next_clock_beat(clock_beat, sync_beat, sync_beat_offset);
+            event->type = CLOCK_SCHEDULER_EVENT_SYNC;
         }
-    }
 
-    for (int i = 0; i < NUM_CLOCK_SCHEDULER_EVENTS; i++) {
-        if (clock_scheduler_events[i].thread_id == -1) {
-            clock_scheduler_events[i].ready = true;
-            clock_scheduler_events[i].thread_id = thread_id;
-            clock_scheduler_events[i].sync_beat = sync_beat;
-            clock_scheduler_events[i].sync_clock_beat = clock_scheduler_next_clock_beat(clock_beat, sync_beat, sync_beat_offset);
-            clock_scheduler_events[i].type = CLOCK_SCHEDULER_EVENT_SYNC;
-
-            pthread_mutex_unlock(&clock_scheduler_events_lock);
-            return true;
-        }
+        pthread_mutex_unlock(&clock_scheduler_events_lock);
+        return true;
     }
 
     pthread_mutex_unlock(&clock_scheduler_events_lock);
@@ -154,31 +172,17 @@ bool clock_scheduler_schedule_sleep(int thread_id, double seconds) {
     pthread_mutex_lock(&clock_scheduler_events_lock);
 
     double clock_time = clock_get_system_time();
+    clock_scheduler_event_t *event = clock_scheduler_find_event(thread_id);
 
-    for (int i = 0; i < NUM_CLOCK_SCHEDULER_EVENTS; i++) {
-        if (clock_scheduler_events[i].thread_id == thread_id) {
-            clock_scheduler_events[i].ready = true;
-            clock_scheduler_events[i].sleep_time = seconds;
-            clock_scheduler_events[i].sleep_clock_time = clock_time + seconds;
-            clock_scheduler_events[i].type = CLOCK_SCHEDULER_EVENT_SLEEP;
+    if (event != NULL) {
+        event->ready = true;
+        event->thread_id = thread_id;
+        event->sleep_time = seconds;
+        event->sleep_clock_time = clock_time + seconds;
+        event->type = CLOCK_SCHEDULER_EVENT_SLEEP;
 
-            pthread_mutex_unlock(&clock_scheduler_events_lock);
-
-            return true;
-        }
-    }
-
-    for (int i = 0; i < NUM_CLOCK_SCHEDULER_EVENTS; i++) {
-        if (clock_scheduler_events[i].thread_id == -1) {
-            clock_scheduler_events[i].ready = true;
-            clock_scheduler_events[i].thread_id = thread_id;
-            clock_scheduler_events[i].sleep_time = seconds;
-            clock_scheduler_events[i].sleep_clock_time = clock_time + seconds;
-            clock_scheduler_events[i].type = CLOCK_SCHEDULER_EVENT_SLEEP;
-
-            pthread_mutex_unlock(&clock_scheduler_events_lock);
-            return true;
-        }
+        pthread_mutex_unlock(&clock_scheduler_events_lock);
+        return true;
     }
 
     pthread_mutex_unlock(&clock_scheduler_events_lock);
@@ -210,17 +214,17 @@ void clock_scheduler_clear_all() {
 }
 
 void clock_scheduler_reschedule_sync_events() {
-    clock_scheduler_event_t *scheduler_event;
+    clock_scheduler_event_t *event;
 
     pthread_mutex_lock(&clock_scheduler_events_lock);
 
     double clock_beat = clock_get_beats();
 
     for (int i = 0; i < NUM_CLOCK_SCHEDULER_EVENTS; i++) {
-        scheduler_event = &clock_scheduler_events[i];
+        event = &clock_scheduler_events[i];
 
-        if (scheduler_event->ready && scheduler_event->type == CLOCK_SCHEDULER_EVENT_SYNC) {
-            scheduler_event->sync_clock_beat = clock_scheduler_next_clock_beat(clock_beat, scheduler_event->sync_beat, scheduler_event->sync_beat_offset);
+        if (event->ready && event->type == CLOCK_SCHEDULER_EVENT_SYNC) {
+            event->sync_clock_beat = clock_scheduler_next_clock_beat(clock_beat, event->sync_beat, event->sync_beat_offset);
         }
     }
 
@@ -228,15 +232,15 @@ void clock_scheduler_reschedule_sync_events() {
 }
 
 void clock_scheduler_reset_sync_events() {
-    clock_scheduler_event_t *scheduler_event;
+    clock_scheduler_event_t *event;
 
     pthread_mutex_lock(&clock_scheduler_events_lock);
 
     for (int i = 0; i < NUM_CLOCK_SCHEDULER_EVENTS; i++) {
-        scheduler_event = &clock_scheduler_events[i];
+        event = &clock_scheduler_events[i];
 
-        if (scheduler_event->ready && scheduler_event->type == CLOCK_SCHEDULER_EVENT_SYNC) {
-            scheduler_event->sync_clock_beat = 0;
+        if (event->ready && event->type == CLOCK_SCHEDULER_EVENT_SYNC) {
+            event->sync_clock_beat = 0;
         }
     }
 


### PR DESCRIPTION
this fixes broken syncs in coroutines, where clock.sleep is mixed with clock.sync as follows:

```
clock.run(function()
  clock.sync(1)
  clock.sleep(5)
  clock.sync(1) -- broken, the coroutine will be resumed immediately
end)
```