### PR TITLE
handle no matching mods more gracefully

### DIFF
--- a/lua/core/startup.lua
+++ b/lua/core/startup.lua
@@ -108,4 +108,4 @@ _norns.start_audio()
 -- load matron mods and invoke system hooks
 local mods = require 'core/mods'
 mods.load_enabled()
-mods.load(mods.scan(), true) -- only load enabled mods
+mods.load(mods.scan() or {}, true) -- only load enabled mods


### PR DESCRIPTION
this came up during the recent docker experimentation. i had incorrectly attributed it to a missing `dust` directory but it happens on any device which is free of mods.