### PR TITLE
util.wrap and util.wrap_max: avoid min > max freezes

### DIFF
--- a/lua/lib/util.lua
+++ b/lua/lib/util.lua
@@ -252,15 +252,19 @@ end
 -- @tparam number max
 -- @treturn number cycled value
 function util.wrap(n, min, max)
-  local y = n
-  local d = max - min + 1
-  while y > max do
-    y = y - d
+  if max >= min then
+    local y = n
+    local d = max - min + 1
+    while y > max do
+      y = y - d
+    end
+    while y < min do
+      y = y + d
+    end
+    return y
+  else
+    error("max needs to be greater than min")
   end
-  while y < min do
-    y = y + d
-  end
-  return y
 end
 
 --- wrap a number to a positive min/max range but clamp the min
@@ -269,15 +273,19 @@ end
 -- @tparam number max
 -- @treturn number cycled value
 function util.wrap_max(n, min, max)
-  local y = n
-  local d = max - min + 1
-  while y > max do
-    y = y - d
+  if max >= min then
+    local y = n
+    local d = max - min + 1
+    while y > max do
+      y = y - d
+    end
+    if y < min then
+      y = min
+    end
+    return y
+  else
+    error("max needs to be greater than min")
   end
-  if y < min then
-    y = min
-  end
-  return y
 end
 
 return util

--- a/lua/lib/util.lua
+++ b/lua/lib/util.lua
@@ -252,10 +252,10 @@ end
 -- @tparam number max
 -- @treturn number cycled value
 function util.wrap(n, min, max)
-  local given_vals = {min,max}
   if max < min then
-    min = given_vals[2]
-    max = given_vals[1]
+    local temp = min
+    min = max
+    max = temp
   end
   local y = n
   local d = max - min + 1
@@ -274,10 +274,10 @@ end
 -- @tparam number max
 -- @treturn number cycled value
 function util.wrap_max(n, min, max)
-  local given_vals = {min,max}
   if max < min then
-    min = given_vals[2]
-    max = given_vals[1]
+    local temp = min
+    min = max
+    max = temp
   end
   local y = n
   local d = max - min + 1

--- a/lua/lib/util.lua
+++ b/lua/lib/util.lua
@@ -252,19 +252,20 @@ end
 -- @tparam number max
 -- @treturn number cycled value
 function util.wrap(n, min, max)
-  if max >= min then
-    local y = n
-    local d = max - min + 1
-    while y > max do
-      y = y - d
-    end
-    while y < min do
-      y = y + d
-    end
-    return y
-  else
-    error("max needs to be greater than min")
+  local given_vals = {min,max}
+  if max < min then
+    min = given_vals[2]
+    max = given_vals[1]
   end
+  local y = n
+  local d = max - min + 1
+  while y > max do
+    y = y - d
+  end
+  while y < min do
+    y = y + d
+  end
+  return y
 end
 
 --- wrap a number to a positive min/max range but clamp the min
@@ -273,19 +274,20 @@ end
 -- @tparam number max
 -- @treturn number cycled value
 function util.wrap_max(n, min, max)
-  if max >= min then
-    local y = n
-    local d = max - min + 1
-    while y > max do
-      y = y - d
-    end
-    if y < min then
-      y = min
-    end
-    return y
-  else
-    error("max needs to be greater than min")
+  local given_vals = {min,max}
+  if max < min then
+    min = given_vals[2]
+    max = given_vals[1]
   end
+  local y = n
+  local d = max - min + 1
+  while y > max do
+    y = y - d
+  end
+  if y < min then
+    y = min
+  end
+  return y
 end
 
 return util


### PR DESCRIPTION
currently, if a script passes a smaller max than min to `util.wrap` or `util.wrap_max`, then norns will freeze. this PR adds an error print to maiden when the max is less than the min and avoids hangs