### PR TITLE
add progress to update download

### DIFF
--- a/lua/core/menu/update.lua
+++ b/lua/core/menu/update.lua
@@ -48,11 +48,13 @@ local function get_update()
   print("starting download...")
   local cmd = "wget -T 180 -q -P /home/we/update/ " .. releases[m.install].url .. " " .. releases[m.install].sha
   print("> "..cmd)
+  m.initial_disk = norns.disk
   norns.system_cmd(cmd, get_update_2) --download
   _menu.timer.time = 0.5
   _menu.timer.count = -1
   _menu.timer.event = function()
     m.blink = m.blink == false
+    m.message = "downloading: " .. m.initial_disk-norns.disk
     _menu.redraw()
   end
   _menu.timer:start()


### PR DESCRIPTION
fixes #1472 by making a reasonable assumption: disk size when update starts should only be changed by the incoming download. so just show the diff. note that norns disk size query updates every 5 seconds (this is in the C layer) so this isn't super real-time, but it helps give some feedback and i think it's a big improvement.