### PR TITLE
Handle no mods found.

### DIFF
--- a/lua/core/mods.lua
+++ b/lua/core/mods.lua
@@ -16,7 +16,7 @@ function Mods.scan(root, pattern)
   local p = pattern or Mods.search_pattern
 
   local matches, error = norns.system_glob(r .. p)
-  if not matches then return nil end
+  if not matches then return {} end
 
   local mods = {}
   local name_pattern = "^" .. r .. "([%w_-]+)/"
@@ -55,11 +55,6 @@ function Mods.load(scan, only_enabled)
     require(package_path)
     Mods.this_name = nil
     loaded_mods[name] = true
-  end
-
-  if scan == nil then
-    print('No mods found!')
-    return
   end
 
   for name, details in pairs(scan) do

--- a/lua/core/mods.lua
+++ b/lua/core/mods.lua
@@ -57,6 +57,11 @@ function Mods.load(scan, only_enabled)
     loaded_mods[name] = true
   end
 
+  if scan == nil then
+    print('No mods found!')
+    return
+  end
+
   for name, details in pairs(scan) do
     if only_enabled then
       if Mods.is_enabled(name) then

--- a/matron/src/weaver.c
+++ b/matron/src/weaver.c
@@ -2586,7 +2586,6 @@ int _system_glob(lua_State *l) {
     glob_status = glob(pattern, glob_flags, NULL, &g);
 
     if (glob_status != 0) {
-        fprintf(stderr, "glob failed for pattern (%s): %s\n", pattern, strerror(errno));
         lua_pushnil(l);
         lua_pushinteger(l, glob_status);
         return 2;

--- a/matron/src/weaver.c
+++ b/matron/src/weaver.c
@@ -2586,6 +2586,7 @@ int _system_glob(lua_State *l) {
     glob_status = glob(pattern, glob_flags, NULL, &g);
 
     if (glob_status != 0) {
+        fprintf(stderr, "glob failed for pattern (%s): %s\n", pattern, strerror(errno));
         lua_pushnil(l);
         lua_pushinteger(l, glob_status);
         return 2;


### PR DESCRIPTION
One error I asked about in #1414 doesn't seem to be a real error:
```
running startup...
start_audio(): 
---> I added the next line. the arguments to scan are null so it uses these defaults, which don't seem to be correct.
r = /home/we/dust/code/, p = */lib/mod.lua
lua: /home/we/norns/lua/core/mods.lua:60: bad argument #1 to 'pairs' (table expected, got nil)
stack traceback:
	[C]: in function 'pairs'
	/home/we/norns/lua/core/mods.lua:60: in function 'core/mods.load'
	/home/we/norns/lua/core/startup.lua:111: in main chunk
	[C]: in function 'require'
	/home/we/norns/lua/core/norns.lua:238: in function '_startup'
scanning devices...
```

This happened because my dust repo doesn't have a `code` directory. I updated the code slightly so that there is an error message instead of a stack trace:
```
start_audio(): 
glob failed for pattern (/home/we/dust/code/*/lib/mod.lua): No such file or directory
scanning devices...
```
