### PR TITLE
verbose 'missing' message

### DIFF
--- a/lua/core/menu.lua
+++ b/lua/core/menu.lua
@@ -76,6 +76,9 @@ norns.menu.toggle = function(status) _menu.set_mode(status) end
 norns.scripterror = function(msg)
   if msg == nil then msg = "" end
   print("### SCRIPT ERROR: "..msg)
+  if util.string_starts(msg,"missing") then
+    print("### try 'SYSTEM > RESTART'")
+  end
   _menu.errormsg = msg
   _menu.scripterror = true
   _menu.locked = true

--- a/lua/core/menu/home.lua
+++ b/lua/core/menu/home.lua
@@ -51,12 +51,17 @@ m.redraw = function()
   end
 
   if not _menu.showstats then
-    screen.move(0,15)
-    screen.level(15)
     local line = string.upper(norns.state.name)
     if(_menu.scripterror and _menu.errormsg ~= 'NO SCRIPT') then
       line = "error: " .. _menu.errormsg
+      if util.string_starts(_menu.errormsg,"missing") then
+        screen.level(8)
+        screen.move(0,25)
+        screen.text("try 'SYSTEM > RESTART'")
+      end
     end
+    screen.level(15)
+    screen.move(0,15)
     screen.text(line)
   else
     screen.level(1)


### PR DESCRIPTION
'missing' errors don't give the user much in the way of next steps if they're new to the ecosystem -- even though troubleshooting is all well-documented and maiden has a heads-up built in, folks still ask how to resolve the error (spun this up after seeing a message posted to the study discord this morning).

this commit would add two bits of helper text, one on-screen and the other printed to the REPL.

**on-screen**, user would see:

```
error: missing ____
try 'SYSTEM > RESTART'
SELECT >
SYSTEM >
SLEEP >
```

**in REPL**, user would see:

```
loading engine: ____
### SCRIPT ERROR: missing ____
### try 'SYSTEM > RESTART'
```