### PR TITLE
fix crash when trying to detect crow

### DIFF
--- a/matron/src/device/device_monitor.c
+++ b/matron/src/device/device_monitor.c
@@ -381,5 +381,8 @@ int is_dev_monome_grid(struct udev_device *dev) {
 
 int is_dev_crow(struct udev_device *dev) { 
     const char *device_product_string = udev_device_get_property_value(dev, "ID_MODEL");
-    return strcmp(device_product_string, "crow:_telephone_line") == 0;
+    if(device_product_string != NULL) {
+        return strcmp(device_product_string, "crow:_telephone_line") == 0;
+    }
+   return 0;
 }


### PR DESCRIPTION
In some cases, `udev_device_get_property_value` can return a NULL. This causes a segmentation fault when trying to detect crow on some setups. Adding a check that the value isn't null fixes this.