### PR TITLE
sky: provide more control over polyperc/polysub parameter definition

### DIFF
--- a/lua/extn/sky/unstable/engine/polyperc.lua
+++ b/lua/extn/sky/unstable/engine/polyperc.lua
@@ -11,7 +11,7 @@ local PolyPerc = sky.Device:extend()
 
 function PolyPerc:new(props)
   PolyPerc.super.new(self, props)
-  self:add_params()
+  -- self:add_params()
 end
 
 function PolyPerc:process(event, output, state)
@@ -22,8 +22,12 @@ function PolyPerc:process(event, output, state)
   output(event)
 end
 
-function PolyPerc:add_params()
-  params:add_separator('polyperc')
+function PolyPerc:add_params(group)
+  if group then
+    params:add_group('polyperc', 5)
+  else
+    params:add_separator('polyperc')
+  end
   params:add{ type = 'control', id = 'amp',
     controlspec = controlspec.new(0, 1, 'lin', 0, 0.5, ''),
     action = function(x) engine.amp(x) end

--- a/lua/extn/sky/unstable/engine/polysub.lua
+++ b/lua/extn/sky/unstable/engine/polysub.lua
@@ -13,8 +13,6 @@ local PolySub = sky.Device:extend()
 
 function PolySub:new(props)
   PolySub.super.new(self, props)
-  -- MAINT: params aren't owned so it is hard to remove
-  glue.params()
   self.next_voice = 1
   self.voices = {}
 end
@@ -36,6 +34,16 @@ function PolySub:process(event, output, state)
     self.voices[event.note] = nil
   end
   output(event)
+end
+
+function PolySub:add_params(group)
+  if group then
+    -- MAINT: this must match the number of params defined by the polysub glue
+    params:add_group('polysub', 19)
+  else
+    params:add_separator('polysub')
+  end
+  glue.params()
 end
 
 local function shared_instance(props)


### PR DESCRIPTION
trivial change unstable sky engine wrappers, specifically
- do not add parameters when the device is constructed the first time
- add separator by default or optionally group into sub menu