### PR TITLE
Add Tilt support for legacy grids

### DIFF
--- a/matron/src/device/device_monome.c
+++ b/matron/src/device/device_monome.c
@@ -183,7 +183,7 @@ void dev_monome_handle_tilt(const monome_event_t *e, void *p) {
     ev->grid_tilt.sensor = e->tilt.sensor;
     ev->grid_tilt.x = e->tilt.x;
     ev->grid_tilt.y = e->tilt.y;
-    ev->grid_tilt.z = e->tilt.y;
+    ev->grid_tilt.z = e->tilt.z;
     event_post(ev);
 }
 

--- a/matron/src/device/device_monome.c
+++ b/matron/src/device/device_monome.c
@@ -21,6 +21,7 @@ static void dev_monome_handle_lift(const monome_event_t *e, void *p);
 static void dev_monome_handle_encoder_delta(const monome_event_t *e, void *p);
 static void dev_monome_handle_encoder_press(const monome_event_t *e, void *p);
 static void dev_monome_handle_encoder_lift(const monome_event_t *e, void *p);
+static void dev_monome_handle_tilt(const monome_event_t *e, void *p);
 
 //-------------------------
 //--- monome device class
@@ -65,6 +66,7 @@ int dev_monome_init(void *self) {
     monome_register_handler(m, MONOME_ENCODER_DELTA, dev_monome_handle_encoder_delta, md);
     monome_register_handler(m, MONOME_ENCODER_KEY_DOWN, dev_monome_handle_encoder_press, md);
     monome_register_handler(m, MONOME_ENCODER_KEY_UP, dev_monome_handle_encoder_lift, md);
+    monome_register_handler(m, MONOME_TILT, dev_monome_handle_tilt, md);
 
     // drop the name set by udev and use libmonome-provided name
     free(base->name);
@@ -92,6 +94,14 @@ static inline uint8_t dev_monome_quad_offset(uint8_t x, uint8_t y) {
 // set grid rotation
 void dev_monome_set_rotation(struct dev_monome *md, uint8_t rotation) {
     monome_set_rotation(md->m, rotation);
+}
+
+// enable/disable grid tilt
+void dev_monome_tilt_enable(struct dev_monome *md, uint8_t sensor) {
+    monome_tilt_enable(md->m, sensor);
+}
+void dev_monome_tilt_disable(struct dev_monome *md, uint8_t sensor) {
+    monome_tilt_disable(md->m, sensor);
 }
 
 // set a given LED value
@@ -164,6 +174,17 @@ void dev_monome_handle_press(const monome_event_t *e, void *p) {
 
 void dev_monome_handle_lift(const monome_event_t *e, void *p) {
     grid_key_event(e, p, 0);
+}
+
+void dev_monome_handle_tilt(const monome_event_t *e, void *p) {
+    struct dev_monome *md = (struct dev_monome *)p;
+    union event_data *ev = event_data_new(EVENT_GRID_TILT);
+    ev->grid_tilt.id = md->dev.id;
+    ev->grid_tilt.sensor = e->tilt.sensor;
+    ev->grid_tilt.x = e->tilt.x;
+    ev->grid_tilt.y = e->tilt.y;
+    ev->grid_tilt.z = e->tilt.y;
+    event_post(ev);
 }
 
 void dev_monome_handle_encoder_delta(const monome_event_t *e, void *p) {

--- a/matron/src/device/device_monome.h
+++ b/matron/src/device/device_monome.h
@@ -42,6 +42,10 @@ extern void dev_monome_intensity(struct dev_monome *md, uint8_t i);
 // set grid rotation
 extern void dev_monome_set_rotation(struct dev_monome *md, uint8_t val);
 
+// grid tilt enable/disable
+extern void dev_monome_tilt_enable(struct dev_monome *md, uint8_t val);
+extern void dev_monome_tilt_disable(struct dev_monome *md, uint8_t val);
+
 // device management
 extern int dev_monome_init(void *self);
 extern void dev_monome_deinit(void *self);

--- a/matron/src/event_types.h
+++ b/matron/src/event_types.h
@@ -33,6 +33,8 @@ typedef enum {
     EVENT_MONOME_REMOVE,
     // monome grid press/lift
     EVENT_GRID_KEY,
+    // monome grid tilt
+    EVENT_GRID_TILT,
     // monome arc encoder delta
     EVENT_ARC_ENCODER_DELTA,
     // monome arc encoder key
@@ -125,6 +127,15 @@ struct event_grid_key {
     uint8_t x;
     uint8_t y;
     uint8_t state;
+}; // +4
+
+struct event_grid_tilt {
+    struct event_common common;
+    uint8_t id;
+    uint8_t sensor;
+    uint8_t x;
+    uint8_t y;
+    uint8_t z;
 }; // +4
 
 struct event_arc_encoder_delta {
@@ -331,6 +342,7 @@ union event_data {
     struct event_monome_add monome_add;
     struct event_monome_remove monome_remove;
     struct event_grid_key grid_key;
+    struct event_grid_tilt grid_tilt;
     struct event_arc_encoder_delta arc_encoder_delta;
     struct event_arc_encoder_key arc_encoder_key;
     struct event_hid_add hid_add;

--- a/matron/src/events.c
+++ b/matron/src/events.c
@@ -227,6 +227,9 @@ static void handle_event(union event_data *ev) {
     case EVENT_GRID_KEY:
         w_handle_grid_key(ev->grid_key.id, ev->grid_key.x, ev->grid_key.y, ev->grid_key.state);
         break;
+    case EVENT_GRID_TILT:
+        w_handle_grid_tilt(ev->grid_tilt.id, ev->grid_tilt.sensor, ev->grid_tilt.x, ev->grid_tilt.y, ev->grid_tilt.z);
+        break;
     case EVENT_ARC_ENCODER_DELTA:
         w_handle_arc_encoder_delta(ev->arc_encoder_delta.id, ev->arc_encoder_delta.number, ev->arc_encoder_delta.delta);
         break;

--- a/matron/src/weaver.h
+++ b/matron/src/weaver.h
@@ -33,6 +33,7 @@ extern void w_reset_lvm();
 extern void w_handle_monome_add(void *dev);
 extern void w_handle_monome_remove(int id);
 extern void w_handle_grid_key(int id, int x, int y, int state);
+extern void w_handle_grid_tilt(int id, int sensor, int x, int y, int z);
 extern void w_handle_arc_encoder_delta(int id, int number, int delta);
 extern void w_handle_arc_encoder_key(int id, int number, int state);
 


### PR DESCRIPTION
Adds support for tilt.

Tested on norns shield and a grayscale 64 (2010-2012) - serial m64-0993  
grid presents as `grid monome 64 m64-0993 8x8`

For testing I added tilt to my grid-test script in this branch: https://github.com/okyeron/grid-test/tree/tilt
(tilt can be enabled/disabled in the params menu)

Results:	 
* X/Y data comes through, no Z (although no Z data was observed on Max test-grid patch either).
* Values displayed are between ~90 and ~170, with ~130 in the center (grid flat on table)

Questions:  
* Is there no Z on that grid model? Is there Z on others?
* What are expected values? Seems like 0 to <200 when testing with the Max test-grid patch
