### PR TITLE
watcher reset, menu passwd entry

### DIFF
--- a/lua/core/menu/system.lua
+++ b/lua/core/menu/system.lua
@@ -47,8 +47,8 @@ m.deinit = norns.none
 
 m.passdone = function(txt)
   if txt ~= nil then
-    print("password change to " .. txt)
-    os.execute("echo 'we:"..txt.."' | sudo chpasswd")
+    local status = os.execute("echo 'we:"..txt.."' | sudo chpasswd")
+    if status then print("password changed") end
   end
   _menu.set_page("SYSTEM")
 end

--- a/lua/core/menu/system.lua
+++ b/lua/core/menu/system.lua
@@ -1,14 +1,20 @@
+local textentry= require 'textentry'
+
 local m = {
   pos = 1,
-  list = {"DEVICES > ", "WIFI >", "MODS >", "RESTART", "RESET", "UPDATE"},
-  pages = {"DEVICES", "WIFI", "MODS", "RESTART", "RESET", "UPDATE"}
+  list = {"DEVICES > ", "WIFI >", "MODS >", "RESTART", "RESET", "UPDATE", "PASSWORD >"},
+  pages = {"DEVICES", "WIFI", "MODS", "RESTART", "RESET", "UPDATE", "PASSWORD"}
 }
 
 m.key = function(n,z)
   if n==2 and z==1 then
     _menu.set_page("HOME")
   elseif n==3 and z==1 then
-    _menu.set_page(m.pages[m.pos])
+    if m.pages[m.pos]=="PASSWORD" then
+      textentry.enter(m.passdone, "", "new password:")
+    else
+      _menu.set_page(m.pages[m.pos])
+    end
   end
 end
 
@@ -21,21 +27,31 @@ end
 
 m.redraw = function()
   screen.clear()
-
-  for i=1,#m.list do
-    screen.move(0,10*i)
-    if(i==m.pos) then
-      screen.level(15)
-    else
-      screen.level(4)
+  for i=1,6 do
+    if (i > 3 - m.pos) and (i < #m.list - m.pos + 4) then
+      screen.move(0,10*i)
+      local line = m.list[i+m.pos-3]
+      if(i==3) then
+        screen.level(15)
+      else
+        screen.level(4)
+      end
+      screen.text(line)
     end
-    screen.text(m.list[i])
   end
-
   screen.update()
 end
 
 m.init = norns.none
 m.deinit = norns.none
+
+m.passdone = function(txt)
+  if txt ~= nil then
+    print("password change to " .. txt)
+    os.execute("echo 'we:"..txt.."' | sudo chpasswd")
+  end
+  _menu.set_page("SYSTEM")
+end
+
 
 return m

--- a/watcher/src/main.c
+++ b/watcher/src/main.c
@@ -24,6 +24,11 @@ void *watch_time(void *);
 int main(void) {
   printf("watcher\n");
 
+  if(access("/boot/norns.txt", F_OK)==0) {
+    system("echo 'we:sleep' | sudo chpasswd");
+    system("sudo rm /boot/norns.txt");
+  }
+
   int fd;
   int open_attempts = 0, ioctl_attempts = 0;
   while (open_attempts < 200) {


### PR DESCRIPTION
- adds `SYSTEM > PASSWORD` which allows entry of new password for user `we` (does not require existing password, no confirmation, no display of current password)
- `watcher` now checks for `/boot.norns.txt`, if present resets pw to `sleep` and deletes `norns.txt` (this file can be created by mounting a norns in DISK mode via `rpiboot` or by inserting shield sdcard into computer) --- this is a failsafe in case the menu system won't load due to a broken update (or something)... the theory being that `watcher` is less fragile.

bonus (i guess): `SYSTEM` menu is now scrolling