### PR TITLE
custom events

### DIFF
--- a/matron/src/event_custom.h
+++ b/matron/src/event_custom.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <lua.h>
+
+typedef void (*event_custom_weave_op_t)(lua_State *lvm, void *value, void *context);
+typedef void (*event_custom_free_op_t)(void *value, void *context);
+
+struct event_custom_ops {
+    const char *type_name;
+    event_custom_weave_op_t weave;
+    event_custom_free_op_t free;
+};

--- a/matron/src/event_types.h
+++ b/matron/src/event_types.h
@@ -3,6 +3,7 @@
 #include "oracle.h"
 #include "osc.h"
 #include <stdint.h>
+#include <lua.h>
 
 typedef enum {
     // unused (do not remove)
@@ -315,7 +316,7 @@ struct event_softcut_position {
     float pos;
 };
 
-typedef void (*event_custom_weave_op_t)(void *value);
+typedef void (*event_custom_weave_op_t)(void *value, lua_State *lvm);
 typedef void (*event_custom_free_op_t)(void *value);
 
 struct event_custom_ops {

--- a/matron/src/event_types.h
+++ b/matron/src/event_types.h
@@ -85,6 +85,8 @@ typedef enum {
     EVENT_SOFTCUT_RENDER,
     // softcut position callback
     EVENT_SOFTCUT_POSITION,
+    // custom events defined in lua extensions
+    EVENT_CUSTOM,
 } event_t;
 
 // a packed data structure for four volume levels
@@ -313,6 +315,21 @@ struct event_softcut_position {
     float pos;
 };
 
+typedef void (*event_custom_weave_op_t)(void *value);
+typedef void (*event_custom_free_op_t)(void *value);
+
+struct event_custom_ops {
+    const char *type_name;
+    event_custom_weave_op_t weave;
+    event_custom_free_op_t free;
+};
+
+struct event_custom {
+    struct event_common common;
+    struct event_custom_ops *ops;
+    void *value;
+}; // +8
+
 union event_data {
     uint32_t type;
     struct event_exec_code_line exec_code_line;
@@ -348,4 +365,5 @@ union event_data {
     struct event_system_cmd system_cmd;
     struct event_softcut_render softcut_render;
     struct event_softcut_position softcut_position;
+    struct event_custom custom;
 };

--- a/matron/src/event_types.h
+++ b/matron/src/event_types.h
@@ -3,7 +3,6 @@
 #include "oracle.h"
 #include "osc.h"
 #include <stdint.h>
-#include <lua.h>
 
 typedef enum {
     // unused (do not remove)
@@ -316,14 +315,8 @@ struct event_softcut_position {
     float pos;
 };
 
-typedef void (*event_custom_weave_op_t)(lua_State *lvm, void *value, void *context);
-typedef void (*event_custom_free_op_t)(void *value, void *context);
-
-struct event_custom_ops {
-    const char *type_name;
-    event_custom_weave_op_t weave;
-    event_custom_free_op_t free;
-};
+// forward declaration to hide scripting layer dependencies
+struct event_custom_ops;
 
 struct event_custom {
     struct event_common common;

--- a/matron/src/event_types.h
+++ b/matron/src/event_types.h
@@ -316,8 +316,8 @@ struct event_softcut_position {
     float pos;
 };
 
-typedef void (*event_custom_weave_op_t)(void *value, lua_State *lvm);
-typedef void (*event_custom_free_op_t)(void *value);
+typedef void (*event_custom_weave_op_t)(lua_State *lvm, void *value, void *context);
+typedef void (*event_custom_free_op_t)(void *value, void *context);
 
 struct event_custom_ops {
     const char *type_name;
@@ -329,7 +329,8 @@ struct event_custom {
     struct event_common common;
     struct event_custom_ops *ops;
     void *value;
-}; // +8
+    void *context;
+}; // +12
 
 union event_data {
     uint32_t type;

--- a/matron/src/events.c
+++ b/matron/src/events.c
@@ -306,8 +306,7 @@ static void handle_event(union event_data *ev) {
         w_handle_softcut_position(ev->softcut_position.idx, ev->softcut_position.pos);
         break;
     case EVENT_CUSTOM:
-        assert(ev->custom.ops->weave != NULL);
-        ev->custom.ops->weave(ev->custom.value);
+        w_handle_custom_weave(ev->custom.ops->weave, ev->custom.value);
         break;
     } /* switch */
 

--- a/matron/src/events.c
+++ b/matron/src/events.c
@@ -104,11 +104,12 @@ MATRON_API union event_data *event_data_new(event_t type) {
     return ev;
 }
 
-MATRON_API union event_data *event_custom_new(struct event_custom_ops *ops, void *value) {
+MATRON_API union event_data *event_custom_new(struct event_custom_ops *ops, void *value, void *context) {
     assert(ops != NULL);
     union event_data *ev = event_data_new(EVENT_CUSTOM);
     ev->custom.ops = ops;
     ev->custom.value = value;
+    ev->custom.context = context;
     return ev;
 }
 
@@ -136,7 +137,9 @@ MATRON_API void event_data_free(union event_data *ev) {
         free(ev->softcut_render.data);
         break;
     case EVENT_CUSTOM:
-        if (ev->custom.ops->free) ev->custom.ops->free(ev->custom.value);
+        if (ev->custom.ops->free) {
+            ev->custom.ops->free(ev->custom.value, ev->custom.context);
+        }
         break;
     }
     free(ev);
@@ -306,7 +309,7 @@ static void handle_event(union event_data *ev) {
         w_handle_softcut_position(ev->softcut_position.idx, ev->softcut_position.pos);
         break;
     case EVENT_CUSTOM:
-        w_handle_custom_weave(ev->custom.ops->weave, ev->custom.value);
+        w_handle_custom_weave(ev->custom.ops->weave, ev->custom.value, ev->custom.context);
         break;
     } /* switch */
 

--- a/matron/src/events.c
+++ b/matron/src/events.c
@@ -97,14 +97,14 @@ void events_init(void) {
     pthread_cond_init(&evq.nonempty, NULL);
 }
 
-union event_data *event_data_new(event_t type) {
+MATRON_API union event_data *event_data_new(event_t type) {
     // FIXME: better not to allocate here, use object pool
     union event_data *ev = calloc(1, sizeof(union event_data));
     ev->type = type;
     return ev;
 }
 
-union event_data *event_custom_new(struct event_custom_ops *ops, void *value) {
+MATRON_API union event_data *event_custom_new(struct event_custom_ops *ops, void *value) {
     assert(ops != NULL);
     union event_data *ev = event_data_new(EVENT_CUSTOM);
     ev->custom.ops = ops;
@@ -112,7 +112,7 @@ union event_data *event_custom_new(struct event_custom_ops *ops, void *value) {
     return ev;
 }
 
-void event_data_free(union event_data *ev) {
+MATRON_API void event_data_free(union event_data *ev) {
     switch (ev->type) {
     case EVENT_EXEC_CODE_LINE:
         free(ev->exec_code_line.line);
@@ -143,7 +143,7 @@ void event_data_free(union event_data *ev) {
 }
 
 // add an event to the q and signal if necessary
-void event_post(union event_data *ev) {
+MATRON_API void event_post(union event_data *ev) {
     assert(ev != NULL);
     pthread_mutex_lock(&evq.lock);
     if (evq.size == 0) {

--- a/matron/src/events.c
+++ b/matron/src/events.c
@@ -17,6 +17,7 @@
 #include "weaver.h"
 
 #include "event_types.h"
+#include "event_custom.h"
 
 //----------------------------
 //--- types and variables
@@ -309,7 +310,7 @@ static void handle_event(union event_data *ev) {
         w_handle_softcut_position(ev->softcut_position.idx, ev->softcut_position.pos);
         break;
     case EVENT_CUSTOM:
-        w_handle_custom_weave(ev->custom.ops->weave, ev->custom.value, ev->custom.context);
+        w_handle_custom_weave(&(ev->custom));
         break;
     } /* switch */
 

--- a/matron/src/events.h
+++ b/matron/src/events.h
@@ -9,7 +9,7 @@
 extern void events_init(void);
 extern void event_loop(void);
 MATRON_API extern union event_data *event_data_new(event_t evcode);
-MATRON_API extern union event_data *event_custom_new(struct event_custom_ops *ops, void *value);
+MATRON_API extern union event_data *event_custom_new(struct event_custom_ops *ops, void *value, void *context);
 MATRON_API extern void event_data_free(union event_data *ev);
 MATRON_API extern void event_post(union event_data *ev);
 extern void event_handle_pending(void);

--- a/matron/src/events.h
+++ b/matron/src/events.h
@@ -8,6 +8,7 @@
 extern void events_init(void);
 extern void event_loop(void);
 extern union event_data *event_data_new(event_t evcode);
+extern union event_data *event_custom_new(struct event_custom_ops *ops, void *value);
 extern void event_data_free(union event_data *ev);
 extern void event_post(union event_data *ev);
 extern void event_handle_pending(void);

--- a/matron/src/events.h
+++ b/matron/src/events.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "matron.h"
 #include "event_types.h"
 
 // number of bytes in waveform data blob
@@ -7,8 +8,8 @@
 
 extern void events_init(void);
 extern void event_loop(void);
-extern union event_data *event_data_new(event_t evcode);
-extern union event_data *event_custom_new(struct event_custom_ops *ops, void *value);
-extern void event_data_free(union event_data *ev);
-extern void event_post(union event_data *ev);
+MATRON_API extern union event_data *event_data_new(event_t evcode);
+MATRON_API extern union event_data *event_custom_new(struct event_custom_ops *ops, void *value);
+MATRON_API extern void event_data_free(union event_data *ev);
+MATRON_API extern void event_post(union event_data *ev);
 extern void event_handle_pending(void);

--- a/matron/src/matron.h
+++ b/matron/src/matron.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#ifndef MATRON_API
+#define MATRON_API __attribute__ ((visibility ("default")))
+#endif

--- a/matron/src/weaver.c
+++ b/matron/src/weaver.c
@@ -53,7 +53,7 @@
 
 //------
 //---- global lua state!
-lua_State *lvm;
+static lua_State *lvm;
 
 void w_run_code(const char *code) {
     l_dostring(lvm, code, "w_run_code");
@@ -2092,6 +2092,12 @@ void w_handle_system_cmd(char *capture) {
     lua_remove(lvm, -2);
     lua_pushstring(lvm, capture);
     l_report(lvm, l_docall(lvm, 1, 0));
+}
+
+void w_handle_custom_weave(event_custom_weave_op_t op, void *value) {
+    // call the externally defined `op` function passing in the current lua
+    // state
+    op(value, lvm);
 }
 
 // helper: set poll given by lua to given state

--- a/matron/src/weaver.c
+++ b/matron/src/weaver.c
@@ -2094,10 +2094,10 @@ void w_handle_system_cmd(char *capture) {
     l_report(lvm, l_docall(lvm, 1, 0));
 }
 
-void w_handle_custom_weave(event_custom_weave_op_t op, void *value) {
+void w_handle_custom_weave(event_custom_weave_op_t op, void *value, void *context) {
     // call the externally defined `op` function passing in the current lua
     // state
-    op(value, lvm);
+    op(lvm, value, context);
 }
 
 // helper: set poll given by lua to given state

--- a/matron/src/weaver.c
+++ b/matron/src/weaver.c
@@ -33,6 +33,7 @@
 #include "device_midi.h"
 #include "device_monome.h"
 #include "events.h"
+#include "event_custom.h"
 #include "hello.h"
 #include "i2c.h"
 #include "lua_eval.h"
@@ -2094,10 +2095,10 @@ void w_handle_system_cmd(char *capture) {
     l_report(lvm, l_docall(lvm, 1, 0));
 }
 
-void w_handle_custom_weave(event_custom_weave_op_t op, void *value, void *context) {
+void w_handle_custom_weave(struct event_custom *ev) {
     // call the externally defined `op` function passing in the current lua
     // state
-    op(lvm, value, context);
+    ev->ops->weave(lvm, ev->value, ev->context);
 }
 
 // helper: set poll given by lua to given state

--- a/matron/src/weaver.h
+++ b/matron/src/weaver.h
@@ -97,4 +97,4 @@ extern void w_handle_startup_ready_timeout();
 extern void w_handle_system_cmd();
 
 // custom events
-extern void w_handle_custom_weave(event_custom_weave_op_t op, void *value, void *context);
+extern void w_handle_custom_weave(struct event_custom *ev);

--- a/matron/src/weaver.h
+++ b/matron/src/weaver.h
@@ -2,6 +2,7 @@
 
 #include "device_hid.h"
 #include "oracle.h"
+#include "event_types.h"
 
 // initialize the lua VM and run setup scripts
 extern void w_init(void);
@@ -94,3 +95,6 @@ extern void w_handle_startup_ready_timeout();
 
 // util callbacks
 extern void w_handle_system_cmd();
+
+// custom events
+extern void w_handle_custom_weave(event_custom_weave_op_t op, void *value);

--- a/matron/src/weaver.h
+++ b/matron/src/weaver.h
@@ -97,4 +97,4 @@ extern void w_handle_startup_ready_timeout();
 extern void w_handle_system_cmd();
 
 // custom events
-extern void w_handle_custom_weave(event_custom_weave_op_t op, void *value);
+extern void w_handle_custom_weave(event_custom_weave_op_t op, void *value, void *context);

--- a/matron/wscript
+++ b/matron/wscript
@@ -77,4 +77,5 @@ def build(bld):
         includes=matron_includes,
         use=matron_use,
         lib=matron_libs,
-        cflags=['-O3', '-Wall'])
+        cflags=['-O3', '-Wall'],
+        ldflags=['-Wl,-export-dynamic'])


### PR DESCRIPTION
this change opens up matron's event loop for access by c-based lua modules loaded at runtime.

the motivation for this change is to allow hardware devices such at the soundplane to have have the same direct, low overhead, channel for pushing events into the running script that built in matron devices enjoy. ...while avoiding the need to integrate/maintain the soundplane support directly in matron.

the approach is straightforward and modeled a bit after how the linux kernel achieves modularity. the new `event_custom` struct contains two pointers, one is an `ops` structure with functions pointers which the event loop core uses to handle the custom event behavior, the other is an arbitrary `value` pointer which gets passed back into the custom functions.

as a proof of concept (and to validate the changes) i have a mostly complete external lua module for demo purposes:
https://github.com/ngwese/norns-event-demo

the demo still needs some polish and documentation.