### PR TITLE
Fix stat on machines with fewer than 4 cores.

### DIFF
--- a/matron/src/hardware/stat.c
+++ b/matron/src/hardware/stat.c
@@ -91,11 +91,15 @@ void *stat_check(void *x) {
         }
 
         // check cpu
-        if ((fd = popen("head -n5 /proc/stat", "r")) == NULL) {
+        if ((fd = popen("cat /proc/stat", "r")) == NULL) {
             fprintf(stderr, "Error opening pipe: cpu read\n");
         } else {
             int i = 0;
             while (fgets(buf, 128, fd) != NULL) {
+                // stop reading when all cpus are checked
+                if (strncmp("cpu", buf, 3) != 0) {
+                  break;
+                }
                 //fprintf(stderr,"%s", buf);
                 strtok(buf, " ");
                 user = atoi(strtok(NULL, " "));


### PR DESCRIPTION
On machines with fewer than 4 cores the stat_check function ends up trying to process the "intr" line, which somehow ends up causing a crash. This fixes the crash by only processing lines beginning with "cpu".