### PR TITLE
make keyboard work w/ textentry

### DIFF
--- a/lua/core/keyboard.lua
+++ b/lua/core/keyboard.lua
@@ -2,6 +2,7 @@
 -- @module keyboard
 
 local tab = require 'tabutil'
+local te_kbd_cb = require 'lib/textentry_kbd'
 
 local char_modifier = require 'core/keymap/char_modifier'
 
@@ -112,9 +113,12 @@ function keyboard.meta()
 function keyboard.process(type,code,value)
   local c = keyboard.codes[code]
 
-  -- menu keycode
-  if _menu.mode then _menu.keycode(c,value)
-  -- script keycode
+  -- textentry keycode
+  if te_kbd_cb.code then
+    te_kbd_cb.code(c,value)
+    -- menu keycode
+  elseif _menu.mode then _menu.keycode(c,value)
+    -- script keycode
   elseif keyboard.code then keyboard.code(c,value) end
 
   keyboard.state[c] = value>0
@@ -128,8 +132,10 @@ function keyboard.process(type,code,value)
     if a then
       --print("char: "..a)
       -- menu keychar
-      if _menu.mode then _menu.keychar(a)
-      -- script keychar
+      if te_kbd_cb.char then te_kbd_cb.char(a)
+        -- script keychar
+      elseif _menu.mode then _menu.keychar(a)
+        -- textentry keycode
       elseif keyboard.char then keyboard.char(a) end
     end
   end

--- a/lua/lib/textentry_kbd.lua
+++ b/lua/lib/textentry_kbd.lua
@@ -1,0 +1,10 @@
+
+--- just a separate module to store textentry keyboard callbacks
+--- prevents having to deal w/ a circular dependency
+
+local te_kbd = {
+  code = nil,
+  char = nil,
+}
+
+return te_kbd


### PR DESCRIPTION
this allows to use the keyboard in `textentry` menu (`TAPE`, Wi-Fi...).

please note that i had to create a new module `lib/textentry_kbd.lua` to hold the (temporary) callbacks. otherwise i would have had a circular dependency between `core/keyboard.lua` and `lib/textentry.lua`.
there might be a more elegant way to do this.