### PR TITLE
jack fail message to OLED

### DIFF
--- a/matron/src/clock.c
+++ b/matron/src/clock.c
@@ -12,19 +12,25 @@
 #include "clocks/clock_midi.h"
 #include "clocks/clock_scheduler.h"
 #include "events.h"
+#include "screen.h"
 
 static clock_source_t clock_source;
 static jack_client_t *jack_client;
 static jack_nframes_t jack_sample_rate;
 
 void clock_init() {
-    if ((jack_client = jack_client_open("matron-clock", JackNoStartServer, NULL)) == 0) {
-        fprintf(stderr, "failed to create JACK client\n");
-    }
+  if ((jack_client = jack_client_open("matron-clock", JackNoStartServer, NULL)) == 0) {
+    fprintf(stderr, "failed to create JACK client\n");
+    screen_clear();
+    screen_level(15);
+    screen_move(0,60);
+    screen_text("jack fail.");
+    screen_update();
+  }
 
-    jack_sample_rate = jack_get_sample_rate(jack_client);
+  jack_sample_rate = jack_get_sample_rate(jack_client);
 
-    clock_set_source(CLOCK_SOURCE_INTERNAL);
+  clock_set_source(CLOCK_SOURCE_INTERNAL);
 }
 
 void clock_deinit() {


### PR DESCRIPTION
adds a message to the screen regarding jack failure (which usually means a bad audio codec in normal use).

does not attempt to exit gracefully, segfaults on following line (should i just add an exit()?)

also see https://github.com/monome/norns-image/pull/87

fixes https://github.com/monome/norns/issues/1437