### PR TITLE
consolidate crone/matron processes

### DIFF
--- a/crone/src/crone_main.h
+++ b/crone/src/crone_main.h
@@ -1,0 +1,8 @@
+#ifndef _CRONE_MAIN_H_
+#define _CRONE_MAIN_H_
+
+
+int crone_main();
+void crone_cleanup();
+
+#endif

--- a/crone/wscript
+++ b/crone/wscript
@@ -40,7 +40,7 @@ def build(bld):
                      'LIBLO',
                  ],
                  lib=[
-                     'atomic',
+                    'atomic',
                      'jack',
                      'pthread',
                      'm',

--- a/matron/src/main.cc
+++ b/matron/src/main.cc
@@ -35,7 +35,7 @@
 
 void print_version(void);
 
-void cleanup(void) {
+void matron_cleanup(void) {
     dev_monitor_deinit();
     osc_deinit();
     o_deinit();
@@ -51,7 +51,7 @@ void cleanup(void) {
     exit(0);
 }
 
-int main(int argc, char **argv) {
+int matron_main(int argc, char **argv) {
     args_parse(argc, argv);
 
     print_version();
@@ -94,14 +94,13 @@ int main(int argc, char **argv) {
 
     // now is a good time to set our cleanup
     fprintf(stderr, "setting cleanup...\n");
-    atexit(cleanup);
+    atexit(matron_cleanup);
 
 
     fprintf(stderr, "init input...\n");
     // start reading input to interpreter
     input_init();
 
-    
     fprintf(stderr, "running startup...\n");
     // i/o subsystems are ready; run user startup routine
     w_startup();
@@ -117,9 +116,9 @@ int main(int argc, char **argv) {
     fprintf(stderr, "running post-startup...\n");
     w_post_startup();
     
-    
     // blocks until quit
     event_loop();
+    return 0;
 }
 
 void print_version(void) {
@@ -127,3 +126,10 @@ void print_version(void) {
     printf("norns version: %d.%d.%d\n", VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH);
     printf("git hash: %s\n\n", VERSION_HASH);
 }
+
+
+#if 0
+int main(int argc, char **argv) {
+    matron_main();
+}
+#endif

--- a/matron/src/matron_main.h
+++ b/matron/src/matron_main.h
@@ -1,0 +1,6 @@
+#ifndef _MATRON_MAIN_H_
+#define _MATRON_MAIN_H_
+
+int matron_main(int argc, char **argv);
+
+#endif

--- a/norns/main.cpp
+++ b/norns/main.cpp
@@ -1,0 +1,16 @@
+#include <thread>
+
+#include "matron_main.h"
+#include "crone_main.h"
+
+int main(int argc, char **argv) {
+    std::thread crone_thread(crone_main);
+
+    std::thread matron_thread([argc, argv]() { matron_main(argc, argv); });
+
+
+    matron_thread.join();
+    crone_cleanup();
+
+    return 0;
+}

--- a/norns/wscript
+++ b/norns/wscript
@@ -1,0 +1,133 @@
+def build(bld):
+
+    matron_sources = [
+        '../matron/src/config.cc',
+        '../matron/src/device/device.cc',
+        '../matron/src/device/device_hid.cc',
+        '../matron/src/device/device_list.cc',
+        '../matron/src/device/device_midi.cc',
+        '../matron/src/device/device_monitor.cc',
+        '../matron/src/device/device_monome.cc',
+        '../matron/src/device/device_crow.cc',
+        '../matron/src/osc.cc',
+        '../matron/src/hardware/battery.cc',
+        '../matron/src/hardware/i2c.cc',
+        '../matron/src/hardware/input.cc',
+        '../matron/src/hardware/io.cc',
+        '../matron/src/hardware/platform.cc',
+        '../matron/src/hardware/screen.cc',
+        '../matron/src/hardware/stat.cc',
+	    '../matron/src/hardware/screen/fbdev.cc',
+        '../matron/src/hardware/input/gpio.cc',
+        '../matron/src/args.cc',
+        '../matron/src/events.cc',
+        '../matron/src/hello.cc',
+        '../matron/src/input.cc',
+        '../matron/src/lua_eval.cc',
+        '../matron/src/main.cc',
+        '../matron/src/metro.cc',
+        '../matron/src/oracle.cc',
+        '../matron/src/weaver.cc',
+        '../matron/src/snd_file.cc',
+        '../matron/src/system_cmd.cc',
+        '../matron/src/clock.cc',
+        '../matron/src/clocks/clock_internal.cc',
+        '../matron/src/clocks/clock_midi.cc',
+        '../matron/src/clocks/clock_crow.cc',
+        '../matron/src/clocks/clock_scheduler.cc',
+    ]
+
+    if bld.env.NORNS_DESKTOP:
+        matron_sources += [
+            '../matron/src/hardware/screen/sdl.cc',
+            '../matron/src/hardware/input/sdl.cc',
+        ]
+
+    crone_sources = [
+        '../crone/src/main.cpp',
+        '../crone/src/BufDiskWorker.cpp',
+        '../crone/src/Commands.cpp',
+        '../crone/src/MixerClient.cpp',
+        '../crone/src/OscInterface.cpp',
+        '../crone/src/SoftcutClient.cpp',
+        '../crone/src/Taper.cpp',
+        '../crone/src/Window.cpp',
+        '../crone/softcut/softcut-lib/src/FadeCurves.cpp',
+        '../crone/softcut/softcut-lib/src/ReadWriteHead.cpp',
+        '../crone/softcut/softcut-lib/src/SubHead.cpp',
+        '../crone/softcut/softcut-lib/src/Svf.cpp',
+        '../crone/softcut/softcut-lib/src/Voice.cpp'
+    ]
+
+    matron_includes = [
+        '../matron/src',
+        '../matron/src/device',
+        '../matron/src/hardware',
+    ]
+
+    matron_libs = [
+        'pthread',
+        'm',
+    ]
+
+    matron_use = [
+        'ALSA',
+        'LIBUDEV',
+        'LIBEVDEV',
+        'CAIRO',
+        'CAIRO-FT',
+        'LUA53',
+        'LIBLO',
+        'LIBMONOME',
+        'SNDFILE',
+        'AVAHI-COMPAT-LIBDNS_SD',
+        'JACK',
+    ]
+
+    if bld.env.NORNS_DESKTOP:
+        matron_libs.append('SDL2')
+        matron_use.append('SDL2')
+
+    if bld.env.ENABLE_ABLETON_LINK:
+        matron_sources += ['../matron/src/clocks/clock_link.cc']
+        matron_includes += ['../third-party/link-c']
+        matron_libs += ['stdc++']
+        matron_use += ['LIBLINK_C']
+
+    if bld.env.PROFILE_MATRON:
+        bld.env.append_unique('CXXFLAGS', ['-pg'])
+        bld.env.append_unique('LDFLAGS', ['-pg'])
+    
+    crone_includes=[
+        '../crone',
+        '../crone/src',
+        '../crone/softcut/softcut-lib/include',
+        '../crone/lib/readerwriterqueue'
+    ]
+
+    crone_use=[
+        'ALSA',
+        'LIBLO',
+    ]
+    
+    crone_libs=[
+        'atomic',
+        'jack',
+        'pthread',
+        'm',
+        'sndfile'
+    ]
+    
+    norns_sources = ["main.cpp"] + matron_sources + crone_sources
+    norns_includes = matron_includes + crone_includes
+    norns_use = matron_use +crone_use
+    norns_libs = matron_libs + crone_libs
+    
+    bld.program(features='c cprogram cxx cxxprogram',
+        target='norns',
+        source=norns_sources,
+        includes=norns_includes,
+        use=norns_use,
+        lib=norns_libs,
+        cxxflags=['-std=c++14', '-O3', '-Wall'],
+        ldflags=['-Wl,-export-dynamic'])

--- a/wscript
+++ b/wscript
@@ -57,6 +57,7 @@ def configure(conf):
     if conf.options.desktop:
         conf.check_cfg(package='sdl2', args=['--cflags', '--libs'])
         conf.define('NORNS_DESKTOP', True)
+        
     conf.env.NORNS_DESKTOP = conf.options.desktop
 
     conf.env.ENABLE_ABLETON_LINK = conf.options.enable_ableton_link
@@ -65,9 +66,10 @@ def configure(conf):
     conf.recurse('maiden-repl')
 
 def build(bld):
-    bld.recurse('matron')
+    #bld.recurse('matron')
     bld.recurse('maiden-repl')
     bld.recurse('ws-wrapper')
-    bld.recurse('crone')
+    #bld.recurse('crone')
     bld.recurse('third-party')
     bld.recurse('watcher')
+    bld.recurse('norns')


### PR DESCRIPTION
### motivation

combine processes, as described in PR #1479 

### solution

- add new target `norns/wscript`, combining sources from `matron/src` and `crone/src`, producing executable at `build/norns/norns`
- small necessary edits to component `main` sources / routines; otherwise sources are unmoved/unchanged

### status / issues

seems to mostly work, with a big caveat: connection to sclang is pretty well broken since the order of process dependencies no longer applies and it is not possible to launch `sclang` between `crone` and `matron`.

fixing this will require some changes to sclang classes (which will be subject of a future PR to v3) and of course to systemd service definitions (which are not in this repo.)