### PR TITLE
persist --desktop option between conf and build

### DIFF
--- a/matron/wscript
+++ b/matron/wscript
@@ -38,7 +38,7 @@ def build(bld):
         'src/clocks/clock_scheduler.c',
     ]
 
-    if bld.options.desktop:
+    if bld.env.NORNS_DESKTOP:
         matron_sources += [
             'src/hardware/screen/sdl.c',
             'src/hardware/input/sdl.c',
@@ -70,7 +70,7 @@ def build(bld):
         'JACK',
     ]
 
-    if bld.options.desktop:
+    if bld.env.NORNS_DESKTOP:
         matron_libs.append('SDL2')
         matron_use.append('SDL2')
 

--- a/wscript
+++ b/wscript
@@ -60,6 +60,7 @@ def configure(conf):
     if conf.options.desktop:
         conf.check_cfg(package='sdl2', args=['--cflags', '--libs'])
         conf.define('NORNS_DESKTOP', True)
+    conf.env.NORNS_DESKTOP = conf.options.desktop
 
     conf.env.ENABLE_ABLETON_LINK = conf.options.enable_ableton_link
     conf.define('HAVE_ABLETON_LINK', conf.options.enable_ableton_link)


### PR DESCRIPTION
save `--desktop` option in environment so you don't need to type it at build