### PR TITLE
don't load tape on cancel

### DIFF
--- a/lua/core/menu/tape.lua
+++ b/lua/core/menu/tape.lua
@@ -49,7 +49,7 @@ local function tape_exists(index)
   return util.file_exists(filename)
 end
 
-local function update_tape_index()
+local function read_tape_index()
   local f = io.open(_path.tape..'index.txt','r')
   if f ~= nil then
     local a = tonumber(f:read("*line"))
@@ -61,7 +61,9 @@ local function update_tape_index()
   while tape_exists(m.fileindex) do
     m.fileindex = m.fileindex+1
   end
+end
 
+local function write_tape_index_v(v)
   local f = io.open(_path.tape..'index.txt','w')
   if f == nil then
     os.execute("mkdir -p ".._path.tape)
@@ -70,16 +72,25 @@ local function update_tape_index()
   if f == nil then
     print("WARNING: couldn't write index file, even after creating `tape/`")
   else
-    f:write(tostring(m.fileindex+1))
+    f:write(tostring(v))
     f:close()
   end
+end
+
+local function update_tape_index()
+  read_tape_index()
+  write_tape_index_v(m.fileindex+1)
 end
 
 local function edit_filename(txt)
   if txt then
     m.rec.file = txt .. ".wav"
   else
-    m.rec.file = string.format("%04d",m.fileindex) .. ".wav"
+    _menu.redraw()
+    return
+  end
+  if txt == string.format("%04d",m.fileindex+1) then
+    update_tape_index(v)
   end
   audio.tape_record_open(_path.audio.."tape/"..m.rec.file)
   m.rec.sel = TAPE_REC_START
@@ -166,10 +177,10 @@ m.key = function(n,z)
     else -- REC CONTROLS
       if m.rec.sel == TAPE_REC_ARM then
         tape_diskfree()
-        update_tape_index()
+        read_tape_index()
         textentry.enter(
           edit_filename,
-          string.format("%04d",m.fileindex),
+          string.format("%04d",m.fileindex+1),
           "tape filename:",
           function(txt)
             if tape_exists(txt) then


### PR DESCRIPTION
when in textentry for tape name, and canceling (by hitting `K2` / `ESC` on keyboard):
- past behavior: a tape gets loaded anyway w/ a newly incremented `fileindex`, `K3` triggers record
- fixed behavior: tape doesn't get loaded, `K3` allows reentering the textentry for the tape name