### PR TITLE
Joining an existing Link session should adopt the session tempo, not force the device tempo

### DIFF
--- a/lua/core/clock.lua
+++ b/lua/core/clock.lua
@@ -183,13 +183,13 @@ function clock.add_params()
     norns.state.clock.source)
   params:set_action("clock_source",
     function(x)
+      if x==3 then clock.link.set_tempo(params:get("clock_tempo")) end -- for link, apply tempo before setting source
       clock.set_source(x)
       if x==4 then
         norns.crow.clock_enable()
       end
       norns.state.clock.source = x
-      if x==1 then clock.internal.set_tempo(params:get("clock_tempo"))
-      elseif x==3 then clock.link.set_tempo(params:get("clock_tempo")) end
+      if x==1 then clock.internal.set_tempo(params:get("clock_tempo")) end
     end)
   params:set_save("clock_source", false)
   params:add_number("clock_tempo", "tempo", 1, 300, norns.state.clock.tempo)

--- a/matron/src/clock.c
+++ b/matron/src/clock.c
@@ -149,6 +149,12 @@ void clock_reschedule_sync_events_from_source(clock_source_t source) {
 }
 
 void clock_set_source(clock_source_t source) {
+    if (clock_source != source && source == CLOCK_SOURCE_LINK) {
+        clock_link_join_session();
+    } else if (clock_source != source && clock_source == CLOCK_SOURCE_LINK) {
+        clock_link_leave_session();
+    }
+
     clock_source = source;
     clock_scheduler_reschedule_sync_events();
 }

--- a/matron/src/clocks/clock_link.h
+++ b/matron/src/clocks/clock_link.h
@@ -2,6 +2,8 @@
 
 void clock_link_init();
 void clock_link_start();
+void clock_link_join_session();
+void clock_link_leave_session();
 void clock_link_set_quantum(double quantum);
 void clock_link_set_tempo(double tempo);
 double clock_link_get_beat();


### PR DESCRIPTION
### background/motivation

The [Link test plan](https://github.com/Ableton/link/blob/master/TEST-PLAN.md) has two clauses about the expectations for how joining a session should affect the app/device tempo:

[TEMPO-2](https://github.com/Ableton/link/blob/master/TEST-PLAN.md#tempo-2-opening-an-app-with-link-enabled-should-not-change-the-tempo-of-an-existing-link-session): Opening an app with Link enabled should not change the tempo of an existing Link session.
[TEMPO-5](https://github.com/Ableton/link/blob/master/TEST-PLAN.md#tempo-5-enabling-link-does-not-change-apps-tempo-if-there-is-no-link-session-to-join): Enabling Link does not change app's tempo if there is no Link session to join.

So the behavior needs to be different based on whether the session has other participants or not. Luckily, this behavior is already implemented in the Link library; in order to take advantage of it, we just need to ~~construct a new Link object when enabling Link~~ manipulate the enable state, and make sure tempo requests are processed before we change the enable state.

### primary change: enable/disable Link when it is selected/deselected as a source

The existing behavior is to create and join a Link session at norns startup, and then switch it to be the clock source (and set the tempo) when Link is enabled from the params menu. The primary change in this PR is to only enable the Link client when Link becomes the clock source, and to send the tempo change request before Link becomes the clock source.

This has a nice consequence in that other Link clients that report number of connected devices will now only count norns when it's using Link for sync, rather than any time it's on the network regardless of clock source.

~~This also has a not-nice consequence: the Link "start/stop sync" feature, which norns previously always enabled, now exhibits behavior that doesn't seem correct or desirable. With start-stop sync always enabled, it's easy to get to a state where you have no way of re-enabling transport from norns, you have to kick the session from another client (or run `_norns.clock.start()` from maiden.)~~

### ~~secondary change: allow user to toggle Link start/stop sync~~

~~To mitigate this, this PR also exposes the Link 3.0 start/stop sync enable/disable state in the menu, and defaults it to disabled. This way Link behaves more like the other clock sources, and it's harder to inadvertently stop the transport by switching sources.~~

~~Start-stop sync is currently tricky to implement correctly because the system does not currently have a clock-source-independent, script-independent notion of whether the global transport is running or not. Having such a state isn't an explicit requirement for Link clients, but reading between the lines of the test plan, that assumption does seem to be in there. A follow-up PR could add a global transport state to cover the edge cases when switching Link on and off with start/stop sync enabled.~~