### PR TITLE
sky: allow beat property to be set on redraw events

### DIFF
--- a/lua/extn/sky/unstable/io/norns.lua
+++ b/lua/extn/sky/unstable/io/norns.lua
@@ -58,8 +58,8 @@ function NornsInput.is_enc(event)
   return event.type == NornsInput.ENC_EVENT
 end
 
-function NornsInput.mk_redraw()
-  return { type = NornsInput.REDRAW_EVENT, beat = clock.get_beats() }
+function NornsInput.mk_redraw(beats)
+  return { type = NornsInput.REDRAW_EVENT, beat = beats or clock.get_beats() }
 end
 
 function NornsInput.is_redraw(event)


### PR DESCRIPTION
trivial addition to sky, allows the beat property to be explicitly set on redraw events which is useful when visualizing the current clock and also implementing transport start/stop behavior 