### PR TITLE
Softcut NRT Enhancement: add preserve and mix to `read_buffer`

### DIFF
--- a/crone/src/BufDiskWorker.cpp
+++ b/crone/src/BufDiskWorker.cpp
@@ -502,7 +502,7 @@ noexcept {
             goto cleanup;
         }
         file.readf(ioBuf, ioBufFrames);
-        for (int fr = 0; fr = ioBufFrames; ++fr) {
+        for (int fr = 0; fr < ioBufFrames; ++fr) {
             buf.data[frDst] = buf.data[frDst] * preserve + ioBuf[fr * numSrcChan + chanSrc] * mix;
             frDst++;
         }

--- a/crone/src/BufDiskWorker.h
+++ b/crone/src/BufDiskWorker.h
@@ -33,6 +33,7 @@ namespace crone {
         enum class JobType {
             Clear, ClearWithFade, Copy,
             ReadMono, ReadStereo,
+            MixMono, MixStereo,
             WriteMono, WriteStereo,
             Render,
         };
@@ -46,6 +47,7 @@ namespace crone {
             int chan;
             float fadeTime;
             float preserve;
+            float mix;
             bool reverse;
             int samples;
             RenderCallback renderCallback;
@@ -106,6 +108,16 @@ namespace crone {
         requestReadStereo(size_t idx0, size_t idx1, std::string path, float startSrc = 0, float startDst = 0,
                           float dur = -1);
 
+        // read mono soundfile into mono buffer with mix parameter
+        static void
+        requestMixMono(size_t idx, std::string path, float srcStart = 0, float dstStart = 0, float dur = -1,
+                       float preserve = 0, float mix = 1, int chanSrc = 0);
+
+        // read and de-interleave stereo soundfile to 2x mono buffers with mix parameter
+        static void
+        requestMixStereo(size_t idx0, size_t idx1, std::string path, float srcStart = 0, float dstStart = 0, float dur = -1,
+                         float preserve = 0, float mix = 1);
+
         // write mono buf to mono soundfile
         static void requestWriteMono(size_t idx, std::string path, float start = 0, float dur = -1);
 
@@ -130,6 +142,14 @@ namespace crone {
 
         static void readBufferStereo(const std::string &path, BufDesc &buf0, BufDesc &buf1,
                                      float startSrc = 0, float startDst = 0, float dur = -1) noexcept;
+
+        static void mixBufferMono(const std::string &path, BufDesc &buf,
+                                  float srcStart = 0, float dstStart = 0, float dur = -1, 
+                                  float preserve = 0, float mix = 1, int chanSrc = 0) noexcept;
+
+        static void mixBufferStereo(const std::string &path, BufDesc &buf0, BufDesc &buf1,
+                                    float srcStart = 0, float dstStart = 0, float dur = -1,
+                                    float preserve = 0, float mix = 1) noexcept;
 
         static void writeBufferMono(const std::string &path, BufDesc &buf,
                                     float start = 0, float dur = -1) noexcept;

--- a/crone/src/BufDiskWorker.h
+++ b/crone/src/BufDiskWorker.h
@@ -33,7 +33,6 @@ namespace crone {
         enum class JobType {
             Clear, ClearWithFade, Copy,
             ReadMono, ReadStereo,
-            MixMono, MixStereo,
             WriteMono, WriteStereo,
             Render,
         };
@@ -101,22 +100,12 @@ namespace crone {
         // read mono soundfile to mono buffer
         static void
         requestReadMono(size_t idx, std::string path, float startSrc = 0, float startDst = 0, float dur = -1,
-                        int chanSrc = 0);
+                        int chanSrc = 0, float preserve = 0, float mix = 1);
 
         // read and de-interleave stereo soundfile to 2x mono buffers
         static void
         requestReadStereo(size_t idx0, size_t idx1, std::string path, float startSrc = 0, float startDst = 0,
-                          float dur = -1);
-
-        // read mono soundfile into mono buffer with mix parameter
-        static void
-        requestMixMono(size_t idx, std::string path, float srcStart = 0, float dstStart = 0, float dur = -1,
-                       float preserve = 0, float mix = 1, int chanSrc = 0);
-
-        // read and de-interleave stereo soundfile to 2x mono buffers with mix parameter
-        static void
-        requestMixStereo(size_t idx0, size_t idx1, std::string path, float srcStart = 0, float dstStart = 0, float dur = -1,
-                         float preserve = 0, float mix = 1);
+                          float dur = -1, float preserve = 0, float mix = 1);
 
         // write mono buf to mono soundfile
         static void requestWriteMono(size_t idx, std::string path, float start = 0, float dur = -1);
@@ -138,18 +127,12 @@ namespace crone {
                                float fadeTime = 0, float preserve = 0, bool reverse = false);
 
         static void readBufferMono(const std::string &path, BufDesc &buf,
-                                   float startSrc = 0, float startDst = 0, float dur = -1, int chanSrc = 0) noexcept;
+                                   float startSrc = 0, float startDst = 0, float dur = -1, int chanSrc = 0,
+                                   float preserve = 0, float mix = 1) noexcept;
 
         static void readBufferStereo(const std::string &path, BufDesc &buf0, BufDesc &buf1,
-                                     float startSrc = 0, float startDst = 0, float dur = -1) noexcept;
-
-        static void mixBufferMono(const std::string &path, BufDesc &buf,
-                                  float srcStart = 0, float dstStart = 0, float dur = -1, 
-                                  float preserve = 0, float mix = 1, int chanSrc = 0) noexcept;
-
-        static void mixBufferStereo(const std::string &path, BufDesc &buf0, BufDesc &buf1,
-                                    float srcStart = 0, float dstStart = 0, float dur = -1,
-                                    float preserve = 0, float mix = 1) noexcept;
+                                     float startSrc = 0, float startDst = 0, float dur = -1,
+                                     float preserve = 0, float mix = 1) noexcept;
 
         static void writeBufferMono(const std::string &path, BufDesc &buf,
                                     float start = 0, float dur = -1) noexcept;

--- a/crone/src/OscInterface.cpp
+++ b/crone/src/OscInterface.cpp
@@ -596,7 +596,7 @@ void OscInterface::addServerMethods() {
         float startDst = 0.f;
         float dur = -1.f;
         float preserve = 0.f;
-        float mix = 1.f
+        float mix = 1.f;
         if (argc < 1) {
             std::cerr << "/softcut/buffer/read_stereo requires at least one argument (file path)" << std::endl;
             return;

--- a/crone/src/OscInterface.cpp
+++ b/crone/src/OscInterface.cpp
@@ -552,12 +552,14 @@ void OscInterface::addServerMethods() {
 
 
     // FIXME: hrm, our system doesn't allow variable argument count. maybe need to make multiple methods
-    addServerMethod("/softcut/buffer/read_mono", "sfffii", [](lo_arg **argv, int argc) {
+    addServerMethod("/softcut/buffer/read_mono", "sfffiiff", [](lo_arg **argv, int argc) {
         float startSrc = 0.f;
         float startDst = 0.f;
         float dur = -1.f;
         int chanSrc = 0;
         int chanDst = 0;
+        float preserve = 0.f;
+        float mix = 1.f;
         if (argc < 1) {
             std::cerr << "/softcut/buffer/read_mono requires at least one argument (file path)" << std::endl;
             return;
@@ -577,16 +579,24 @@ void OscInterface::addServerMethods() {
         if (argc > 5) {
             chanDst = argv[5]->i;
         }
+        if (argc > 6) {
+            preserve = argv[6]->f;
+        }
+        if (argc > 7) {
+            mix = argv[7]->f;
+        }
         const char *str = &argv[0]->s;
-        softCutClient->readBufferMono(str, startSrc, startDst, dur, chanSrc, chanDst);
+        softCutClient->readBufferMono(str, startSrc, startDst, dur, chanSrc, chanDst, preserve, mix);
 
     });
 
     // FIXME: hrm, our system doesn't allow variable argument count. maybe need to make multiple methods
-    addServerMethod("/softcut/buffer/read_stereo", "sfff", [](lo_arg **argv, int argc) {
+    addServerMethod("/softcut/buffer/read_stereo", "sfffff", [](lo_arg **argv, int argc) {
         float startSrc = 0.f;
         float startDst = 0.f;
         float dur = -1.f;
+        float preserve = 0.f;
+        float mix = 1.f
         if (argc < 1) {
             std::cerr << "/softcut/buffer/read_stereo requires at least one argument (file path)" << std::endl;
             return;
@@ -600,76 +610,16 @@ void OscInterface::addServerMethods() {
         if (argc > 3) {
             dur = argv[3]->f;
         }
+        if (argc > 4) {
+            preserve = argv[4]->f;
+        }
+        if (argc > 5) {
+            mix = argv[5]->f;
+        }
         const char *str = &argv[0]->s;
-        softCutClient->readBufferStereo(str, startSrc, startDst, dur);
+        softCutClient->readBufferStereo(str, startSrc, startDst, dur, preserve, mix);
     });
     
-    addServerMethod("/softcut/buffer/mix_mono", "sfffffii", [](lo_arg **argv, int argc) {
-            float startSrc = 0.f;
-            float startDst = 0.f;
-            float dur = -1.f;
-            float preserve = 0.f;
-            float mix = 1.f;
-            int chanSrc = 0;
-            int chanDst = 0;
-            if (argc < 1) {
-                std::cerr << "softcut/buffer/mix_mono requires at least one argument (file path)" << std::endl;
-                return;
-            }
-            if (argc > 1) {
-                startSrc = argv[1]->f;
-            }
-            if (argc > 2) {
-                startDst = argv[2]->f;
-            }
-            if (argc > 3) {
-                dur = argv[3]->f;
-            }
-            if (argc > 4) {
-                preserve = argv[4]->f;
-            }
-            if (argc > 5) {
-                mix = argv[5]->f;
-            }
-            if (argc > 6) {
-                chanSrc = argv[6]->i;
-            }
-            if (argc > 7) {
-                chanDst = argv[7]->i;
-            }
-            const char *str = &argv[0]->s;
-            softCutClient->mixBufferMono(str, startSrc, startDst, dur, preserve, mix, chanSrc, chanDst);
-    });
-    
-    addServerMethod("/softcut/buffer/mix_stereo", "sfffff", [](lo_arg **argv, int argc) {
-            float startSrc = 0.f;
-            float startDst = 0.f;
-            float dur = -1.f;
-            float preserve = 0.f;
-            float mix = 1.f;
-            if (argc < 1) {
-                std::cerr << "softcut/buffer/mix_stereo requires at least one argument (file path)" << std::endl;
-                return;
-            }
-            if (argc > 1) {
-                startSrc = argv[1]->f;
-            }
-            if (argc > 2) {
-                startDst = argv[2]->f;
-            }
-            if (argc > 3) {
-                dur = argv[3]->f;
-            }
-            if (argc > 4) {
-                preserve = argv[4]->f;
-            }
-            if (argc > 5) {
-                mix = argv[5]->f;
-            }
-            const char *str = &argv[0]->s;
-            softCutClient->mixBufferStereo(str, startSrc, startDst, dur, preserve, mix);
-    });
-
 
     // FIXME: hrm, our system doesn't allow variable argument count. maybe need to make multiple methods
     addServerMethod("/softcut/buffer/write_mono", "sffi", [](lo_arg **argv, int argc) {

--- a/crone/src/OscInterface.cpp
+++ b/crone/src/OscInterface.cpp
@@ -603,6 +603,72 @@ void OscInterface::addServerMethods() {
         const char *str = &argv[0]->s;
         softCutClient->readBufferStereo(str, startSrc, startDst, dur);
     });
+    
+    addServerMethod("/softcut/buffer/mix_mono", "sfffffii", [](lo_arg **argv, int argc) {
+            float startSrc = 0.f;
+            float startDst = 0.f;
+            float dur = -1.f;
+            float preserve = 0.f;
+            float mix = 1.f;
+            int chanSrc = 0;
+            int chanDst = 0;
+            if (argc < 1) {
+                std::cerr << "softcut/buffer/mix_mono requires at least one argument (file path)" << std::endl;
+                return;
+            }
+            if (argc > 1) {
+                startSrc = argv[1]->f;
+            }
+            if (argc > 2) {
+                startDst = argv[2]->f;
+            }
+            if (argc > 3) {
+                dur = argv[3]->f;
+            }
+            if (argc > 4) {
+                preserve = argv[4]->f;
+            }
+            if (argc > 5) {
+                mix = argv[5]->f;
+            }
+            if (argc > 6) {
+                chanSrc = argv[6]->i;
+            }
+            if (argc > 7) {
+                chanDst = argv[7]->i;
+            }
+            const char *str = &argv[0]->s;
+            softCutClient->mixBufferMono(str, startSrc, startDst, dur, preserve, mix, chanSrc, chanDst);
+    });
+    
+    addServerMethod("/softcut/buffer/mix_stereo", "sfffff", [](lo_arg **argv, int argc) {
+            float startSrc = 0.f;
+            float startDst = 0.f;
+            float dur = -1.f;
+            float preserve = 0.f;
+            float mix = 1.f;
+            if (argc < 1) {
+                std::cerr << "softcut/buffer/mix_stereo requires at least one argument (file path)" << std::endl;
+                return;
+            }
+            if (argc > 1) {
+                startSrc = argv[1]->f;
+            }
+            if (argc > 2) {
+                startDst = argv[2]->f;
+            }
+            if (argc > 3) {
+                dur = argv[3]->f;
+            }
+            if (argc > 4) {
+                preserve = argv[4]->f;
+            }
+            if (argc > 5) {
+                mix = argv[5]->f;
+            }
+            const char *str = &argv[0]->s;
+            softCutClient->mixBufferStereo(str, startSrc, startDst, dur, preserve, mix);
+    });
 
 
     // FIXME: hrm, our system doesn't allow variable argument count. maybe need to make multiple methods

--- a/crone/src/SoftcutClient.h
+++ b/crone/src/SoftcutClient.h
@@ -67,23 +67,13 @@ namespace crone {
         //-- time parameters are in seconds
         //-- negative 'dur' parameter reads/clears/writes as much as possible.
         void readBufferMono(const std::string &path, float startTimeSrc = 0.f, float startTimeDst = 0.f,
-                            float dur = -1.f, int chanSrc = 0, int chanDst = 0) {
-            BufDiskWorker::requestReadMono(bufIdx[chanDst], path, startTimeSrc, startTimeDst, dur, chanSrc);
+                            float dur = -1.f, int chanSrc = 0, int chanDst = 0, float preserve = 0.f, float mix = 1.f) {
+            BufDiskWorker::requestReadMono(bufIdx[chanDst], path, startTimeSrc, startTimeDst, dur, chanSrc, preserve, mix);
         }
 
         void readBufferStereo(const std::string &path, float startTimeSrc = 0.f, float startTimeDst = 0.f,
-                              float dur = -1.f) {
-            BufDiskWorker::requestReadStereo(bufIdx[0], bufIdx[1], path, startTimeSrc, startTimeDst, dur);
-        }
-
-        void mixBufferMono(const std::string &path, float startTimeSrc = 0.f, float startTimeDst = 0.f,
-                           float dur = -1.f, float preserve = 0.f, float mix = 1.f, int chanSrc = 0, int chanDst = 0) {
-            BufDiskWorker::requestMixMono(bufIdx[chanDst], path, startTimeSrc, startTimeDst, dur, preserve, mix, chanSrc);
-        }
-
-        void mixBufferStereo(const std::string &path, float startTimeSrc = 0.f, float startTimeDst = 0.f,
-                             float dur = -1.f, float preserve = 0.f, float mix = 1.f) {
-            BufDiskWorker::requestMixStereo(bufIdx[0], bufIdx[1], path, startTimeSrc, startTimeDst, dur, preserve, mix);
+                              float dur = -1.f, float preserve = 0.f, float mix = 1.f) {
+            BufDiskWorker::requestReadStereo(bufIdx[0], bufIdx[1], path, startTimeSrc, startTimeDst, dur, preserve, mix);
         }
 
         void writeBufferMono(const std::string &path, float start, float dur, int chan) {

--- a/crone/src/SoftcutClient.h
+++ b/crone/src/SoftcutClient.h
@@ -76,6 +76,16 @@ namespace crone {
             BufDiskWorker::requestReadStereo(bufIdx[0], bufIdx[1], path, startTimeSrc, startTimeDst, dur);
         }
 
+        void mixBufferMono(const std::string &path, float startTimeSrc = 0.f, float startTimeDst = 0.f,
+                           float dur = -1.f, float preserve = 0.f, float mix = 1.f, int chanSrc = 0, int chanDst = 0) {
+            BufDiskWorker::requestMixMono(bufIdx[chanDst], path, startTimeSrc, startTimeDst, dur, preserve, mix, chanSrc);
+        }
+
+        void mixBufferStereo(const std::string &path, float startTimeSrc = 0.f, float startTimeDst = 0.f,
+                             float dur = -1.f, float preserve = 0.f, float mix = 1.f) {
+            BufDiskWorker::requestMixStereo(bufIdx[0], bufIdx[1], path, startTimeSrc, startTimeDst, dur, preserve, mix);
+        }
+
         void writeBufferMono(const std::string &path, float start, float dur, int chan) {
             BufDiskWorker::requestWriteMono(bufIdx[chan], path, start, dur);
 

--- a/lua/core/softcut.lua
+++ b/lua/core/softcut.lua
@@ -333,8 +333,10 @@ end
 -- @tparam number dur : duration in seconds. if -1, read as much as possible.
 -- @tparam int ch_src : soundfie channel to read
 -- @tparam int ch_dst : buffer channel to write
-SC.buffer_read_mono = function(file, start_src, start_dst, dur, ch_src, ch_dst)
-  _norns.cut_buffer_read_mono(file, start_src, start_dst, dur, ch_src, ch_dst)
+-- @tparam number preserve : level of existing material
+-- @tparam number mix : level of new material
+SC.buffer_read_mono = function(file, start_src, start_dst, dur, ch_src, ch_dst, preserve, mix)
+  _norns.cut_buffer_read_mono(file, start_src, start_dst, dur, ch_src, ch_dst, preserve or 0, mix or 1)
 end
 
 --- read stereo soundfile to an arbitrary region in both buffers
@@ -342,32 +344,10 @@ end
 -- @tparam number start_src : start point in source, in seconds
 -- @tparam number start_dst : start point in destination, in seconds
 -- @tparam number dur : duration in seconds. if -1, read as much as possible
-SC.buffer_read_stereo = function(file, start_src, start_dst, dur)
-  _norns.cut_buffer_read_stereo(file, start_src, start_dst, dur)
-end
-
--- mix mono soundfile with arbitrary region of single buffer
--- @tparam string file : input file path
--- @tparam number start_src : start point in source, in seconds
--- @tparam number start_dst : start point in destination, in seconds
--- @tparam number dur : duration in seconds. if -1, read as much as possible.
 -- @tparam number preserve : level of existing material
 -- @tparam number mix : level of new material
--- @tparam int ch_src : soundfile channel to read
--- @tparam int ch_dst : buffer channel to write
-SC.buffer_mix_mono = function(file, start_src, start_dst, dur, preserve, mix, ch_src, ch_dst)
-    _norns.cut_buffer_mix_mono(file, start_src, start_dst, dur, preserve or 0, mix or 1, ch_src or 0, ch_dst or 0)
-end
-
--- mix stereo soundfile with arbitrary region in both buffers
--- @tparam string file : input file path
--- @tparam number start_src : start point in source, in seconds
--- @tparam number start_dst : start point in destination, in seconds
--- @tparam number dur : duration in seconds. if -1, read as much as possible.
--- @tparam number preserve : level of existing material
--- @tparam number mix : level of new material
-SC.buffer_mix_stereo = function(file, start_src, start_dst, dur, preserve, mix)
-    _norns.cut_buffer_mix_stereo(file, start_src, start_dst, dur, preserve or 0, mix or 1)
+SC.buffer_read_stereo = function(file, start_src, start_dst, dur, preserve, mix)
+  _norns.cut_buffer_read_stereo(file, start_src, start_dst, dur, preserve or 0, mix or 1)
 end
 
 --- write an arbitrary buffer region to soundfile (mono)

--- a/lua/core/softcut.lua
+++ b/lua/core/softcut.lua
@@ -312,7 +312,7 @@ end
 -- @tparam number preserve : level of existing material
 -- @tparam int reverse : nonzero to reverse while copying. when reversing, overlap between source and destination regions is not handled.
 SC.buffer_copy_mono = function(src_ch, dst_ch, start_src, start_dst, dur, fade_time, preserve, reverse)
-  _norns.cut_buffer_copy_mono(src_ch, dst_ch, start_src, start_dst, dur, fade_time or 0, preserve or 0, reverse or 0)
+  _norns.cut_buffer_copy_mono(src_ch, dst_ch, start_src, start_dst, dur or -1, fade_time or 0, preserve or 0, reverse or 0)
 end
 
 --- copy region of both buffers to another point
@@ -323,7 +323,7 @@ end
 -- @tparam number preserve : level of existing material
 -- @tparam int reverse : nonzero to reverse while copying.
 SC.buffer_copy_stereo = function(start_src, start_dst, dur, fade_time, preserve, reverse)
-  _norns.cut_buffer_copy_stereo(start_src, start_dst, dur, fade_time or 0, preserve or 0, reverse or 0)
+  _norns.cut_buffer_copy_stereo(start_src, start_dst, dur or -1, fade_time or 0, preserve or 0, reverse or 0)
 end
 
 --- read mono soundfile to arbitrary region of single buffer
@@ -336,7 +336,7 @@ end
 -- @tparam number preserve : level of existing material
 -- @tparam number mix : level of new material
 SC.buffer_read_mono = function(file, start_src, start_dst, dur, ch_src, ch_dst, preserve, mix)
-  _norns.cut_buffer_read_mono(file, start_src, start_dst, dur, ch_src, ch_dst, preserve or 0, mix or 1)
+  _norns.cut_buffer_read_mono(file, start_src or 0, start_dst or 0, dur or -1, ch_src or 1, ch_dst or 1, preserve or 0, mix or 1)
 end
 
 --- read stereo soundfile to an arbitrary region in both buffers
@@ -347,7 +347,7 @@ end
 -- @tparam number preserve : level of existing material
 -- @tparam number mix : level of new material
 SC.buffer_read_stereo = function(file, start_src, start_dst, dur, preserve, mix)
-  _norns.cut_buffer_read_stereo(file, start_src, start_dst, dur, preserve or 0, mix or 1)
+  _norns.cut_buffer_read_stereo(file, start_src or 0, start_dst or 0, dur or -1, preserve or 0, mix or 1)
 end
 
 --- write an arbitrary buffer region to soundfile (mono)
@@ -356,7 +356,7 @@ end
 -- @tparam number dur : duration in seconds. if -1, read as much as possible
 -- @tparam int ch : buffer channel index (1-based)
 SC.buffer_write_mono = function(file, start, dur, ch)
-  _norns.cut_buffer_write_mono(file, start, dur, ch)
+  _norns.cut_buffer_write_mono(file, start or 0, dur or -1, ch or 1)
 end
 
 --- write an arbitrary region from both buffers to stereo soundfile
@@ -364,7 +364,7 @@ end
 -- @tparam number start : start point in seconds
 -- @tparam number dur : duration in seconds. if -1, read as much as possible
 SC.buffer_write_stereo = function(file, start, dur)
-  _norns.cut_buffer_write_stereo(file, start, dur)
+  _norns.cut_buffer_write_stereo(file, start or 0, dur or -1)
 end
 
 --- set function for phase poll

--- a/lua/core/softcut.lua
+++ b/lua/core/softcut.lua
@@ -346,6 +346,30 @@ SC.buffer_read_stereo = function(file, start_src, start_dst, dur)
   _norns.cut_buffer_read_stereo(file, start_src, start_dst, dur)
 end
 
+-- mix mono soundfile with arbitrary region of single buffer
+-- @tparam string file : input file path
+-- @tparam number start_src : start point in source, in seconds
+-- @tparam number start_dst : start point in destination, in seconds
+-- @tparam number dur : duration in seconds. if -1, read as much as possible.
+-- @tparam number preserve : level of existing material
+-- @tparam number mix : level of new material
+-- @tparam int ch_src : soundfile channel to read
+-- @tparam int ch_dst : buffer channel to write
+SC.buffer_mix_mono = function(file, start_src, start_dst, dur, preserve, mix, ch_src, ch_dst)
+    _norns.cut_buffer_mix_mono(file, start_src, start_dst, dur, preserve or 0, mix or 1, ch_src or 0, ch_dst or 0)
+end
+
+-- mix stereo soundfile with arbitrary region in both buffers
+-- @tparam string file : input file path
+-- @tparam number start_src : start point in source, in seconds
+-- @tparam number start_dst : start point in destination, in seconds
+-- @tparam number dur : duration in seconds. if -1, read as much as possible.
+-- @tparam number preserve : level of existing material
+-- @tparam number mix : level of new material
+SC.buffer_mix_stereo = function(file, start_src, start_dst, dur, preserve, mix)
+    _norns.cut_buffer_mix_stereo(file, start_src, start_dst, dur, preserve or 0, mix or 1)
+end
+
 --- write an arbitrary buffer region to soundfile (mono)
 -- @tparam string file : output file path
 -- @tparam number start : start point in seconds

--- a/matron/src/oracle.c
+++ b/matron/src/oracle.c
@@ -585,20 +585,12 @@ void o_cut_buffer_copy_stereo(float src_start, float dst_start, float dur,
             src_start, dst_start, dur, fade_time, preserve, reverse);
 }
 
-void o_cut_buffer_read_mono(char *file, float start_src, float start_dst, float dur, int ch_src, int ch_dst) {
-    lo_send(crone_addr, "/softcut/buffer/read_mono", "sfffii", file, start_src, start_dst, dur, ch_src, ch_dst);
+void o_cut_buffer_read_mono(char *file, float start_src, float start_dst, float dur, int ch_src, int ch_dst, float preserve, float mix) {
+    lo_send(crone_addr, "/softcut/buffer/read_mono", "sfffiiff", file, start_src, start_dst, dur, ch_src, ch_dst, preserve, mix);
 }
 
-void o_cut_buffer_read_stereo(char *file, float start_src, float start_dst, float dur) {
-    lo_send(crone_addr, "/softcut/buffer/read_stereo", "sfff", file, start_src, start_dst, dur);
-}
-
-void o_cut_buffer_mix_mono(char *file, float start_src, float start_dst, float dur, float preserve, float mix, int ch_src, int ch_dst) {
-    lo_send(crone_addr, "/softcut/buffer/mix_mono", "sfffffii", file, start_src, start_dst, dur, preserve, mix, ch_src, ch_dst);
-}
-
-void o_cut_buffer_mix_stereo(char *file, float start_src, float start_dst, float dur, float preserve, float mix) {
-    lo_send(crone_addr, "/softcut/buffer/mix_stereo", "sfffff", file, start_src, start_dst, dur, preserve, mix);
+void o_cut_buffer_read_stereo(char *file, float start_src, float start_dst, float dur, float preserve, float mix) {
+    lo_send(crone_addr, "/softcut/buffer/read_stereo", "sfffff", file, start_src, start_dst, dur, preserve, mix);
 }
 
 void o_cut_buffer_write_mono(char *file, float start, float dur, int ch) {

--- a/matron/src/oracle.c
+++ b/matron/src/oracle.c
@@ -593,6 +593,14 @@ void o_cut_buffer_read_stereo(char *file, float start_src, float start_dst, floa
     lo_send(crone_addr, "/softcut/buffer/read_stereo", "sfff", file, start_src, start_dst, dur);
 }
 
+void o_cut_buffer_mix_mono(char *file, float start_src, float start_dst, float dur, float preserve, float mix, int ch_src, int ch_dst) {
+    lo_send(crone_addr, "/softcut/buffer/mix_mono", "sfffffii", file, start_src, start_dst, dur, preserve, mix, ch_src, ch_dst);
+}
+
+void o_cut_buffer_mix_stereo(char *file, float start_src, float start_dst, float dur, float preserve, float mix) {
+    lo_send(crone_addr, "/softcut/buffer/mix_stereo", "sfffff", file, start_src, start_dst, dur, preserve, mix);
+}
+
 void o_cut_buffer_write_mono(char *file, float start, float dur, int ch) {
     lo_send(crone_addr, "/softcut/buffer/write_mono", "sffi", file, start, dur, ch);
 }

--- a/matron/src/oracle.h
+++ b/matron/src/oracle.h
@@ -141,6 +141,8 @@ extern void o_cut_buffer_copy_mono(int src_ch, int dst_ch, float src_start, floa
 extern void o_cut_buffer_copy_stereo(float src_start, float dst_start, float dur, float fade_time, float preserve, int reverse);
 extern void o_cut_buffer_read_mono(char *file, float start_src, float start_dst, float dur, int ch_src, int ch_dst);
 extern void o_cut_buffer_read_stereo(char *file, float start_src, float start_dst, float dur);
+extern void o_cut_buffer_mix_mono(char *file, float start_src, float start_dst, float dur, float preserve, float mix, int ch_src, int ch_dst);
+extern void o_cut_buffer_mix_stereo(char *file, float start_src, float start_dst, float dur, float preserve, float mix);
 extern void o_cut_buffer_write_mono(char *file, float start, float dur, int ch);
 extern void o_cut_buffer_write_stereo(char *file, float start, float dur);
 extern void o_cut_buffer_render(int ch, float start, float dur, int samples);

--- a/matron/src/oracle.h
+++ b/matron/src/oracle.h
@@ -139,10 +139,8 @@ extern void o_cut_buffer_clear_region(float start, float dur, float fade_time, f
 extern void o_cut_buffer_clear_region_channel(int ch, float start, float dur, float fade_time, float preserve);
 extern void o_cut_buffer_copy_mono(int src_ch, int dst_ch, float src_start, float dst_start, float dur, float fade_time, float preserve, int reverse);
 extern void o_cut_buffer_copy_stereo(float src_start, float dst_start, float dur, float fade_time, float preserve, int reverse);
-extern void o_cut_buffer_read_mono(char *file, float start_src, float start_dst, float dur, int ch_src, int ch_dst);
-extern void o_cut_buffer_read_stereo(char *file, float start_src, float start_dst, float dur);
-extern void o_cut_buffer_mix_mono(char *file, float start_src, float start_dst, float dur, float preserve, float mix, int ch_src, int ch_dst);
-extern void o_cut_buffer_mix_stereo(char *file, float start_src, float start_dst, float dur, float preserve, float mix);
+extern void o_cut_buffer_read_mono(char *file, float start_src, float start_dst, float dur, int ch_src, int ch_dst, float preserve, float mix);
+extern void o_cut_buffer_read_stereo(char *file, float start_src, float start_dst, float dur, float preserve, float mix);
 extern void o_cut_buffer_write_mono(char *file, float start, float dur, int ch);
 extern void o_cut_buffer_write_stereo(char *file, float start, float dur);
 extern void o_cut_buffer_render(int ch, float start, float dur, int samples);

--- a/matron/src/weaver.c
+++ b/matron/src/weaver.c
@@ -191,6 +191,8 @@ static int _cut_buffer_copy_mono(lua_State *l);
 static int _cut_buffer_copy_stereo(lua_State *l);
 static int _cut_buffer_read_mono(lua_State *l);
 static int _cut_buffer_read_stereo(lua_State *l);
+static int _cut_buffer_mix_mono(lua_State *l);
+static int _cut_buffer_mix_stereo(lua_State *l);
 static int _cut_buffer_write_mono(lua_State *l);
 static int _cut_buffer_write_stereo(lua_State *l);
 static int _cut_buffer_render(lua_State *l);
@@ -333,6 +335,8 @@ void w_init(void) {
     lua_register_norns("cut_buffer_copy_stereo", &_cut_buffer_copy_stereo);
     lua_register_norns("cut_buffer_read_mono", &_cut_buffer_read_mono);
     lua_register_norns("cut_buffer_read_stereo", &_cut_buffer_read_stereo);
+    lua_register_norns("cut_buffer_mix_mono", &_cut_buffer_mix_mono);
+    lua_register_norns("_cut_buffer_mix_stereo", &_cut_buffer_mix_stereo);
     lua_register_norns("cut_buffer_write_mono", &_cut_buffer_write_mono);
     lua_register_norns("cut_buffer_write_stereo", &_cut_buffer_write_stereo);
     lua_register_norns("cut_buffer_render", &_cut_buffer_render);
@@ -2391,6 +2395,32 @@ int _cut_buffer_read_stereo(lua_State *l) {
     float start_dst = (float)luaL_checknumber(l, 3);
     float dur = (float)luaL_checknumber(l, 4);
     o_cut_buffer_read_stereo((char *)s, start_src, start_dst, dur);
+    return 0;
+}
+
+int _cut_buffer_mix_mono(lua_State *l) {
+    lua_check_num_args(8);
+    const char *s = luaL_checkstring(l, 1);
+    float start_src = (float)luaL_checknumber(l, 2);
+    float start_dst = (float)luaL_checknumber(l, 3);
+    float dur = (float)luaL_checknumber(l, 4);
+    float preserve = (float)luaL_checknumber(l, 5);
+    float mix = (float)luaL_checknumber(l, 6);
+    int ch_src = (int)luaL_checknumber(l, 7) - 1;
+    int ch_dst = (int)luaL_checknumber(l, 8) - 1;
+    o_cut_buffer_mix_mono((char *)s, start_src, start_dst, dur, preserve, mix, ch_src, ch_dst);
+    return 0;
+}
+
+int _cut_buffer_mix_stereo(lua_State *l) {
+    lua_check_num_args(6);
+    const char *s = luaL_checkstring(l, 1);
+    float start_src = (float)luaL_checknumber(l, 2);
+    float start_dst = (float)luaL_checknumber(l, 3);
+    float dur = (float)luaL_checknumber(l, 4);
+    float preserve = (float)luaL_checknumber(l, 5);
+    float mix = (float)luaL_checknumber(1, 6);
+    o_cut_buffer_mix_stereo((char *)s, start_src, start_dst, dur, preserve, mix);
     return 0;
 }
 

--- a/matron/src/weaver.c
+++ b/matron/src/weaver.c
@@ -191,8 +191,6 @@ static int _cut_buffer_copy_mono(lua_State *l);
 static int _cut_buffer_copy_stereo(lua_State *l);
 static int _cut_buffer_read_mono(lua_State *l);
 static int _cut_buffer_read_stereo(lua_State *l);
-static int _cut_buffer_mix_mono(lua_State *l);
-static int _cut_buffer_mix_stereo(lua_State *l);
 static int _cut_buffer_write_mono(lua_State *l);
 static int _cut_buffer_write_stereo(lua_State *l);
 static int _cut_buffer_render(lua_State *l);
@@ -335,8 +333,6 @@ void w_init(void) {
     lua_register_norns("cut_buffer_copy_stereo", &_cut_buffer_copy_stereo);
     lua_register_norns("cut_buffer_read_mono", &_cut_buffer_read_mono);
     lua_register_norns("cut_buffer_read_stereo", &_cut_buffer_read_stereo);
-    lua_register_norns("cut_buffer_mix_mono", &_cut_buffer_mix_mono);
-    lua_register_norns("_cut_buffer_mix_stereo", &_cut_buffer_mix_stereo);
     lua_register_norns("cut_buffer_write_mono", &_cut_buffer_write_mono);
     lua_register_norns("cut_buffer_write_stereo", &_cut_buffer_write_stereo);
     lua_register_norns("cut_buffer_render", &_cut_buffer_render);
@@ -2377,42 +2373,20 @@ int _cut_buffer_copy_stereo(lua_State *l) {
 }
 
 int _cut_buffer_read_mono(lua_State *l) {
-    lua_check_num_args(6);
+    lua_check_num_args(8);
     const char *s = luaL_checkstring(l, 1);
     float start_src = (float)luaL_checknumber(l, 2);
     float start_dst = (float)luaL_checknumber(l, 3);
     float dur = (float)luaL_checknumber(l, 4);
     int ch_src = (int)luaL_checkinteger(l, 5) - 1;
     int ch_dst = (int)luaL_checkinteger(l, 6) - 1;
-    o_cut_buffer_read_mono((char *)s, start_src, start_dst, dur, ch_src, ch_dst);
+    float preserve = (float)luaL_checknumber(l, 7);
+    float mix = (float)luaL_checknumber(l, 8);
+    o_cut_buffer_read_mono((char *)s, start_src, start_dst, dur, ch_src, ch_dst, preserve, mix);
     return 0;
 }
 
 int _cut_buffer_read_stereo(lua_State *l) {
-    lua_check_num_args(4);
-    const char *s = luaL_checkstring(l, 1);
-    float start_src = (float)luaL_checknumber(l, 2);
-    float start_dst = (float)luaL_checknumber(l, 3);
-    float dur = (float)luaL_checknumber(l, 4);
-    o_cut_buffer_read_stereo((char *)s, start_src, start_dst, dur);
-    return 0;
-}
-
-int _cut_buffer_mix_mono(lua_State *l) {
-    lua_check_num_args(8);
-    const char *s = luaL_checkstring(l, 1);
-    float start_src = (float)luaL_checknumber(l, 2);
-    float start_dst = (float)luaL_checknumber(l, 3);
-    float dur = (float)luaL_checknumber(l, 4);
-    float preserve = (float)luaL_checknumber(l, 5);
-    float mix = (float)luaL_checknumber(l, 6);
-    int ch_src = (int)luaL_checknumber(l, 7) - 1;
-    int ch_dst = (int)luaL_checknumber(l, 8) - 1;
-    o_cut_buffer_mix_mono((char *)s, start_src, start_dst, dur, preserve, mix, ch_src, ch_dst);
-    return 0;
-}
-
-int _cut_buffer_mix_stereo(lua_State *l) {
     lua_check_num_args(6);
     const char *s = luaL_checkstring(l, 1);
     float start_src = (float)luaL_checknumber(l, 2);
@@ -2420,7 +2394,7 @@ int _cut_buffer_mix_stereo(lua_State *l) {
     float dur = (float)luaL_checknumber(l, 4);
     float preserve = (float)luaL_checknumber(l, 5);
     float mix = (float)luaL_checknumber(l, 6);
-    o_cut_buffer_mix_stereo((char *)s, start_src, start_dst, dur, preserve, mix);
+    o_cut_buffer_read_stereo((char *)s, start_src, start_dst, dur, preserve, mix);
     return 0;
 }
 

--- a/matron/src/weaver.c
+++ b/matron/src/weaver.c
@@ -2419,7 +2419,7 @@ int _cut_buffer_mix_stereo(lua_State *l) {
     float start_dst = (float)luaL_checknumber(l, 3);
     float dur = (float)luaL_checknumber(l, 4);
     float preserve = (float)luaL_checknumber(l, 5);
-    float mix = (float)luaL_checknumber(1, 6);
+    float mix = (float)luaL_checknumber(l, 6);
     o_cut_buffer_mix_stereo((char *)s, start_src, start_dst, dur, preserve, mix);
     return 0;
 }


### PR DESCRIPTION
Adds `mix_buffer_mono(file, start_src, start_dst, dur, preserve, mix, chan_src, chan_dst)` and `mix_buffer_stereo(file, start_src, start_dst, dur, preserve, mix)` methods to softcut. These methods act like `read_buffer`, except they mix the existing buffer content with the new soundfile according to the `preserve` and `mix` params. See #1151.

Questions:
- should there be a fade_time parameter?
- is `clamp(frSrc, bufFrames - 1);` towards the beginning of `BufDiskWorker::readBufferMono` a bug? It seems like this says that we can't read a position in a file past the length of the softcut buffer?
- I mildly refactored `BufDiskWorker::Job` to add a `mix` parameter before the callback. I hope this is okay.
- when I run `crone.sh` or `start.sh` on my Norns after building, I get `liblo error: 9913; Invalid message path;`. Is this a problem?