### PR TITLE
Use tab.count to get count of table w/ string keys

### DIFF
--- a/lua/core/crow.lua
+++ b/lua/core/crow.lua
@@ -108,7 +108,7 @@ end
 
 -- event handling
 function norns.crow.register_event(fn)
-  local n = #norns.crow.events + 1
+  local n = tab.count(norns.crow.events) + 1
   local c = ""
   if     n <= 26 then c = string.char(n + 64) -- uppercase alphas
   elseif n <= 52 then c = string.char(n + 70) -- lowercase alphas


### PR DESCRIPTION
Fix for https://github.com/monome/norns/issues/1402

`norns.crow.events` is a table of string keys, the `#` operator only works on tables of integer keys.