### PR TITLE
Support PSET entries above 99

### DIFF
--- a/lua/core/menu/params.lua
+++ b/lua/core/menu/params.lua
@@ -75,8 +75,7 @@ local function pset_list(results)
   end
 
   for _,file in pairs(t) do
-    local n = string.gsub(file,'.pset','')
-    n = tonumber(string.sub(n,-2,-1))
+    local n = tonumber(file:match"(%d+).pset$")
     if not n then n=1 end
     --print(file,n)
     local name = norns.state.shortname


### PR DESCRIPTION
This PR makes PSET files list parsing more generic.

Before this PR, PSET list show only up to entry `#99`.
PSET entry `#100` could be saved but not loaded. Worse, it in fact overrode entry for PSET `#10`.