### PR TITLE
Bootstrap supercollider after installing trampoline.

### DIFF
--- a/sc/install.sh
+++ b/sc/install.sh
@@ -2,3 +2,4 @@
 
 sc_ext_dir=~/.local/share/SuperCollider/Extensions
 cp norns-config.sc $sc_ext_dir/
+echo | sclang


### PR DESCRIPTION
When setting up matron / supercollider for the first time you need to bootstrap things by running `sclang` twice. This codifies that process.

This idea was shamelessly borrows from this comment: https://github.com/monome/norns/issues/799#issuecomment-483065692

This approach works great with my docker environment, but I'm not sure if it fits with the way `install.sh` is normally used. Figured I'd make a PR and see what people thought.