### PR TITLE
lib/lattice: add pattern delay

### DIFF
--- a/lua/lib/lattice.lua
+++ b/lua/lib/lattice.lua
@@ -103,10 +103,10 @@ function Lattice:pulse()
         end
         if pattern.phase > (pattern.division * ppm)*swing_val then
           pattern.phase = pattern.phase - (pattern.division * ppm)
-	  if pattern.delay_new ~= nil then
-	    pattern.phase = pattern.phase - (pattern.division*ppm)*(1-(pattern.delay-pattern.delay_new))
+          if pattern.delay_new ~= nil then
+            pattern.phase = pattern.phase - (pattern.division*ppm)*(1-(pattern.delay-pattern.delay_new))
             pattern.delay = pattern.delay_new
-	    pattern.delay_new = nil
+            pattern.delay_new = nil
           end
           pattern.action(self.transport)
           pattern.downbeat = not pattern.downbeat
@@ -125,6 +125,7 @@ end
 -- - "division" (number) the division of the pattern, defaults to 1/4
 -- - "enabled" (boolean) is this pattern enabled, defaults to true
 -- - "swing" (number) is the percentage of swing (0 - 100%), defaults to 50
+-- - "delay" (number) specifies amount of delay, as fraction of division (0.0 - 1.0), defaults to 0
 -- @treturn table a new pattern
 function Lattice:new_pattern(args)
   self.pattern_id_counter = self.pattern_id_counter + 1
@@ -197,7 +198,7 @@ function Pattern:set_swing(swing)
 end
 
 -- set the delay for this pattern
--- @tparam fraction of the time between beats to delay
+-- @tparam fraction of the time between beats to delay (0-1)
 function Pattern:set_delay(delay)
   self.delay_new = util.clamp(delay,0,1)
 end


### PR DESCRIPTION
one more lattice addition. this PR builds off https://github.com/monome/norns/pull/1468, but I would consider it separate. so it might be easier to consider that PR first.

this PR adds the ability to delay a pattern by a fraction of its current division. this type of feature is useful when implementing note-off events using patterns. if this PR is out of the scope of lattice, that is no problem, feel free to ignore :)

use case: in many sequencing scripts I need to make a note-off event in between two note-on events. ideally the position of the note-off event is configurable (i.e. the "duration" of the note). by adding "delay" to a pattern, you can accomplish this easily with lattice, with two patterns: one pattern for note-on events, and one pattern for note-off events, both with the same division but with different offsets. by varying the offset of the note-off pattern you can effectively dial in exactly where you want the note-off event to occur, and it will occur between the two note-on events.

this current implementation lets you change while the pattern is playing, but it does take about two notes to get it back into the correct offset.

here is a test script:

```lua
-- aa

engine.name="PolyPerc"

function init()

  lattice = require("lattice")

  -- default lattice usage, showing default arguments
  my_lattice = lattice:new{}

  my_patterns={}
  my_patterns[1]=my_lattice:new_pattern{
    action = function(t)
      engine.amp(0.5)
      engine.hz(110)
    end,
    division = 1/4,
  }  
  my_patterns[2]=my_lattice:new_pattern{
    action = function(t)
      engine.amp(0.2)
      engine.hz(440)
    end,
    division = 1/4,
    delay = 0.3,
  }

  -- start the lattice
  my_lattice:start()

  -- delay controller
  for i=1,2 do 
    params:add{type="control",id=i.."delay",name="delay "..i,
      controlspec=controlspec.new(0,1,'lin',0.01,my_patterns[i].delay,'',0.01/1),action=function(v)
        my_patterns[i]:set_delay(v)
    end}
  end

  clock.run(redraw_clock)
end

function redraw_clock() -- our grid redraw clock
  while true do -- while it's running...
    clock.sleep(1/10) -- refresh
    redraw()
  end
end


function key(k,z)
  if z==0 then 
    do return end 
  end
  if k==2 then 
    my_lattice:reset()
  elseif k==3 then 
    my_lattice:start()
  end
end

function enc(k,d)
  if k>1 then 
    params:delta((k-1).."delay",d)
  else
    for k=2,3 do 
      params:delta((k-1).."delay",d)
    end
  end
end

function redraw()
  screen.clear()
  screen.level(15)
  screen.move(10,10)
  screen.text("pattern 1 delay: "..params:get("1delay"))
  screen.move(10,20)
  screen.text("pattern 2 delay: "..params:get("2delay"))
  screen.move(10,30)
  screen.text("K2 stops, K3 starts")
  screen.move(10,40)
  screen.text("E1 adjusts both delays")
  screen.move(10,50)
  screen.text("E2/E3 adjust pattern delay")
  screen.update()
end
```

ping @tyleretters 