### PR TITLE
V3 wip/fix combined process

### DIFF
--- a/crone/src/MixerClient.cpp
+++ b/crone/src/MixerClient.cpp
@@ -207,7 +207,7 @@ MixerClient::SmoothLevelList::SmoothLevelList() {
     dac.setTarget(1.f);
     ext.setTarget(1.f);
     cut.setTarget(1.f);
-    monitor.setTarget(0.f);
+    monitor.setTarget(1.f);
     tape.setTarget(0.f);
     adc_cut.setTarget(0.f);
     ext_cut.setTarget(0.f);

--- a/crone/src/main.cpp
+++ b/crone/src/main.cpp
@@ -60,6 +60,13 @@ int crone_main() {
     OscInterface::init(m.get(), sc.get());
     OscInterface::printServerMethods();
 
+    return 0;
+}
+
+#if 0
+int main() {
+    crone_main();
+
     cout << "entering main loop..." << endl;
     while(!OscInterface::shouldQuit())  {
         sleep(100);
@@ -67,9 +74,5 @@ int crone_main() {
     
     crone_cleanup();
 
-    return 0;
-}
-
-#if 0
-int main() { crone_main(); }
+ }
 #endif

--- a/matron/src/matron_main.h
+++ b/matron/src/matron_main.h
@@ -2,5 +2,6 @@
 #define _MATRON_MAIN_H_
 
 int matron_main(int argc, char **argv);
+void matron_cleanup(void);
 
 #endif

--- a/norns/main.cpp
+++ b/norns/main.cpp
@@ -1,16 +1,29 @@
-#include <thread>
+    #include <thread>
 
-#include "matron_main.h"
-#include "crone_main.h"
+    #include "matron_main.h"
+    #include "crone_main.h"
 
-int main(int argc, char **argv) {
-    std::thread crone_thread(crone_main);
-
-    std::thread matron_thread([argc, argv]() { matron_main(argc, argv); });
+    #include "OscInterface.h"
 
 
-    matron_thread.join();
-    crone_cleanup();
-
-    return 0;
-}
+    int main(int argc, char **argv) {   
+        if(fork() != 0) {
+            // parent process
+            if(fork() != 0) {
+                // second fork: matron
+                matron_main(argc, argv);
+                matron_cleanup();
+            } else {
+                // nothing to do..
+                while (1) {;;}
+            }
+        } else { 
+            // first fork: crone
+            crone_main();
+            while (!crone::OscInterface::shouldQuit()) { 
+                std::this_thread::sleep_for(std::chrono::milliseconds(100));
+            }
+            crone_cleanup();
+        }
+        return 0;
+    }

--- a/sc/core/Crone.sc
+++ b/sc/core/Crone.sc
@@ -93,7 +93,7 @@ Crone {
 		complete = 1;
 
 		/// test..
-		{ SinOsc.ar([218,223]) * 0.125 * EnvGen.ar(Env.linen(2, 4, 6), doneAction:2) }.play(server);
+		{ SinOsc.ar([218,223]) * 0.125 * EnvGen.ar(Env.linen(2, 3, 6), doneAction:2) }.play(server);
 
 	}
 


### PR DESCRIPTION
### motivation

encountered a _fascinating_ performance issue:

- seems that posix `system()` and `popen()` routines perform a full fork of the parent process. this involves copying all thread states (?) including RT/audio threads, which apparently also requires halting the threads in question.

- both the C and lua layers of `matron` perform a lot of child process calls. after combining `matron` and `crone` processes, every one of these calls would halt the audio threads and cause underruns.

### solution

seems a little crazy, but seems to work: 

- fork the parent process immediately into 2 child processes, before any threads are created
- now when the `matron` process forks, only its own threads are affected; other child process is fine.

(NB: it didn't seem to be entirely effective to keep `crone` routines in the parent process / on the main thread.)

### status / issues

- could use cleanup. in particular, `norns/src/main.cpp` probably needs signal handlers and cleaner / more explicit management of  component lifcycles. 

- not entirely sure how smoothly it's going to go to actually make these child procs communicate without IPC.

- and i'm all ears in case anyone would like to correct my observations of the issue!

but it seems good enough to keep going on.