### PR TITLE
Fix/softcut phase invert

### DIFF
--- a/crone/CMakeLists.txt
+++ b/crone/CMakeLists.txt
@@ -8,25 +8,22 @@ set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS_DEBUG} -O0")
 set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS_RELEASE} -O2")
 
 set (SRC src/main.cpp
-        src/BufDiskWorker.h
-        src/Client.h
-        src/Utilities.h
-        src/OscInterface.cpp
+        src/BufDiskWorker.cpp
         src/Commands.cpp
-        src/Evil.h
-        src/Client.h
-        src/MixerClient.h
         src/MixerClient.cpp
+        src/OscInterface.cpp
         src/SoftcutClient.cpp
-        src/SoftcutClient.h
-        src/Poll.h
         src/Taper.cpp
         src/Window.cpp
-        src/BufDiskWorker.cpp)
+        softcut/softcut-lib/src/FadeCurves.cpp
+        softcut/softcut-lib/src/ReadWriteHead.cpp
+        softcut/softcut-lib/src/SubHead.cpp
+        softcut/softcut-lib/src/Svf.cpp
+        softcut/softcut-lib/src/Voice.cpp )
 
 add_executable(crone ${SRC})
 
-include_directories(./faust ./softcut/softcut-lib/include)
+include_directories(./faust ./softcut/softcut-lib/include lib/readerwriterqueue)
 
 if(UNIX)
     if(APPLE)


### PR DESCRIPTION
bring in a few small fixes from softcut repo.

most significantly, this fixes a bug where the signal was inverted before writing to the buffer! wow not sure how nobody ever noticed this. 

other minor stuff:
- update `CMakeLists.txt` for crone, so it works again 
- some fixes in the softcut demo client
- typos in markdown
- beginnings of softcut contributor readme