### PR TITLE
Fix/softcut voice enable

### DIFF
--- a/crone/src/SoftcutClient.cpp
+++ b/crone/src/SoftcutClient.cpp
@@ -75,7 +75,7 @@ void crone::SoftcutClient::mixInput(size_t numFrames) {
 
 void crone::SoftcutClient::mixOutput(size_t numFrames) {
     for (int v = 0; v < NumVoices; ++v) {
-        if (cut.getPlayFlag(v)) {
+        if (cut.getPlayFlag(v) && enabled[v]) {
             mix.panMixEpFrom(output[v], numFrames, outLevel[v], outPan[v]);
         }
     }

--- a/crone/src/SoftcutClient.cpp
+++ b/crone/src/SoftcutClient.cpp
@@ -30,7 +30,6 @@ crone::SoftcutClient::SoftcutClient() : Client<2, 2>("softcut") {
     }
     bufIdx[0] = BufDiskWorker::registerBuffer(buf[0], BufFrames);
     bufIdx[1] = BufDiskWorker::registerBuffer(buf[1], BufFrames);
-
 }
 
 void crone::SoftcutClient::process(jack_nframes_t numFrames) {
@@ -60,12 +59,12 @@ void crone::SoftcutClient::clearBusses(size_t numFrames) {
 
 void crone::SoftcutClient::mixInput(size_t numFrames) {
     for (int dst = 0; dst < NumVoices; ++dst) {
-        if (cut.getRecFlag(dst)) {
+        if (cut.getRecFlag(dst) && enabled[dst]) {
             for (int ch = 0; ch < 2; ++ch) {
                 input[dst].mixFrom(&source[SourceAdc][ch], numFrames, inLevel[ch][dst]);
             }
             for (int src = 0; src < NumVoices; ++src) {
-                if (cut.getPlayFlag(src)) {
+                if (cut.getPlayFlag(src) && enabled[src]) {
                     input[dst].mixFrom(output[src], numFrames, fbLevel[src][dst]);
                 }
             }
@@ -90,6 +89,9 @@ void crone::SoftcutClient::handleCommand(Commands::CommandPacket *p) {
         //-- softcut routing
     case Commands::Id::SET_ENABLED_CUT:
 	enabled[idx_0] = value > 0.f;
+	if (!enabled[idx_0]) {
+	    cut.stopVoice(idx_0);
+	}
 	break;
     case Commands::Id::SET_LEVEL_CUT:
 	outLevel[idx_0].setTarget(value);


### PR DESCRIPTION
this fixes a couple bugged cases around dynamically disabling/enabling voices. (which isn't a super common pattern, but should be supported.)

- most egregiously, `SoftcutClient` wasn't checking the enabled flags during mixup/mixdown (only rec/play flags). for mixup this just wasted a few cycles, but for mixdown it meant that the same bus contents were written out every block resulting in a "stuck buffer sound" if you disabled an audibly playing voice.

- at the library level there is no concept of "disabling" a voice, the library simply isn't called to process disabled voices. this meant that re-enabling a voice would start it up in exactly the same state it was left in. in particular, if a position change request was processed while disabled, it would start-up with a bogus crossafade from its former position. so this PR includes an update to the submodule allowing the client to explicitly reset appropriate voice state when disabling.

its probably worth checking for similar issues around play-state toggling, but i'll leave that for a separate pull.

----

oh yeah - the submodule update pulls in some little formatting changes too. for the record, i'm keeping `norns-latest` branch alive in `softcut-lib` and will always try to have this submodule pointed there. (softcut `main` is starting to get changes for 1.5 and shouldn't be used for norns releases.)