### PR TITLE
V3 wip/replace lua calls

### DIFF
--- a/crone/src/Commands.cpp
+++ b/crone/src/Commands.cpp
@@ -37,8 +37,6 @@ void Commands::post(Commands::Id id, int i, int j, float f) {
 }
 
 void Commands::post(CommandPacket &p) {
-    
-	std::cerr << " posting a command packet: " << p.id << std::endl;
     bool ok = q.try_enqueue(p);
     if (!ok) {
 	    std::cerr << " warning: failed to post a command (queue full, most likely)" << std::endl;

--- a/crone/src/MixerClient.cpp
+++ b/crone/src/MixerClient.cpp
@@ -115,13 +115,11 @@ void MixerClient::processFx(size_t numFrames) {
 }
 
 void MixerClient::handleCommand(Commands::CommandPacket *p) {
-    std::cerr << "handling a command: " << p->id << std::endl;
     switch(p->id) {
         case Commands::Id::SET_LEVEL_ADC:
             smoothLevels.adc.setTarget(p->value);
             break;
         case Commands::Id::SET_LEVEL_DAC:
-            std::cerr << "handling DAC command (audio thread): " << p->value << std::endl;
             smoothLevels.dac.setTarget(p->value);
             break;
         case Commands::Id::SET_LEVEL_EXT:

--- a/lua/core/menu/params.lua
+++ b/lua/core/menu/params.lua
@@ -271,7 +271,7 @@ m.key = function(n,z)
         -- delete
       elseif m.ps_action == 3 then
         if pset[m.ps_pos+1] then
-          os.execute("rm "..pset[m.ps_pos+1].file)
+          _norns.execute("rm "..pset[m.ps_pos+1].file)
           init_pset()
         end
       end

--- a/lua/core/menu/reset.lua
+++ b/lua/core/menu/reset.lua
@@ -8,10 +8,10 @@ m.key = function(n,z)
   elseif n==3 and z==1 then
     m.confirmed = true
     _menu.redraw()
-    os.execute("rm ~/dust/data/system.pset")
-    os.execute("rm ~/dust/data/system.state")
-    os.execute("rm "..paths.favorites)
-    os.execute("rm "..paths.enabled_mods)
+    _norns.execute("rm ~/dust/data/system.pset")
+    _norns.execute("rm ~/dust/data/system.state")
+    _norns.execute("rm "..paths.favorites)
+    _norns.execute("rm "..paths.enabled_mods)
     _norns.reset()
   end
 end

--- a/lua/core/menu/system.lua
+++ b/lua/core/menu/system.lua
@@ -47,7 +47,7 @@ m.deinit = norns.none
 
 m.passdone = function(txt)
   if txt ~= nil then
-    local status = os.execute("echo 'we:"..txt.."' | sudo chpasswd")
+    local status = _norns.execute("echo 'we:"..txt.."' | sudo chpasswd")
     if status then print("password changed") end
   end
   _menu.set_page("SYSTEM")

--- a/lua/core/menu/tape.lua
+++ b/lua/core/menu/tape.lua
@@ -66,7 +66,7 @@ end
 local function write_tape_index_v(v)
   local f = io.open(_path.tape..'index.txt','w')
   if f == nil then
-    os.execute("mkdir -p ".._path.tape)
+    _norns.execute("mkdir -p ".._path.tape)
     f = io.open(_path.tape..'index.txt','w')
   end
   if f == nil then

--- a/lua/core/menu/update.lua
+++ b/lua/core/menu/update.lua
@@ -38,11 +38,11 @@ local function get_update()
   norns.script.clear()
   _menu.locked = true
   print("shutting down audio...")
-  --os.execute("sudo systemctl stop norns-jack.service") -- disable audio
-  os.execute("sudo systemctl stop norns-crone.service") -- disable audio
-  os.execute("sudo systemctl stop norns-sclang.service") -- disable audio
+  --_norns.execute("sudo systemctl stop norns-jack.service") -- disable audio
+  _norns.execute("sudo systemctl stop norns-crone.service") -- disable audio
+  _norns.execute("sudo systemctl stop norns-sclang.service") -- disable audio
   print("clearing old updates...")
-  os.execute("sudo rm -rf /home/we/update/*") -- clear old updates
+  _norns.execute("sudo rm -rf /home/we/update/*") -- clear old updates
   m.message = "downloading..."
   _menu.redraw()
   print("starting download...")
@@ -69,11 +69,11 @@ get_update_2 = function()
   local checksum = util.os_capture("cd /home/we/update; sha256sum -c /home/we/update/*.sha256 | grep OK")
   if checksum:match("OK") then
     print("unpacking...")
-    os.execute("tar xzvf /home/we/update/*.tgz -C /home/we/update/")
+    _norns.execute("tar xzvf /home/we/update/*.tgz -C /home/we/update/")
     m.message = "running update..."
     _menu.redraw()
     print("running update...")
-    os.execute("/home/we/update/"..releases[m.install].version.."/update.sh")
+    _norns.execute("/home/we/update/"..releases[m.install].version.."/update.sh")
     m.message = "done. any key to shut down."
     _menu.redraw()
     print("update complete.")
@@ -114,7 +114,7 @@ m.key = function(n,z)
     m.stage = "shutdown"
     print("shutting down.")
     _menu.redraw()
-    os.execute("sleep 0.5; sudo shutdown now")
+    _norns.execute("sleep 0.5; sudo shutdown now")
   end
 end
 

--- a/lua/core/norns.lua
+++ b/lua/core/norns.lua
@@ -186,7 +186,7 @@ norns.shutdown = function()
   pcall(cleanup)
   audio.level_dac(0)
   audio.headphone_gain(0)
-  os.execute("sleep 0.5; sudo shutdown now")
+  _norns.execute("sleep 0.5; sudo shutdown now")
 end
 
 -- platform detection
@@ -227,9 +227,9 @@ norns.system_glob = _norns.system_glob
 
 -- audio reset
 _norns.reset = function()
-  os.execute("sudo systemctl restart norns-sclang.service")
-  os.execute("sudo systemctl restart norns-crone.service")
-  os.execute("sudo systemctl restart norns-matron.service")
+  _norns.execute("sudo systemctl restart norns-sclang.service")
+  _norns.execute("sudo systemctl restart norns-crone.service")
+  _norns.execute("sudo systemctl restart norns-matron.service")
 end
 
 -- startup function will be run after I/O subsystems are initialized,

--- a/lua/core/script.lua
+++ b/lua/core/script.lua
@@ -172,7 +172,7 @@ Script.load = function(filename)
       print("### initializing data folder")
       util.make_dir(norns.state.data)
       if util.file_exists(norns.state.path.."/data") then
-        os.execute("cp "..norns.state.path.."/data/*.pset "..norns.state.data)
+        _norns.execute("cp "..norns.state.path.."/data/*.pset "..norns.state.data)
         print("### copied default psets")
       end
     end

--- a/lua/core/startup.lua
+++ b/lua/core/startup.lua
@@ -91,14 +91,14 @@ _norns.screen_save()
 -- reverse stereo for norns shield
 if util.file_exists(_path.home .. "/reverse.txt") then
   print("NORNS SHIELD: REVERSING STEREO")
-  os.execute("jack_disconnect 'crone:output_1' 'system:playback_1'")
-  os.execute("jack_disconnect 'crone:output_2' 'system:playback_2'")
-  os.execute("jack_connect 'crone:output_1' 'system:playback_2'")
-  os.execute("jack_connect 'crone:output_2' 'system:playback_1'")
-  os.execute("jack_disconnect 'system:capture_1' 'crone:input_1'")
-  os.execute("jack_disconnect 'system:capture_2' 'crone:input_2'")
-  os.execute("jack_connect 'system:capture_1' 'crone:input_2'")
-  os.execute("jack_connect 'system:capture_2' 'crone:input_1'")
+  _norns.execute("jack_disconnect 'crone:output_1' 'system:playback_1'")
+  _norns.execute("jack_disconnect 'crone:output_2' 'system:playback_2'")
+  _norns.execute("jack_connect 'crone:output_1' 'system:playback_2'")
+  _norns.execute("jack_connect 'crone:output_2' 'system:playback_1'")
+  _norns.execute("jack_disconnect 'system:capture_1' 'crone:input_1'")
+  _norns.execute("jack_disconnect 'system:capture_2' 'crone:input_2'")
+  _norns.execute("jack_connect 'system:capture_1' 'crone:input_2'")
+  _norns.execute("jack_connect 'system:capture_2' 'crone:input_1'")
 end
 
 print("start_audio(): ")

--- a/lua/core/wifi.lua
+++ b/lua/core/wifi.lua
@@ -185,14 +185,14 @@ end
 
 function Wifi.off()
   print("do wifi off")
-  os.execute("nmcli radio wifi off")
+  _norns.execute("nmcli radio wifi off")
 end
 
 function Wifi.hotspot()
   print("activating hotspot")
   Wifi.ensure_radio_is_on()
-  os.execute("nmcli c delete Hotspot")
-  os.execute("nmcli dev wifi hotspot ifname wlan0 ssid $(hostname) password " .. hotspot_password)
+  _norns.execute("nmcli c delete Hotspot")
+  _norns.execute("nmcli dev wifi hotspot ifname wlan0 ssid $(hostname) password " .. hotspot_password)
 end
 
 function Wifi.on(connection)
@@ -207,7 +207,7 @@ function Wifi.on(connection)
     print("enabling connection: '" .. connection .. "'")
     Wifi.ensure_radio_is_on()
     -- change connection in bg to allow ui to update
-    os.execute("nmcli --wait 2 connection up id '" .. connection .. "' &")
+    _norns.execute("nmcli --wait 2 connection up id '" .. connection .. "' &")
   end
 end
 
@@ -254,8 +254,8 @@ end
 
 function Wifi.ensure_radio_is_on()
   if Wifi.radio_state() ~= "enabled" then
-    os.execute("nmcli radio wifi on")
-    os.execute("sleep 1.5")  -- various operations fail if called right after radio on
+    _norns.execute("nmcli radio wifi on")
+    _norns.execute("sleep 1.5")  -- various operations fail if called right after radio on
   end
 end
 
@@ -265,10 +265,10 @@ function Wifi.add(ssid, psk)
   local cmd = "nmcli --wait 10 device wifi connect"
   cmd = cmd .. " '" .. ssid .. "' password '" .. psk .. "'"
   cmd = cmd .. " ifname " .. Wifi.device.name
-  os.execute(cmd)
+  _norns.execute(cmd)
   -- dis-associate connection profile from hardware MAC address
   cmd = "nmcli con mod '" .. ssid .. "' -802-11-wireless.mac-address ''"
-  os.execute(cmd)
+  _norns.execute(cmd)
   -- ensure connection list is up to date
   Wifi.conn_list = Wifi.connections()
 end
@@ -276,7 +276,7 @@ end
 function Wifi.delete(name)
   -- FIXME: do we need to turn off radio if name == active_connection?
   print("deleting wifi network: " .. name)
-  os.execute("nmcli connection delete id '" .. name .. "'")
+  _norns.execute("nmcli connection delete id '" .. name .. "'")
   -- ensure connection list is up to date
   Wifi.conn_list = Wifi.connections()
 end

--- a/lua/lib/util.lua
+++ b/lua/lib/util.lua
@@ -79,9 +79,10 @@ end
 -- @param raw raw output (omit for scrubbed)
 -- @return output
 util.os_capture = function(cmd, raw)
-  local f = assert(io.popen(cmd, 'r'))
-  local s = assert(f:read('*a'))
-  f:close()
+  -- local f = assert(io.popen(cmd, 'r'))
+  -- local s = assert(f:read('*a'))
+  -- f:close()
+  local s = _norns.execute(cmd)
   if raw then return s end
   s = string.gsub(s, '^%s+', '')
   s = string.gsub(s, '%s+$', '')

--- a/lua/lib/util.lua
+++ b/lua/lib/util.lua
@@ -23,16 +23,12 @@ end
 -- @tparam string directory path to directory
 -- @treturn table
 util.scandir = function(directory)
-  --local i, t, popen = 0, {}, io.popen
   local i, t = 0, {}
-  --local pfile = popen('ls -pL --group-directories-first "'..directory..'"')
   local text = _norns.execute('ls -pL --group-directories-first "'..directory..'"')
-  --for filename in pfile:lines() do
     for filename in text:gmatch("[^\r\n]+") do
     i = i + 1
     t[i] = filename
   end
-  --pfile:close()
   return t
 end
 
@@ -79,9 +75,6 @@ end
 -- @param raw raw output (omit for scrubbed)
 -- @return output
 util.os_capture = function(cmd, raw)
-  -- local f = assert(io.popen(cmd, 'r'))
-  -- local s = assert(f:read('*a'))
-  -- f:close()
   local s = _norns.execute(cmd)
   if raw then return s end
   s = string.gsub(s, '^%s+', '')

--- a/lua/lib/util.lua
+++ b/lua/lib/util.lua
@@ -67,7 +67,7 @@ end
 --- make directory (with parents as needed).
 -- @tparam string path
 util.make_dir = function(path)
-  os.execute("mkdir -p " .. path)
+  _norns.execute("mkdir -p " .. path)
 end
 
 

--- a/lua/lib/util.lua
+++ b/lua/lib/util.lua
@@ -23,13 +23,16 @@ end
 -- @tparam string directory path to directory
 -- @treturn table
 util.scandir = function(directory)
-  local i, t, popen = 0, {}, io.popen
-  local pfile = popen('ls -pL --group-directories-first "'..directory..'"')
-  for filename in pfile:lines() do
+  --local i, t, popen = 0, {}, io.popen
+  local i, t = 0, {}
+  --local pfile = popen('ls -pL --group-directories-first "'..directory..'"')
+  local text = _norns.execute('ls -pL --group-directories-first "'..directory..'"')
+  --for filename in pfile:lines() do
+    for filename in text:gmatch("[^\r\n]+") do
     i = i + 1
     t[i] = filename
   end
-  pfile:close()
+  --pfile:close()
   return t
 end
 

--- a/matron/src/weaver.cc
+++ b/matron/src/weaver.cc
@@ -42,6 +42,7 @@
 #include "osc.h"
 #include "platform.h"
 #include "screen.h"
+#include "sidecar.h"
 #include "snd_file.h"
 #include "system_cmd.h"
 #include "weaver.h"
@@ -69,7 +70,7 @@ void w_handle_exec_code_line(char *line) {
 //--- declare lua->c glue
 
 // NB these static functions are prefixed  with '_'
-// to avoid shadowing similar-named extern functions in other moduels (like
+// to avoid shadowing similar-named extern functions in other modules (like
 // screen)
 // and also to distinguish from extern 'w_' functions.
 
@@ -142,6 +143,7 @@ static int _start_poll(lua_State *l);
 static int _stop_poll(lua_State *l);
 static int _set_poll_time(lua_State *l);
 static int _request_poll_value(lua_State *l);
+
 // timing
 static int _metro_start(lua_State *l);
 static int _metro_stop(lua_State *l);
@@ -228,8 +230,11 @@ static int _restart_audio(lua_State *l);
 static int _sound_file_inspect(lua_State *l);
 
 // util
+/// run command in child process asynchronously (with callback)
 static int _system_cmd(lua_State *l);
 static int _system_glob(lua_State *l);
+/// run command in child process, blocking (replaces `os.execute`)
+static int _execute(lua_State *l);
 
 // reset LVM
 static int _reset_lvm(lua_State *l);
@@ -353,6 +358,7 @@ void w_init(void) {
     // util
     lua_register_norns("system_cmd", &_system_cmd);
     lua_register_norns("system_glob", &_system_glob);
+    lua_register_norns("execute", &_execute);
 
     // low-level monome grid control
     lua_register_norns("grid_set_led", &_grid_set_led);
@@ -2656,6 +2662,18 @@ int _system_glob(lua_State *l) {
     globfree(&g);
     return 1;
 }
+
+int _execute(lua_State *l) {
+    lua_check_num_args(1);
+    const char *cmd = luaL_checkstring(l, 1);
+    char *buf = NULL;
+    size_t size;
+    sidecar_client_cmd(&buf, &size, cmd);
+    lua_pushstring(l, buf);
+    free(buf);
+    return 0;
+}
+
 
 int _platform(lua_State *l) {
     lua_check_num_args(0);


### PR DESCRIPTION
added new FFI function `_norns.execute` that calls `sidecar_client_cmd` and returns directly to lua.

replaced all calls to `os.execute` and `io.popen` in lua `core/` and `lib/`

so far, seems to have fixed all remaining xruns for me. 