### PR TITLE
process parameters in order when writing pset

### DIFF
--- a/lua/core/paramset.lua
+++ b/lua/core/paramset.lua
@@ -377,7 +377,7 @@ function ParamSet:write(filename, name)
   if fd then
     io.output(fd)
     if name then io.write("-- "..name.."\n") end
-    for _,param in pairs(self.params) do
+    for _,param in ipairs(self.params) do
       if param.id and param.save and param.t ~= self.tTRIGGER then
         io.write(string.format("%s: %s\n", quote(param.id), param:get()))
       end


### PR DESCRIPTION
sometimes it would be nice to know the order in which parameters are recalled from a paramset. 

when adding params, we use `table.insert` with default position (last), so ordering is known at that point.

when actually reading the saved pset, we loop over lines in file, so that ordering is also known.

but in between, we loop using `pairs` to write the file... and while the order in saved .psets _looks_  consistent to me so far, lua spec explicitly says the order of `pairs` is undefined and cannot be relied on.

hence, this smallest imaginable change is i think enough to guarantee ordering. so why not