### PR TITLE
Add override to tabutil

### DIFF
--- a/lua/lib/tabutil.lua
+++ b/lua/lib/tabutil.lua
@@ -235,5 +235,16 @@ function tab.readonly(params)
   return proxy
 end
 
+--- return new table with defaults overridden by values
+-- @tparam table defaults base values (keys from this)
+-- @tparam table values override values
+-- @treturn table sorted table
+function tab.override(defaults, values)
+	local result = {}
+  for k,v in pairs(defaults) do 
+		result[k] = (values[k] ~= nil) and values[k] or v
+	end
+	return result
+end
 
 return tab


### PR DESCRIPTION
Returns a new table, overriding default table's values with those of override value table, using the keys of the default.

Neither the default table nor the override table are mutated.

Examples of potential usage:
https://github.com/monome/norns/blob/main/lua/lib/lattice.lua#L17
https://github.com/monome/norns/blob/main/lua/lib/lattice.lua#L119
These uses the `nil` check  + default pattern for each arg to override. This utility could sweeten the syntax a bit by providing all the default values in one object, then reassigning the result to args (whose original value is used for the overrides).