### PR TITLE
Midi clock broadcast

### DIFF
--- a/lua/core/clock.lua
+++ b/lua/core/clock.lua
@@ -226,17 +226,17 @@ function clock.add_params()
 		print("adding "..short_name.." to clock out table at i: "..i)
     clock_midi_out_parameter_table[i+1] = "port "..(i)..""..(midi.vports[i].name ~= "none" and (": "..short_name) or "")
 		if midi.vports[i].name ~= "none" then
-			clock_midi_sync_function_table[i+1] = (function() print("midi clock send is set to CONNECTED vport: "..i) midi.vports[i]:clock() end)
+			clock_midi_sync_function_table[i+1] = (function() --[[print("midi clock send is set to CONNECTED vport: "..i)]] midi.vports[i]:clock() end)
 			clock_midi_connected_device_numbers[i] = i
 		else
-			clock_midi_sync_function_table[i+1] = (function() print("midi clock send is set to disconnected vport"..i ) end)
+			clock_midi_sync_function_table[i+1] = (function() --[[print("midi clock send is set to disconnected vport"..i )]] end)
 		end
 		if i == max_midi_clock_out_devices then -- TODO: if clock in is set to midi, we do not allow broadcast. 
 																						-- If I find a cost efficient way, we will filter the incoming device to avoid feedback.
 			clock_midi_out_parameter_table[i+2] = "Broadcast"
 			clock_midi_sync_function_table[i+2] = (function() 
-				for c=1, max_midi_clock_out_devices do
-					print("midi clock send is set to Broadcast!") 
+				for c=1	, max_midi_clock_out_devices do
+					-- print("midi clock send is set to Broadcast!") 
 					midi.vports[c]:clock()
 				end
 			end)

--- a/lua/core/clock.lua
+++ b/lua/core/clock.lua
@@ -215,13 +215,18 @@ function clock.add_params()
       norns.state.clock.link_quantum = x
     end)
   params:set_save("link_quantum", false)
-  local clock_table = {"off"}
-  for i = 1,16 do
+  local clock_midi_out_table = {"off"}
+	local max_midi_clock_out_devices = 16
+  for i = 1,max_midi_clock_out_devices do
     local short_name = string.len(midi.vports[i].name) < 12 and midi.vports[i].name or util.acronym(midi.vports[i].name)
-    clock_table[i+1] = "port "..(i)..""..(midi.vports[i].name ~= "none" and (": "..short_name) or "")
+    clock_midi_out_table[i+1] = "port "..(i)..""..(midi.vports[i].name ~= "none" and (": "..short_name) or "")
+		if i == max_midi_clock_out_devices then -- TODO: if clock in is set to midi, we do not allow broadcast. 
+																						-- If I find a cost efficient way, we will filter the incoming device to avoid feedback.
+			clock_midi_out_table[i+2] = "Broadcast"
+		end
   end
   params:add_option("clock_midi_out", "midi out",
-      clock_table, norns.state.clock.midi_out)
+      clock_midi_out_table, norns.state.clock.midi_out)
   params:set_action("clock_midi_out", function(x) norns.state.clock.midi_out = x end)
   params:set_save("clock_midi_out", false)
   params:add_option("clock_crow_out", "crow out",
@@ -265,15 +270,21 @@ function clock.add_params()
 
   -- executes midi out (needs a subtick)
   -- FIXME: lots of if's every tick blah
-  clock.run(function()
+ clock.run(function()
     while true do
       clock.sync(1/24)
       local midi_out = params:get("clock_midi_out")-1
-      if midi_out > 0 then
+      if midi_out > 0 and midi_out <= 16 then
         if midi.vports[midi_out].name ~= "none" then
           midi.vports[midi_out]:clock()
-        end
-      end
+				end
+			elseif midi_out == max_midi_clock_out_devices + 1 then
+				for i=1, max_midi_clock_out_devices do
+					if midi.vports[i].name ~= "none" then
+						midi.vports[i]:clock()	
+					end
+				end
+			end
     end
   end)
 


### PR DESCRIPTION
Allow sending midi broadcasts to all devices as discussed on lines here:
[https://llllllll.co/t/norns-midi-clock-to-all-connected-devices/48673](url)
The change also reduces the logic in the clock.run loop by accessing a function in an array. If I understood correctly, this costs more memory but saves decisions by moving the conditions into the parameter setup.
Todo: Offer broadcast to connected devices only by filtering the array. I suppose a smaller array might bring even better timing. All performance gains a hypothetical. I did not measure anything because I do not know how. Suggestions welcome.