### PR TITLE
fix alt variable

### DIFF
--- a/lua/core/menu/select.lua
+++ b/lua/core/menu/select.lua
@@ -70,7 +70,7 @@ m.deinit = norns.none
 m.key = function(n,z)
   -- back
   if n == 1 then
-    alt = z == 1 and true or false
+    m.alt = z == 1 and true or false
   elseif n==2 and z==1 then
     _menu.set_page("HOME")
   -- select
@@ -95,7 +95,7 @@ end
 
 m.enc = function(n,delta)
   if n==2 then
-    delta = not alt and delta or delta*6
+    delta = not m.alt and delta or delta*6
     m.pos = util.clamp(m.pos + delta, 0, m.len - 1)
     _menu.redraw()
   elseif n==3 then


### PR DESCRIPTION
`alt` variable was not enclosed in the `m` table, which causes namespace collision with scripts which have `alt` in the script's scope.