### PR TITLE
V3 wip/replace osc hack

### DIFF
--- a/crone/src/Commands.h
+++ b/crone/src/Commands.h
@@ -9,126 +9,124 @@
 
 namespace crone {
 
-class MixerClient;
-class SoftcutClient;
+    class MixerClient;
+    class SoftcutClient;
 
-class Commands {
- public:
-  static constexpr int COMMAND_Q_CAPACITY = 256;
-  typedef enum {
-    //-- level commands
-    SET_LEVEL_ADC,
-    SET_LEVEL_DAC,
-    SET_LEVEL_EXT,
-    SET_LEVEL_EXT_AUX,
-    SET_LEVEL_CUT_MASTER,
-    SET_LEVEL_AUX_DAC,
-    SET_LEVEL_MONITOR,
-    SET_LEVEL_MONITOR_MIX,
-    SET_LEVEL_MONITOR_AUX,
-    SET_LEVEL_INS_MIX,
+    class Commands {	
+    public:
+	static constexpr int COMMAND_Q_CAPACITY = 256;
+        typedef enum {
+            //-- level commands
+            SET_LEVEL_ADC,
+            SET_LEVEL_DAC,
+            SET_LEVEL_EXT,
+            SET_LEVEL_EXT_AUX,
+	    SET_LEVEL_CUT_MASTER,
+            SET_LEVEL_AUX_DAC,
+            SET_LEVEL_MONITOR,
+            SET_LEVEL_MONITOR_MIX,
+            SET_LEVEL_MONITOR_AUX,
+            SET_LEVEL_INS_MIX,
 
-    SET_PARAM_REVERB,
-    SET_PARAM_COMPRESSOR,
+            SET_PARAM_REVERB,
+            SET_PARAM_COMPRESSOR,
 
-    SET_ENABLED_REVERB,
-    SET_ENABLED_COMPRESSOR,
+            SET_ENABLED_REVERB,
+            SET_ENABLED_COMPRESSOR,
 
-    // level of stereo ext out -> stereo cut in
-    SET_LEVEL_EXT_CUT,
-    // level of stereo ADC out -> stereo cut in
-    SET_LEVEL_ADC_CUT,
+            // level of stereo ext out -> stereo cut in
+            SET_LEVEL_EXT_CUT,
+            // level of stereo ADC out -> stereo cut in
+            SET_LEVEL_ADC_CUT,
 
-    //-- softcut commands
+            //-- softcut commands
 
-    // mix
-    SET_ENABLED_CUT,
-    SET_LEVEL_CUT,
-    SET_PAN_CUT,
-    SET_LEVEL_CUT_AUX,
-    SET_LEVEL_IN_CUT,
-    SET_LEVEL_CUT_CUT,
-    SET_LEVEL_TAPE,
-    SET_LEVEL_TAPE_AUX,
-    SET_LEVEL_TAPE_CUT,
+            // mix
+            SET_ENABLED_CUT,
+            SET_LEVEL_CUT,
+            SET_PAN_CUT,
+            SET_LEVEL_CUT_AUX,
+            // level of individual input channel -> cut voice
+            // (separate commands just to avoid a 3rd parameter)
+            SET_LEVEL_IN_CUT,
+            SET_LEVEL_CUT_CUT,
+            SET_LEVEL_TAPE,
+            SET_LEVEL_TAPE_AUX,
+            SET_LEVEL_TAPE_CUT,
 
-    // params
-    SET_CUT_REC_FLAG,
-    SET_CUT_PLAY_FLAG,
+            // params
+            SET_CUT_REC_FLAG,
+            SET_CUT_PLAY_FLAG,
 
-    SET_CUT_RATE,
-    SET_CUT_LOOP_START,
-    SET_CUT_LOOP_END,
-    SET_CUT_LOOP_FLAG,
-    SET_CUT_POSITION,
+            SET_CUT_RATE,
+            SET_CUT_LOOP_START,
+            SET_CUT_LOOP_END,
+            SET_CUT_LOOP_FLAG,
+            SET_CUT_POSITION,
 
-    SET_CUT_FADE_TIME,
-    SET_CUT_REC_LEVEL,
-    SET_CUT_PRE_LEVEL,
-    SET_CUT_REC_OFFSET,
+            SET_CUT_FADE_TIME,
+            SET_CUT_REC_LEVEL,
+            SET_CUT_PRE_LEVEL,
+            SET_CUT_REC_OFFSET,
 
-    SET_CUT_PRE_FILTER_FC,
-    SET_CUT_PRE_FILTER_FC_MOD,
-    SET_CUT_PRE_FILTER_RQ,
-    SET_CUT_PRE_FILTER_LP,
-    SET_CUT_PRE_FILTER_HP,
-    SET_CUT_PRE_FILTER_BP,
-    SET_CUT_PRE_FILTER_BR,
-    SET_CUT_PRE_FILTER_DRY,
+            SET_CUT_PRE_FILTER_FC,
+            SET_CUT_PRE_FILTER_FC_MOD,
+            SET_CUT_PRE_FILTER_RQ,
+            SET_CUT_PRE_FILTER_LP,
+            SET_CUT_PRE_FILTER_HP,
+            SET_CUT_PRE_FILTER_BP,
+            SET_CUT_PRE_FILTER_BR,
+            SET_CUT_PRE_FILTER_DRY,
 
-    SET_CUT_POST_FILTER_FC,
-    SET_CUT_POST_FILTER_RQ,
-    SET_CUT_POST_FILTER_LP,
-    SET_CUT_POST_FILTER_HP,
-    SET_CUT_POST_FILTER_BP,
-    SET_CUT_POST_FILTER_BR,
-    SET_CUT_POST_FILTER_DRY,
+	    SET_CUT_POST_FILTER_FC,
+	    SET_CUT_POST_FILTER_RQ,
+            SET_CUT_POST_FILTER_LP,
+            SET_CUT_POST_FILTER_HP,
+            SET_CUT_POST_FILTER_BP,
+            SET_CUT_POST_FILTER_BR,
+            SET_CUT_POST_FILTER_DRY,
 
-    SET_CUT_LEVEL_SLEW_TIME,
-    SET_CUT_PAN_SLEW_TIME,
-    SET_CUT_RECPRE_SLEW_TIME,
-    SET_CUT_RATE_SLEW_TIME,
-    SET_CUT_VOICE_SYNC,
-    SET_CUT_BUFFER,
-    
-    NUM_COMMANDS,
-  } Id;
+            SET_CUT_LEVEL_SLEW_TIME,
+            SET_CUT_PAN_SLEW_TIME,
+            SET_CUT_RECPRE_SLEW_TIME,
+            SET_CUT_RATE_SLEW_TIME,
+            SET_CUT_VOICE_SYNC,
+            SET_CUT_BUFFER,
+            NUM_COMMANDS,
+        } Id;
 
- public:
-  Commands();
+    public:
+        Commands();
+	
+        struct CommandPacket {
+            CommandPacket() = default;
+            CommandPacket(Commands::Id i, int i0,  float f) : id(i), idx_0(i0), idx_1(-1), value(f) {}
+            CommandPacket(Commands::Id i, int i0, int i1) : id(i), idx_0(i0), idx_1(i1) {}
+            CommandPacket(Commands::Id i, int i0, int i1, float f) : id(i), idx_0(i0), idx_1(i1), value(f) {}
+            Id id;
+            int idx_0;
+            int idx_1;
+            float value;
+        };
+	
+	void post(CommandPacket& p);
+        void post(Commands::Id id, float f);
+        void post(Commands::Id id, int i, float f);
+        void post(Commands::Id id, int i, int j);
+        void post(Commands::Id id, int i, int j, float f);
 
-  struct CommandPacket {
-    CommandPacket() = default;
-    CommandPacket(Commands::Id i, int i0, float f)
-        : id(i), idx_0(i0), idx_1(-1), value(f) {}
-    CommandPacket(Commands::Id i, int i0, int i1)
-        : id(i), idx_0(i0), idx_1(i1) {}
-    CommandPacket(Commands::Id i, int i0, int i1, float f)
-        : id(i), idx_0(i0), idx_1(i1), value(f) {}
-    Id id;
-    int idx_0;
-    int idx_1;
-    float value;
-  };
+        // FIXME: i guess things would be cleaner with a non-templated Client base/interface class
+        void handlePending(MixerClient *client);
+        void handlePending(SoftcutClient *client);
 
-  void post(CommandPacket &p);
-  void post(Commands::Id id, float f);
-  void post(Commands::Id id, int i, float f);
-  void post(Commands::Id id, int i, int j);
-  void post(Commands::Id id, int i, int j, float f);
+        static Commands mixerCommands;
+        static Commands softcutCommands;
 
-  // FIXME: i guess things would be cleaner with a non-templated Client
-  // base/interface class
-  void handlePending(MixerClient *client);
-  void handlePending(SoftcutClient *client);
+    private:
 
-  static Commands mixerCommands;
-  static Commands softcutCommands;
+    	moodycamel::ReaderWriterQueue<CommandPacket> q;
+    };
 
- private:
-  moodycamel::ReaderWriterQueue<CommandPacket> q;
-};
+}
 
-}  // namespace crone
-
-#endif  // CRONE_COMMANDS_H
+#endif //CRONE_COMMANDS_H

--- a/crone/src/Commands.h
+++ b/crone/src/Commands.h
@@ -9,124 +9,126 @@
 
 namespace crone {
 
-    class MixerClient;
-    class SoftcutClient;
+class MixerClient;
+class SoftcutClient;
 
-    class Commands {	
-    public:
-	static constexpr int COMMAND_Q_CAPACITY = 256;
-        typedef enum {
-            //-- level commands
-            SET_LEVEL_ADC,
-            SET_LEVEL_DAC,
-            SET_LEVEL_EXT,
-            SET_LEVEL_EXT_AUX,
-	    SET_LEVEL_CUT_MASTER,
-            SET_LEVEL_AUX_DAC,
-            SET_LEVEL_MONITOR,
-            SET_LEVEL_MONITOR_MIX,
-            SET_LEVEL_MONITOR_AUX,
-            SET_LEVEL_INS_MIX,
+class Commands {
+ public:
+  static constexpr int COMMAND_Q_CAPACITY = 256;
+  typedef enum {
+    //-- level commands
+    SET_LEVEL_ADC,
+    SET_LEVEL_DAC,
+    SET_LEVEL_EXT,
+    SET_LEVEL_EXT_AUX,
+    SET_LEVEL_CUT_MASTER,
+    SET_LEVEL_AUX_DAC,
+    SET_LEVEL_MONITOR,
+    SET_LEVEL_MONITOR_MIX,
+    SET_LEVEL_MONITOR_AUX,
+    SET_LEVEL_INS_MIX,
 
-            SET_PARAM_REVERB,
-            SET_PARAM_COMPRESSOR,
+    SET_PARAM_REVERB,
+    SET_PARAM_COMPRESSOR,
 
-            SET_ENABLED_REVERB,
-            SET_ENABLED_COMPRESSOR,
+    SET_ENABLED_REVERB,
+    SET_ENABLED_COMPRESSOR,
 
-            // level of stereo ext out -> stereo cut in
-            SET_LEVEL_EXT_CUT,
-            // level of stereo ADC out -> stereo cut in
-            SET_LEVEL_ADC_CUT,
+    // level of stereo ext out -> stereo cut in
+    SET_LEVEL_EXT_CUT,
+    // level of stereo ADC out -> stereo cut in
+    SET_LEVEL_ADC_CUT,
 
-            //-- softcut commands
+    //-- softcut commands
 
-            // mix
-            SET_ENABLED_CUT,
-            SET_LEVEL_CUT,
-            SET_PAN_CUT,
-            SET_LEVEL_CUT_AUX,
-            // level of individual input channel -> cut voice
-            // (separate commands just to avoid a 3rd parameter)
-            SET_LEVEL_IN_CUT,
-            SET_LEVEL_CUT_CUT,
-            SET_LEVEL_TAPE,
-            SET_LEVEL_TAPE_AUX,
-            SET_LEVEL_TAPE_CUT,
+    // mix
+    SET_ENABLED_CUT,
+    SET_LEVEL_CUT,
+    SET_PAN_CUT,
+    SET_LEVEL_CUT_AUX,
+    SET_LEVEL_IN_CUT,
+    SET_LEVEL_CUT_CUT,
+    SET_LEVEL_TAPE,
+    SET_LEVEL_TAPE_AUX,
+    SET_LEVEL_TAPE_CUT,
 
-            // params
-            SET_CUT_REC_FLAG,
-            SET_CUT_PLAY_FLAG,
+    // params
+    SET_CUT_REC_FLAG,
+    SET_CUT_PLAY_FLAG,
 
-            SET_CUT_RATE,
-            SET_CUT_LOOP_START,
-            SET_CUT_LOOP_END,
-            SET_CUT_LOOP_FLAG,
-            SET_CUT_POSITION,
+    SET_CUT_RATE,
+    SET_CUT_LOOP_START,
+    SET_CUT_LOOP_END,
+    SET_CUT_LOOP_FLAG,
+    SET_CUT_POSITION,
 
-            SET_CUT_FADE_TIME,
-            SET_CUT_REC_LEVEL,
-            SET_CUT_PRE_LEVEL,
-            SET_CUT_REC_OFFSET,
+    SET_CUT_FADE_TIME,
+    SET_CUT_REC_LEVEL,
+    SET_CUT_PRE_LEVEL,
+    SET_CUT_REC_OFFSET,
 
-            SET_CUT_PRE_FILTER_FC,
-            SET_CUT_PRE_FILTER_FC_MOD,
-            SET_CUT_PRE_FILTER_RQ,
-            SET_CUT_PRE_FILTER_LP,
-            SET_CUT_PRE_FILTER_HP,
-            SET_CUT_PRE_FILTER_BP,
-            SET_CUT_PRE_FILTER_BR,
-            SET_CUT_PRE_FILTER_DRY,
+    SET_CUT_PRE_FILTER_FC,
+    SET_CUT_PRE_FILTER_FC_MOD,
+    SET_CUT_PRE_FILTER_RQ,
+    SET_CUT_PRE_FILTER_LP,
+    SET_CUT_PRE_FILTER_HP,
+    SET_CUT_PRE_FILTER_BP,
+    SET_CUT_PRE_FILTER_BR,
+    SET_CUT_PRE_FILTER_DRY,
 
-	    SET_CUT_POST_FILTER_FC,
-	    SET_CUT_POST_FILTER_RQ,
-            SET_CUT_POST_FILTER_LP,
-            SET_CUT_POST_FILTER_HP,
-            SET_CUT_POST_FILTER_BP,
-            SET_CUT_POST_FILTER_BR,
-            SET_CUT_POST_FILTER_DRY,
+    SET_CUT_POST_FILTER_FC,
+    SET_CUT_POST_FILTER_RQ,
+    SET_CUT_POST_FILTER_LP,
+    SET_CUT_POST_FILTER_HP,
+    SET_CUT_POST_FILTER_BP,
+    SET_CUT_POST_FILTER_BR,
+    SET_CUT_POST_FILTER_DRY,
 
-            SET_CUT_LEVEL_SLEW_TIME,
-            SET_CUT_PAN_SLEW_TIME,
-            SET_CUT_RECPRE_SLEW_TIME,
-            SET_CUT_RATE_SLEW_TIME,
-            SET_CUT_VOICE_SYNC,
-            SET_CUT_BUFFER,
-            NUM_COMMANDS,
-        } Id;
+    SET_CUT_LEVEL_SLEW_TIME,
+    SET_CUT_PAN_SLEW_TIME,
+    SET_CUT_RECPRE_SLEW_TIME,
+    SET_CUT_RATE_SLEW_TIME,
+    SET_CUT_VOICE_SYNC,
+    SET_CUT_BUFFER,
+    
+    NUM_COMMANDS,
+  } Id;
 
-    public:
-        Commands();
-	
-        struct CommandPacket {
-            CommandPacket() = default;
-            CommandPacket(Commands::Id i, int i0,  float f) : id(i), idx_0(i0), idx_1(-1), value(f) {}
-            CommandPacket(Commands::Id i, int i0, int i1) : id(i), idx_0(i0), idx_1(i1) {}
-            CommandPacket(Commands::Id i, int i0, int i1, float f) : id(i), idx_0(i0), idx_1(i1), value(f) {}
-            Id id;
-            int idx_0;
-            int idx_1;
-            float value;
-        };
-	
-	void post(CommandPacket& p);
-        void post(Commands::Id id, float f);
-        void post(Commands::Id id, int i, float f);
-        void post(Commands::Id id, int i, int j);
-        void post(Commands::Id id, int i, int j, float f);
+ public:
+  Commands();
 
-        // FIXME: i guess things would be cleaner with a non-templated Client base/interface class
-        void handlePending(MixerClient *client);
-        void handlePending(SoftcutClient *client);
+  struct CommandPacket {
+    CommandPacket() = default;
+    CommandPacket(Commands::Id i, int i0, float f)
+        : id(i), idx_0(i0), idx_1(-1), value(f) {}
+    CommandPacket(Commands::Id i, int i0, int i1)
+        : id(i), idx_0(i0), idx_1(i1) {}
+    CommandPacket(Commands::Id i, int i0, int i1, float f)
+        : id(i), idx_0(i0), idx_1(i1), value(f) {}
+    Id id;
+    int idx_0;
+    int idx_1;
+    float value;
+  };
 
-        static Commands mixerCommands;
-        static Commands softcutCommands;
+  void post(CommandPacket &p);
+  void post(Commands::Id id, float f);
+  void post(Commands::Id id, int i, float f);
+  void post(Commands::Id id, int i, int j);
+  void post(Commands::Id id, int i, int j, float f);
 
-    private:
+  // FIXME: i guess things would be cleaner with a non-templated Client
+  // base/interface class
+  void handlePending(MixerClient *client);
+  void handlePending(SoftcutClient *client);
 
-    	moodycamel::ReaderWriterQueue<CommandPacket> q;
-    };
+  static Commands mixerCommands;
+  static Commands softcutCommands;
 
-}
+ private:
+  moodycamel::ReaderWriterQueue<CommandPacket> q;
+};
 
-#endif //CRONE_COMMANDS_H
+}  // namespace crone
+
+#endif  // CRONE_COMMANDS_H

--- a/crone/src/MixerClient.h
+++ b/crone/src/MixerClient.h
@@ -16,7 +16,6 @@
 #include "effects/StereoCompressor.h"
 #include "effects/ZitaReverb.h"
 
-
 namespace  crone {
     class MixerClient: public Client<6, 6> {
 

--- a/crone/src/crone.h
+++ b/crone/src/crone.h
@@ -353,7 +353,7 @@ void crone_set_param_cut_buffer(int arg0, int arg1) {
   crone::Commands::softcutCommands.post(crone::Commands::Id::SET_CUT_BUFFER, arg0, arg1);
 }
 
-void crone_softcut_buffer_read_mono(const char *arg0, float arg1, float arg2,
+void crone_cut_buffer_read_mono(const char *arg0, float arg1, float arg2,
                                     float arg3, int arg4, int arg5, float arg6,
                                     float arg7) {
 
@@ -369,7 +369,7 @@ void crone_softcut_buffer_read_mono(const char *arg0, float arg1, float arg2,
                                 preserve, mix);
 }
 
-void crone_softcut_buffer_read_stereo(const char *arg0, float arg1, float arg2,
+void crone_cut_buffer_read_stereo(const char *arg0, float arg1, float arg2,
                                       float arg3, float arg4, float arg5) {
                                         // FIXME: defaults
 // FIXME: default args
@@ -382,7 +382,7 @@ void crone_softcut_buffer_read_stereo(const char *arg0, float arg1, float arg2,
   softCutClient->readBufferStereo(str, startSrc, startDst, dur, preserve, mix);
 }
 
-void crone_softcut_buffer_write_mono(const char *arg0, float arg1, float arg2,
+void crone_cut_buffer_write_mono(const char *arg0, float arg1, float arg2,
                                      int arg3) {
   // FIXME: defaults  
   float start = 0.f;
@@ -392,7 +392,7 @@ void crone_softcut_buffer_write_mono(const char *arg0, float arg1, float arg2,
   softCutClient->writeBufferMono(str, start, dur, chan);
 }
 
-void crone_softcut_buffer_write_stereo(const char *arg0, float arg1,
+void crone_cut_buffer_write_stereo(const char *arg0, float arg1,
                                        float arg2) {
   
   // FIXME: default args
@@ -403,26 +403,26 @@ void crone_softcut_buffer_write_stereo(const char *arg0, float arg1,
   softCutClient->writeBufferStereo(str, start, dur);
 }
 
-void crone_softcut_buffer_clear() {
+void crone_cut_buffer_clear() {
   softCutClient->clearBuffer(0);
   softCutClient->clearBuffer(1);
 }
 
-void crone_softcut_buffer_clear_channel(int arg0) {
+void crone_cut_buffer_clear_channel(int arg0) {
   softCutClient->clearBuffer(arg0);
 }
 
-void crone_softcut_buffer_clear_region(float arg0, float arg1) {
-  softCutClient->clearBuffer(0, arg0, arg1);
-  softCutClient->clearBuffer(1, arg0, arg1);
+void crone_cut_buffer_clear_region(float start, float dur, float fade_time, float preserve) {
+  softCutClient->clearBuffer(0, start, dur, fade_time, preserve);
+  softCutClient->clearBuffer(1, dur, fade_time, preserve);
 }
 
-void crone_softcut_buffer_clear_region_channel(int arg0, float arg1,
+void crone_cut_buffer_clear_region_channel(int arg0, float arg1,
                                                float arg2) {
   softCutClient->clearBuffer(arg0, arg1, arg2);
 }
 
-void crone_softcut_buffer_clear_fade_region(float arg0, float arg1, float arg2,
+void crone_cut_buffer_clear_fade_region(float arg0, float arg1, float arg2,
                                             float arg3) {
                                             
   // FIXME: default args
@@ -433,7 +433,7 @@ void crone_softcut_buffer_clear_fade_region(float arg0, float arg1, float arg2,
   softCutClient->clearBufferWithFade(1, arg0, dur, fadeTime, preserve);
 }
 
-void crone_softcut_buffer_clear_fade_region_channel(int arg0, float arg1,
+void crone_cut_buffer_clear_fade_region_channel(int arg0, float arg1,
                                                     float arg2, float arg3,
                                                     float arg4) {
   // FIXME: default args
@@ -443,7 +443,7 @@ void crone_softcut_buffer_clear_fade_region_channel(int arg0, float arg1,
   softCutClient->clearBufferWithFade(arg0, arg1, dur, fadeTime, preserve);
 }
 
-void crone_softcut_buffer_copy_mono(int arg0, int arg1, float arg2, float arg3,
+void crone_cut_buffer_copy_mono(int arg0, int arg1, float arg2, float arg3,
                                     float arg4, float arg5, float arg6,
                                     int arg7) {
   // FIXME: default args
@@ -456,7 +456,7 @@ void crone_softcut_buffer_copy_mono(int arg0, int arg1, float arg2, float arg3,
                             reverse);
 }
 
-void crone_softcut_buffer_copy_stereo(float arg0, float arg1, float arg2,
+void crone_cut_buffer_copy_stereo(float arg0, float arg1, float arg2,
                                       float arg3, float arg4, int arg5) {
   // FIXME: default args
   float dur = -1.f;
@@ -468,7 +468,7 @@ void crone_softcut_buffer_copy_stereo(float arg0, float arg1, float arg2,
   softCutClient->copyBuffer(1, 1, arg0, arg1, dur, fadeTime, preserve, reverse);
 }
 
-void crone_softcut_buffer_render(int arg0, float arg1, float arg2, int arg3) {
+void crone_cut_buffer_render(int arg0, float arg1, float arg2, int arg3) {
   int sampleCt = 128;
   int ch = arg0;
 
@@ -482,7 +482,7 @@ void crone_softcut_buffer_render(int arg0, float arg1, float arg2, int arg3) {
       });
 }
 
-void crone_softcut_query_position(int arg0) {
+void crone_cut_query_position(int arg0) {
   int idx = arg0;
   float pos = softCutClient->getPosition(idx);
   (void)pos;
@@ -490,7 +490,7 @@ void crone_softcut_query_position(int arg0) {
   // lo_send(matronAddress, "/poll/softcut/position", "if", idx, pos);
 }
 
-void crone_softcut_reset() {
+void crone_cut_reset() {
 
   softCutClient->clearBuffer(0, 0, -1);
   softCutClient->clearBuffer(1, 0, -1);
@@ -515,14 +515,13 @@ void crone_poll_start_cut_phase() { phasePoll->start(); }
 
 void crone_poll_stop_cut_phase() { phasePoll->stop(); }
 
-void crone_tape_record_open(const char *arg0) {
-
+void crone_tape_rec_open(const char *arg0) {
   mixerClient->openTapeRecord(arg0);
 }
 
-void crone_tape_record_start() { mixerClient->startTapeRecord(); }
+void crone_tape_rec_start() { mixerClient->startTapeRecord(); }
 
-void crone_tape_record_stop() { mixerClient->stopTapeRecord(); }
+void crone_tape_rec_stop() { mixerClient->stopTapeRecord(); }
 
 void crone_tape_play_open(const char *arg0) {
 

--- a/crone/src/crone.h
+++ b/crone/src/crone.h
@@ -12,533 +12,403 @@
 #include "effects/ReverbParams.h"
 #include "softcut/FadeCurves.h"
 
-// FIXME: need static references to polls, clients
-crone::MixerClient *mixerClient;
-crone::SoftcutClient *softCutClient;
-Poll *vuPoll;
-Poll *phasePoll;
+void crone_init(crone::MixerClient *mixerClient,
+                crone::SoftcutClient *softCutClient);
 
-void crone_poll_start_vu() { vuPoll->start(); }
-void crone_poll_stop_vu() { vuPoll->stop(); }
+void crone_poll_start_vu();
 
-void crone_set_level_adc(float arg0) {
+void crone_poll_stop_vu();
+
+inline void crone_set_level_adc(float arg0) {
   crone::Commands::mixerCommands.post(crone::Commands::Id::SET_LEVEL_ADC, arg0);
 }
 
-void crone_set_level_dac(float arg0) {
+inline void crone_set_level_dac(float arg0) {
   std::cerr << "crone_set_level_dac(" << arg0 << ")" << std::endl;
   std::cerr << "&mixerCommands: " << std::hex
             << &(crone::Commands::mixerCommands) << std::endl;
   crone::Commands::mixerCommands.post(crone::Commands::Id::SET_LEVEL_DAC, arg0);
 }
 
-void crone_set_level_ext(float arg0) {
+inline void crone_set_level_ext(float arg0) {
   crone::Commands::mixerCommands.post(crone::Commands::Id::SET_LEVEL_EXT, arg0);
 }
 
-void crone_set_level_cut_master(float arg0) {
+inline void crone_set_level_cut_master(float arg0) {
   crone::Commands::mixerCommands.post(crone::Commands::Id::SET_LEVEL_CUT_MASTER,
                                       arg0);
 }
 
-void crone_set_level_ext_rev(float arg0) {
+inline void crone_set_level_ext_rev(float arg0) {
   crone::Commands::mixerCommands.post(crone::Commands::Id::SET_LEVEL_EXT_AUX,
                                       arg0);
 }
 
-void crone_set_level_rev_dac(float arg0) {
+inline void crone_set_level_rev_dac(float arg0) {
   crone::Commands::mixerCommands.post(crone::Commands::Id::SET_LEVEL_AUX_DAC,
                                       arg0);
 }
 
-void crone_set_level_monitor(float arg0) {
+inline void crone_set_level_monitor(float arg0) {
   crone::Commands::mixerCommands.post(crone::Commands::Id::SET_LEVEL_MONITOR,
                                       arg0);
 }
 
-void crone_set_level_monitor_mix(int arg0, float arg1) {
+inline void crone_set_level_monitor_mix(int arg0, float arg1) {
   crone::Commands::mixerCommands.post(
       crone::Commands::Id::SET_LEVEL_MONITOR_MIX, arg0, arg1);
 }
 
-void crone_set_level_monitor_rev(float arg0) {
+inline void crone_set_level_monitor_rev(float arg0) {
   crone::Commands::mixerCommands.post(
       crone::Commands::Id::SET_LEVEL_MONITOR_AUX, arg0);
 }
 
-void crone_set_level_compressor_mix(float arg0) {
+inline void crone_set_level_compressor_mix(float arg0) {
   crone::Commands::mixerCommands.post(crone::Commands::Id::SET_LEVEL_INS_MIX,
                                       arg0);
 }
 
-void crone_set_enabled_compressor(float arg0) {
+inline void crone_set_enabled_compressor(float arg0) {
   crone::Commands::mixerCommands.post(
       crone::Commands::Id::SET_ENABLED_COMPRESSOR, arg0);
 }
 
-void crone_set_enabled_reverb(float arg0) {
+inline void crone_set_enabled_reverb(float arg0) {
   crone::Commands::mixerCommands.post(crone::Commands::Id::SET_ENABLED_REVERB,
                                       arg0);
 }
 
-void crone_set_param_compressor_ratio(float arg0) {
+inline void crone_set_param_compressor_ratio(float arg0) {
   crone::Commands::mixerCommands.post(crone::Commands::Id::SET_PARAM_COMPRESSOR,
                                       crone::CompressorParam::RATIO, arg0);
 }
 
-void crone_set_param_compressor_threshold(float arg0) {
+inline void crone_set_param_compressor_threshold(float arg0) {
   crone::Commands::mixerCommands.post(crone::Commands::Id::SET_PARAM_COMPRESSOR,
                                       crone::CompressorParam::THRESHOLD, arg0);
 }
 
-void crone_set_param_compressor_attack(float arg0) {
+inline void crone_set_param_compressor_attack(float arg0) {
   crone::Commands::mixerCommands.post(crone::Commands::Id::SET_PARAM_COMPRESSOR,
                                       crone::CompressorParam::ATTACK, arg0);
 }
 
-void crone_set_param_compressor_release(float arg0) {
+inline void crone_set_param_compressor_release(float arg0) {
   crone::Commands::mixerCommands.post(crone::Commands::Id::SET_PARAM_COMPRESSOR,
                                       crone::CompressorParam::RELEASE, arg0);
 }
 
-void crone_set_param_compressor_gain_pre(float arg0) {
+inline void crone_set_param_compressor_gain_pre(float arg0) {
   crone::Commands::mixerCommands.post(crone::Commands::Id::SET_PARAM_COMPRESSOR,
                                       crone::CompressorParam::GAIN_PRE, arg0);
 }
 
-void crone_set_param_compressor_gain_post(float arg0) {
+inline void crone_set_param_compressor_gain_post(float arg0) {
   crone::Commands::mixerCommands.post(crone::Commands::Id::SET_PARAM_COMPRESSOR,
                                       crone::CompressorParam::GAIN_POST, arg0);
 }
 
-void crone_set_param_reverb_pre_del(float arg0) {
+inline void crone_set_param_reverb_pre_del(float arg0) {
   crone::Commands::mixerCommands.post(crone::Commands::Id::SET_PARAM_REVERB,
                                       crone::ReverbParam::PRE_DEL, arg0);
 }
 
-void crone_set_param_reverb_lf_fc(float arg0) {
+inline void crone_set_param_reverb_lf_fc(float arg0) {
   crone::Commands::mixerCommands.post(crone::Commands::Id::SET_PARAM_REVERB,
                                       crone::ReverbParam::LF_FC, arg0);
 }
 
-void crone_set_param_reverb_low_rt60(float arg0) {
+inline void crone_set_param_reverb_low_rt60(float arg0) {
   crone::Commands::mixerCommands.post(crone::Commands::Id::SET_PARAM_REVERB,
                                       crone::ReverbParam::LOW_RT60, arg0);
 }
 
-void crone_set_param_reverb_mid_rt60(float arg0) {
+inline void crone_set_param_reverb_mid_rt60(float arg0) {
   crone::Commands::mixerCommands.post(crone::Commands::Id::SET_PARAM_REVERB,
                                       crone::ReverbParam::MID_RT60, arg0);
 }
 
-void crone_set_param_reverb_hf_damp(float arg0) {
+inline void crone_set_param_reverb_hf_damp(float arg0) {
   crone::Commands::mixerCommands.post(crone::Commands::Id::SET_PARAM_REVERB,
                                       crone::ReverbParam::HF_DAMP, arg0);
 }
 
-void crone_set_enabled_cut(int arg0, float arg1) {
+inline void crone_set_enabled_cut(int arg0, float arg1) {
   crone::Commands::softcutCommands.post(crone::Commands::Id::SET_ENABLED_CUT,
                                         arg0, arg1);
 }
 
-void crone_set_level_cut(int arg0, float arg1) {
+inline void crone_set_level_cut(int arg0, float arg1) {
   crone::Commands::softcutCommands.post(crone::Commands::Id::SET_LEVEL_CUT,
                                         arg0, arg1);
 }
 
-void crone_set_pan_cut(int arg0, float arg1) {
+inline void crone_set_pan_cut(int arg0, float arg1) {
   crone::Commands::softcutCommands.post(crone::Commands::Id::SET_PAN_CUT, arg0,
                                         arg1);
 }
 
-void crone_set_level_adc_cut(float arg0) {
+inline void crone_set_level_adc_cut(float arg0) {
   crone::Commands::mixerCommands.post(crone::Commands::Id::SET_LEVEL_ADC_CUT,
                                       arg0);
 }
 
-void crone_set_level_ext_cut(float arg0) {
+inline void crone_set_level_ext_cut(float arg0) {
   crone::Commands::mixerCommands.post(crone::Commands::Id::SET_LEVEL_EXT_CUT,
                                       arg0);
 }
 
-void crone_set_level_tape_cut(float arg0) {
+inline void crone_set_level_tape_cut(float arg0) {
   crone::Commands::mixerCommands.post(crone::Commands::Id::SET_LEVEL_TAPE_CUT,
                                       arg0);
 }
 
-void crone_set_level_cut_rev(float arg0) {
+inline void crone_set_level_cut_rev(float arg0) {
   crone::Commands::mixerCommands.post(crone::Commands::Id::SET_LEVEL_CUT_AUX,
                                       arg0);
 }
 
-void crone_set_level_in_cut(int arg0, int arg1, float arg2) {
+inline void crone_set_level_in_cut(int arg0, int arg1, float arg2) {
   crone::Commands::softcutCommands.post(crone::Commands::Id::SET_LEVEL_IN_CUT,
                                         arg0, arg1, arg2);
 }
 
-void crone_set_level_cut_cut(int arg0, int arg1, float arg2) {
+inline void crone_set_level_cut_cut(int arg0, int arg1, float arg2) {
   crone::Commands::softcutCommands.post(crone::Commands::Id::SET_LEVEL_CUT_CUT,
                                         arg0, arg1, arg2);
 }
 
-void crone_set_param_cut_rate(int arg0, float arg1) {
+inline void crone_set_param_cut_rate(int arg0, float arg1) {
   crone::Commands::softcutCommands.post(crone::Commands::Id::SET_CUT_RATE, arg0,
                                         arg1);
 }
 
-void crone_set_param_cut_loop_start(int arg0, float arg1) {
+inline void crone_set_param_cut_loop_start(int arg0, float arg1) {
   crone::Commands::softcutCommands.post(crone::Commands::Id::SET_CUT_LOOP_START,
                                         arg0, arg1);
 }
 
-void crone_set_param_cut_loop_end(int arg0, float arg1) {
+inline void crone_set_param_cut_loop_end(int arg0, float arg1) {
   crone::Commands::softcutCommands.post(crone::Commands::Id::SET_CUT_LOOP_END,
                                         arg0, arg1);
 }
 
-void crone_set_param_cut_loop_flag(int arg0, float arg1) {
+inline void crone_set_param_cut_loop_flag(int arg0, float arg1) {
   crone::Commands::softcutCommands.post(crone::Commands::Id::SET_CUT_LOOP_FLAG,
                                         arg0, arg1);
 }
 
-void crone_set_param_cut_fade_time(int arg0, float arg1) {
+inline void crone_set_param_cut_fade_time(int arg0, float arg1) {
   crone::Commands::softcutCommands.post(crone::Commands::Id::SET_CUT_FADE_TIME,
                                         arg0, arg1);
 }
 
-void crone_set_param_cut_rec_level(int arg0, float arg1) {
+inline void crone_set_param_cut_rec_level(int arg0, float arg1) {
   crone::Commands::softcutCommands.post(crone::Commands::Id::SET_CUT_REC_LEVEL,
                                         arg0, arg1);
 }
 
-void crone_set_param_cut_pre_level(int arg0, float arg1) {
+inline void crone_set_param_cut_pre_level(int arg0, float arg1) {
   crone::Commands::softcutCommands.post(crone::Commands::Id::SET_CUT_PRE_LEVEL,
                                         arg0, arg1);
 }
 
-void crone_set_param_cut_rec_flag(int arg0, float arg1) {
+inline void crone_set_param_cut_rec_flag(int arg0, float arg1) {
   crone::Commands::softcutCommands.post(crone::Commands::Id::SET_CUT_REC_FLAG,
                                         arg0, arg1);
 }
 
-void crone_set_param_cut_play_flag(int arg0, float arg1) {
+inline void crone_set_param_cut_play_flag(int arg0, float arg1) {
   crone::Commands::softcutCommands.post(crone::Commands::Id::SET_CUT_PLAY_FLAG,
                                         arg0, arg1);
 }
 
-void crone_set_param_cut_rec_offset(int arg0, float arg1) {
+inline void crone_set_param_cut_rec_offset(int arg0, float arg1) {
   crone::Commands::softcutCommands.post(crone::Commands::Id::SET_CUT_REC_OFFSET,
                                         arg0, arg1);
 }
 
-void crone_set_param_cut_position(int arg0, float arg1) {
+inline void crone_set_param_cut_position(int arg0, float arg1) {
   crone::Commands::softcutCommands.post(crone::Commands::Id::SET_CUT_POSITION,
                                         arg0, arg1);
 }
 
-void crone_set_param_cut_pre_filter_fc(int arg0, float arg1) {
+inline void crone_set_param_cut_pre_filter_fc(int arg0, float arg1) {
   crone::Commands::softcutCommands.post(
       crone::Commands::Id::SET_CUT_PRE_FILTER_FC, arg0, arg1);
 }
 
-void crone_set_param_cut_pre_filter_fc_mod(int arg0, float arg1) {
+inline void crone_set_param_cut_pre_filter_fc_mod(int arg0, float arg1) {
   crone::Commands::softcutCommands.post(
       crone::Commands::Id::SET_CUT_PRE_FILTER_FC_MOD, arg0, arg1);
 }
 
-void crone_set_param_cut_pre_filter_rq(int arg0, float arg1) {
+inline void crone_set_param_cut_pre_filter_rq(int arg0, float arg1) {
   crone::Commands::softcutCommands.post(
       crone::Commands::Id::SET_CUT_PRE_FILTER_RQ, arg0, arg1);
 }
 
-void crone_set_param_cut_pre_filter_lp(int arg0, float arg1) {
+inline void crone_set_param_cut_pre_filter_lp(int arg0, float arg1) {
   crone::Commands::softcutCommands.post(
       crone::Commands::Id::SET_CUT_PRE_FILTER_LP, arg0, arg1);
 }
 
-void crone_set_param_cut_pre_filter_hp(int arg0, float arg1) {
+inline void crone_set_param_cut_pre_filter_hp(int arg0, float arg1) {
   crone::Commands::softcutCommands.post(
       crone::Commands::Id::SET_CUT_PRE_FILTER_HP, arg0, arg1);
 }
 
-void crone_set_param_cut_pre_filter_bp(int arg0, float arg1) {
+inline void crone_set_param_cut_pre_filter_bp(int arg0, float arg1) {
   crone::Commands::softcutCommands.post(
       crone::Commands::Id::SET_CUT_PRE_FILTER_BP, arg0, arg1);
 }
 
-void crone_set_param_cut_pre_filter_br(int arg0, float arg1) {
+inline void crone_set_param_cut_pre_filter_br(int arg0, float arg1) {
   crone::Commands::softcutCommands.post(
       crone::Commands::Id::SET_CUT_PRE_FILTER_BR, arg0, arg1);
 }
 
-void crone_set_param_cut_pre_filter_dry(int arg0, float arg1) {
+inline void crone_set_param_cut_pre_filter_dry(int arg0, float arg1) {
   crone::Commands::softcutCommands.post(
       crone::Commands::Id::SET_CUT_PRE_FILTER_DRY, arg0, arg1);
 }
 
-void crone_set_param_cut_post_filter_fc(int arg0, float arg1) {
+inline void crone_set_param_cut_post_filter_fc(int arg0, float arg1) {
   crone::Commands::softcutCommands.post(
       crone::Commands::Id::SET_CUT_POST_FILTER_FC, arg0, arg1);
 }
 
-void crone_set_param_cut_post_filter_rq(int arg0, float arg1) {
+inline void crone_set_param_cut_post_filter_rq(int arg0, float arg1) {
   crone::Commands::softcutCommands.post(
       crone::Commands::Id::SET_CUT_POST_FILTER_RQ, arg0, arg1);
 }
 
-void crone_set_param_cut_post_filter_lp(int arg0, float arg1) {
+inline void crone_set_param_cut_post_filter_lp(int arg0, float arg1) {
   crone::Commands::softcutCommands.post(
       crone::Commands::Id::SET_CUT_POST_FILTER_LP, arg0, arg1);
 }
 
-void crone_set_param_cut_post_filter_hp(int arg0, float arg1) {
+inline void crone_set_param_cut_post_filter_hp(int arg0, float arg1) {
   crone::Commands::softcutCommands.post(
       crone::Commands::Id::SET_CUT_POST_FILTER_HP, arg0, arg1);
 }
 
-void crone_set_param_cut_post_filter_bp(int arg0, float arg1) {
+inline void crone_set_param_cut_post_filter_bp(int arg0, float arg1) {
   crone::Commands::softcutCommands.post(
       crone::Commands::Id::SET_CUT_POST_FILTER_BP, arg0, arg1);
 }
 
-void crone_set_param_cut_post_filter_br(int arg0, float arg1) {
+inline void crone_set_param_cut_post_filter_br(int arg0, float arg1) {
   crone::Commands::softcutCommands.post(
       crone::Commands::Id::SET_CUT_POST_FILTER_BR, arg0, arg1);
 }
 
-void crone_set_param_cut_post_filter_dry(int arg0, float arg1) {
+inline void crone_set_param_cut_post_filter_dry(int arg0, float arg1) {
   crone::Commands::softcutCommands.post(
       crone::Commands::Id::SET_CUT_POST_FILTER_DRY, arg0, arg1);
 }
 
-void crone_set_param_cut_voice_sync(int arg0, int arg1, float arg2) {
+inline void crone_set_param_cut_voice_sync(int arg0, int arg1, float arg2) {
   crone::Commands::softcutCommands.post(crone::Commands::Id::SET_CUT_VOICE_SYNC,
                                         arg0, arg1, arg2);
 }
 
-void crone_set_param_cut_pre_fade_window(int arg0, float arg1) {
-  (void)arg0; (void)arg1;
+inline void crone_set_param_cut_pre_fade_window(int arg0, float arg1) {
+  (void)arg0;
+  (void)arg1;
   // FIXME: revise fade shapes
 }
 
-void crone_set_param_cut_rec_fade_delay(int arg0, float arg1) {
-  (void)arg0; (void)arg1;
+inline void crone_set_param_cut_rec_fade_delay(int arg0, float arg1) {
+  (void)arg0;
+  (void)arg1;
   // FIXME: revise fade shapes
 }
 
-void crone_set_param_cut_pre_fade_shape(int arg0, float arg1) {
-  (void)arg0; (void)arg1;
+inline void crone_set_param_cut_pre_fade_shape(int arg0, float arg1) {
+  (void)arg0;
+  (void)arg1;
   // FIXME: revise fade shapes
 }
 
-void crone_set_param_cut_rec_fade_shape(int arg0, float arg1) {
-  (void)arg0; (void)arg1;
+inline void crone_set_param_cut_rec_fade_shape(int arg0, float arg1) {
+  (void)arg0;
+  (void)arg1;
   // FIXME: revise fade shapes
 }
 
-void crone_set_param_cut_level_slew_time(int arg0, float arg1) {
+inline void crone_set_param_cut_level_slew_time(int arg0, float arg1) {
   crone::Commands::softcutCommands.post(
       crone::Commands::Id::SET_CUT_LEVEL_SLEW_TIME, arg0, arg1);
 }
 
-void crone_set_param_cut_pan_slew_time(int arg0, float arg1) {
+inline void crone_set_param_cut_pan_slew_time(int arg0, float arg1) {
   crone::Commands::softcutCommands.post(
       crone::Commands::Id::SET_CUT_PAN_SLEW_TIME, arg0, arg1);
 }
 
-void crone_set_param_cut_recpre_slew_time(int arg0, float arg1) {
+inline void crone_set_param_cut_recpre_slew_time(int arg0, float arg1) {
   crone::Commands::softcutCommands.post(
       crone::Commands::Id::SET_CUT_RECPRE_SLEW_TIME, arg0, arg1);
 }
 
-void crone_set_param_cut_rate_slew_time(int arg0, float arg1) {
+inline void crone_set_param_cut_rate_slew_time(int arg0, float arg1) {
   crone::Commands::softcutCommands.post(
       crone::Commands::Id::SET_CUT_RATE_SLEW_TIME, arg0, arg1);
 }
 
-void crone_set_param_cut_buffer(int arg0, int arg1) {
+inline void crone_set_param_cut_buffer(int arg0, int arg1) {
   crone::Commands::softcutCommands.post(crone::Commands::Id::SET_CUT_BUFFER,
                                         arg0, arg1);
 }
 
 void crone_cut_buffer_read_mono(const char *arg0, float arg1, float arg2,
                                 float arg3, int arg4, int arg5, float arg6,
-                                float arg7) {
-  // FIXME: defaults
-  float startSrc = 0.f;
-  float startDst = 0.f;
-  float dur = -1.f;
-  int chanSrc = 0;
-  int chanDst = 0;
-  float preserve = 0.f;
-  float mix = 1.f;
-  softCutClient->readBufferMono(arg0, startSrc, startDst, dur, chanSrc, chanDst,
-                                preserve, mix);
-}
-
+                                float arg7);
 void crone_cut_buffer_read_stereo(const char *arg0, float arg1, float arg2,
-                                  float arg3, float arg4, float arg5) {
-  // FIXME: defaults
-  // FIXME: default args
-  float startSrc = 0.f;
-  float startDst = 0.f;
-  float dur = -1.f;
-  float preserve = 0.f;
-  float mix = 1.f;
-  const char *str = arg0;
-  softCutClient->readBufferStereo(str, startSrc, startDst, dur, preserve, mix);
-}
-
+                                  float arg3, float arg4, float arg5);
 void crone_cut_buffer_write_mono(const char *arg0, float arg1, float arg2,
-                                 int arg3) {
-  // FIXME: defaults
-  float start = 0.f;
-  float dur = -1.f;
-  int chan = 0;
-  const char *str = arg0;
-  softCutClient->writeBufferMono(str, start, dur, chan);
-}
+                                 int arg3);
 
-void crone_cut_buffer_write_stereo(const char *arg0, float arg1, float arg2) {
-  // FIXME: default args
-  float start = 0.f;
-  float dur = -1.f;
+void crone_cut_buffer_write_stereo(const char *arg0, float arg1, float arg2);
 
-  const char *str = arg0;
-  softCutClient->writeBufferStereo(str, start, dur);
-}
-
-void crone_cut_buffer_clear() {
-  softCutClient->clearBuffer(0);
-  softCutClient->clearBuffer(1);
-}
-
-void crone_cut_buffer_clear_channel(int arg0) {
-  softCutClient->clearBuffer(arg0);
-}
-
+void crone_cut_buffer_clear();
+void crone_cut_buffer_clear_channel(int arg0);
 void crone_cut_buffer_clear_region(float start, float dur, float fade_time,
-                                   float preserve) {
-  softCutClient->clearBufferWithFade(0, start, dur, fade_time, preserve);
-  softCutClient->clearBufferWithFade(1, start, dur, fade_time, preserve);
-}
-
+                                   float preserve);
 void crone_cut_buffer_clear_region_channel(int ch, float start, float dur,
-                                           float fade_time, float preserve) {
-  softCutClient->clearBufferWithFade(ch, start, dur, fade_time, preserve);
-}
-
+                                           float fade_time, float preserve);
 void crone_cut_buffer_clear_fade_region(float arg0, float arg1, float arg2,
-                                        float arg3) {
-  // FIXME: default args
-  float dur = -1;
-  float fadeTime = 0;
-  float preserve = 0;
-  softCutClient->clearBufferWithFade(0, arg0, dur, fadeTime, preserve);
-  softCutClient->clearBufferWithFade(1, arg0, dur, fadeTime, preserve);
-}
-
+                                        float arg3);
 void crone_cut_buffer_clear_fade_region_channel(int arg0, float arg1,
                                                 float arg2, float arg3,
-                                                float arg4) {
-  // FIXME: default args
-  float dur = -1;
-  float fadeTime = 0;
-  float preserve = 0;
-  softCutClient->clearBufferWithFade(arg0, arg1, dur, fadeTime, preserve);
-}
-
+                                                float arg4);
 void crone_cut_buffer_copy_mono(int arg0, int arg1, float arg2, float arg3,
-                                float arg4, float arg5, float arg6, int arg7) {
-  // FIXME: default args
-  float dur = -1.f;
-  float fadeTime = 0.f;
-  float preserve = 0.f;
-  bool reverse = false;
-
-  softCutClient->copyBuffer(arg0, arg1, arg2, arg3, dur, fadeTime, preserve,
-                            reverse);
-}
-
+                                float arg4, float arg5, float arg6, int arg7);
 void crone_cut_buffer_copy_stereo(float arg0, float arg1, float arg2,
-                                  float arg3, float arg4, int arg5) {
-  // FIXME: default args
-  float dur = -1.f;
-  float fadeTime = 0.f;
-  float preserve = 0.f;
-  bool reverse = false;
+                                  float arg3, float arg4, int arg5);
+void crone_cut_buffer_render(int arg0, float arg1, float arg2, int arg3);
+void crone_cut_query_position(int arg0);
 
-  softCutClient->copyBuffer(0, 0, arg0, arg1, dur, fadeTime, preserve, reverse);
-  softCutClient->copyBuffer(1, 1, arg0, arg1, dur, fadeTime, preserve, reverse);
-}
+void crone_cut_reset();
+void crone_set_param_cut_phase_quant(int arg0, float arg1);
+void crone_set_param_cut_phase_offset(int arg0, float arg1);
+void crone_poll_start_cut_phase();
+void crone_poll_stop_cut_phase();
+void crone_tape_rec_open(const char *arg0);
+void crone_tape_rec_start();
+void crone_tape_rec_stop();
+void crone_tape_play_open(const char *arg0);
+void crone_tape_play_start();
+void crone_tape_play_stop();
 
-void crone_cut_buffer_render(int arg0, float arg1, float arg2, int arg3) {
-  int sampleCt = 128;
-  int ch = arg0;
-
-  softCutClient->renderSamples(
-      ch, arg1, arg2, sampleCt,
-      [=](float secPerSample, float start, size_t count, float *samples) {
-        // FIXME: perform render callback directly.. maybe take arg to FP
-
-        // lo_blob bl = lo_blob_new(count * sizeof(float), samples);
-        // lo_send(matronAddress, "/softcut/buffer/render_callback", "iffb", ch,
-        //         secPerSample, start, bl);
-      });
-}
-
-void crone_cut_query_position(int arg0) {
-  int idx = arg0;
-  float pos = softCutClient->getPosition(idx);
-  (void)pos;
-  // FIXME
-  // lo_send(matronAddress, "/poll/softcut/position", "if", idx, pos);
-}
-
-void crone_cut_reset() {
-  softCutClient->clearBuffer(0, 0, -1);
-  softCutClient->clearBuffer(1, 0, -1);
-
-  softCutClient->reset();
-  for (int i = 0; i < crone::SoftcutClient::NumVoices; ++i) {
-    phasePoll->stop();
-  }
-}
-
-void crone_set_param_cut_phase_quant(int arg0, float arg1) {
-  softCutClient->setPhaseQuant(arg0, arg1);
-}
-
-void crone_set_param_cut_phase_offset(int arg0, float arg1) {
-  softCutClient->setPhaseOffset(arg0, arg1);
-}
-
-void crone_poll_start_cut_phase() { phasePoll->start(); }
-
-void crone_poll_stop_cut_phase() { phasePoll->stop(); }
-
-void crone_tape_rec_open(const char *arg0) {
-  mixerClient->openTapeRecord(arg0);
-}
-
-void crone_tape_rec_start() { mixerClient->startTapeRecord(); }
-
-void crone_tape_rec_stop() { mixerClient->stopTapeRecord(); }
-
-void crone_tape_play_open(const char *arg0) {
-  mixerClient->openTapePlayback(arg0);
-}
-
-void crone_tape_play_start() { mixerClient->startTapePlayback(); }
-
-void crone_tape_play_stop() { mixerClient->stopTapePlayback(); }
-
-void crone_set_level_tape(float arg0) {
+inline void crone_set_level_tape(float arg0) {
   crone::Commands::mixerCommands.post(crone::Commands::Id::SET_LEVEL_TAPE,
                                       arg0);
 }
 
-void crone_set_level_tape_rev(float arg0) {
+inline void crone_set_level_tape_rev(float arg0) {
   crone::Commands::mixerCommands.post(crone::Commands::Id::SET_LEVEL_TAPE_AUX,
                                       arg0);
 }

--- a/crone/src/crone.h
+++ b/crone/src/crone.h
@@ -276,6 +276,11 @@ void crone_set_param_cut_pre_filter_dry(int arg0, float arg1) {
       crone::Commands::Id::SET_CUT_PRE_FILTER_DRY, arg0, arg1);
 }
 
+void crone_set_param_cut_post_filter_fc(int arg0, float arg1) {
+  crone::Commands::softcutCommands.post(
+      crone::Commands::Id::SET_CUT_POST_FILTER_FC, arg0, arg1);
+}
+
 void crone_set_param_cut_post_filter_rq(int arg0, float arg1) {
   crone::Commands::softcutCommands.post(
       crone::Commands::Id::SET_CUT_POST_FILTER_RQ, arg0, arg1);
@@ -312,51 +317,23 @@ void crone_set_param_cut_voice_sync(int arg0, int arg1, float arg2) {
 }
 
 void crone_set_param_cut_pre_fade_window(int arg0, float arg1) {
-  // FIXME: this escaped the script because it is converting ->f to int. is that
-  // on purpose?
-  //  float x = argv[0]->f;
-  float x = arg0;
-  auto t = std::thread([x] {
-    // FIXME
-    // softcut::FadeCurves::setPreWindowRatio(x);
-  });
-  t.detach();
+  (void)arg0; (void)arg1;
+  // FIXME: revise fade shapes
 }
 
 void crone_set_param_cut_rec_fade_delay(int arg0, float arg1) {
-  // FIXME: this escaped the script because it is converting ->f to int. is that
-  // on purpose?
-  //  float x = argv[0]->f;
-  float x = arg0;
-  auto t = std::thread([x] {
-    // FIXME
-    // softcut::FadeCurves::setRecDelayRatio(x);
-  });
-  t.detach();
+  (void)arg0; (void)arg1;
+  // FIXME: revise fade shapes
 }
 
 void crone_set_param_cut_pre_fade_shape(int arg0, float arg1) {
-  // FIXME: this escaped the script because it is converting ->f to int. is that
-  // on purpose?
-  //  float x = argv[0]->f;
-  float x = arg0;
-  auto t = std::thread([x] {
-    // FIXME
-    // softcut::FadeCurves::setPreShape(static_cast<softcut::FadeCurves::Shape>(x));
-  });
-  t.detach();
+  (void)arg0; (void)arg1;
+  // FIXME: revise fade shapes
 }
 
 void crone_set_param_cut_rec_fade_shape(int arg0, float arg1) {
-  // FIXME: this escaped the script because it is converting ->f to int. is that
-  // on purpose?
-  //  float x = argv[0]->f;
-  float x = arg0;
-  auto t = std::thread([x] {
-    // FIXME
-    // softcut::FadeCurves::setRecShape(static_cast<softcut::FadeCurves::Shape>(x));
-  });
-  t.detach();
+  (void)arg0; (void)arg1;
+  // FIXME: revise fade shapes
 }
 
 void crone_set_param_cut_level_slew_time(int arg0, float arg1) {
@@ -502,7 +479,8 @@ void crone_cut_buffer_render(int arg0, float arg1, float arg2, int arg3) {
   softCutClient->renderSamples(
       ch, arg1, arg2, sampleCt,
       [=](float secPerSample, float start, size_t count, float *samples) {
-        // FIXME
+        // FIXME: perform render callback directly.. maybe take arg to FP
+
         // lo_blob bl = lo_blob_new(count * sizeof(float), samples);
         // lo_send(matronAddress, "/softcut/buffer/render_callback", "iffb", ch,
         //         secPerSample, start, bl);

--- a/crone/src/crone.h
+++ b/crone/src/crone.h
@@ -21,17 +21,6 @@ Poll *phasePoll;
 void crone_poll_start_vu() { vuPoll->start(); }
 void crone_poll_stop_vu() { vuPoll->stop(); }
 
-
-// void crone_hello() { std::cout << "hello" << std::endl; }
-
-// void crone_goodbye() {
-//   std::cout << "goodbye" << std::endl;
-//   OscInterface::quitFlag = true;
-// }
-
-// void crone_quit() { OscInterface::quitFlag = true; }
-
-
 void crone_set_level_adc(float arg0) {
   crone::Commands::mixerCommands.post(crone::Commands::Id::SET_LEVEL_ADC, arg0);
 }

--- a/crone/src/crone.h
+++ b/crone/src/crone.h
@@ -3,14 +3,14 @@
 
 #include <iostream>
 
+#include "BufDiskWorker.h"
 #include "Commands.h"
 #include "MixerClient.h"
-#include "SoftcutClient.h"
-#include "BufDiskWorker.h"
 #include "Poll.h"
-#include "softcut/FadeCurves.h"
+#include "SoftcutClient.h"
 #include "effects/CompressorParams.h"
 #include "effects/ReverbParams.h"
+#include "softcut/FadeCurves.h"
 
 // FIXME: need static references to polls, clients
 crone::MixerClient *mixerClient;
@@ -26,8 +26,9 @@ void crone_set_level_adc(float arg0) {
 }
 
 void crone_set_level_dac(float arg0) {
-  std::cerr << "crone_set_level_dac("<<arg0<<")"<<std::endl;
-  std::cerr << "&mixerCommands: " << std::hex << &(crone::Commands::mixerCommands) << std::endl;
+  std::cerr << "crone_set_level_dac(" << arg0 << ")" << std::endl;
+  std::cerr << "&mixerCommands: " << std::hex
+            << &(crone::Commands::mixerCommands) << std::endl;
   crone::Commands::mixerCommands.post(crone::Commands::Id::SET_LEVEL_DAC, arg0);
 }
 
@@ -36,328 +37,357 @@ void crone_set_level_ext(float arg0) {
 }
 
 void crone_set_level_cut_master(float arg0) {
-  crone::Commands::mixerCommands.post(crone::Commands::Id::SET_LEVEL_CUT_MASTER, arg0);
+  crone::Commands::mixerCommands.post(crone::Commands::Id::SET_LEVEL_CUT_MASTER,
+                                      arg0);
 }
 
 void crone_set_level_ext_rev(float arg0) {
-  crone::Commands::mixerCommands.post(crone::Commands::Id::SET_LEVEL_EXT_AUX, arg0);
+  crone::Commands::mixerCommands.post(crone::Commands::Id::SET_LEVEL_EXT_AUX,
+                                      arg0);
 }
 
 void crone_set_level_rev_dac(float arg0) {
-  crone::Commands::mixerCommands.post(crone::Commands::Id::SET_LEVEL_AUX_DAC, arg0);
+  crone::Commands::mixerCommands.post(crone::Commands::Id::SET_LEVEL_AUX_DAC,
+                                      arg0);
 }
 
 void crone_set_level_monitor(float arg0) {
-  crone::Commands::mixerCommands.post(crone::Commands::Id::SET_LEVEL_MONITOR, arg0);
+  crone::Commands::mixerCommands.post(crone::Commands::Id::SET_LEVEL_MONITOR,
+                                      arg0);
 }
 
 void crone_set_level_monitor_mix(int arg0, float arg1) {
-  crone::Commands::mixerCommands.post(crone::Commands::Id::SET_LEVEL_MONITOR_MIX, arg0, arg1);
+  crone::Commands::mixerCommands.post(
+      crone::Commands::Id::SET_LEVEL_MONITOR_MIX, arg0, arg1);
 }
 
 void crone_set_level_monitor_rev(float arg0) {
-  crone::Commands::mixerCommands.post(crone::Commands::Id::SET_LEVEL_MONITOR_AUX, arg0);
+  crone::Commands::mixerCommands.post(
+      crone::Commands::Id::SET_LEVEL_MONITOR_AUX, arg0);
 }
 
 void crone_set_level_compressor_mix(float arg0) {
-  crone::Commands::mixerCommands.post(crone::Commands::Id::SET_LEVEL_INS_MIX, arg0);
+  crone::Commands::mixerCommands.post(crone::Commands::Id::SET_LEVEL_INS_MIX,
+                                      arg0);
 }
 
 void crone_set_enabled_compressor(float arg0) {
-  crone::Commands::mixerCommands.post(crone::Commands::Id::SET_ENABLED_COMPRESSOR, arg0);
+  crone::Commands::mixerCommands.post(
+      crone::Commands::Id::SET_ENABLED_COMPRESSOR, arg0);
 }
 
 void crone_set_enabled_reverb(float arg0) {
-  crone::Commands::mixerCommands.post(crone::Commands::Id::SET_ENABLED_REVERB, arg0);
+  crone::Commands::mixerCommands.post(crone::Commands::Id::SET_ENABLED_REVERB,
+                                      arg0);
 }
 
 void crone_set_param_compressor_ratio(float arg0) {
   crone::Commands::mixerCommands.post(crone::Commands::Id::SET_PARAM_COMPRESSOR,
-                               crone::CompressorParam::RATIO, arg0);
+                                      crone::CompressorParam::RATIO, arg0);
 }
 
 void crone_set_param_compressor_threshold(float arg0) {
   crone::Commands::mixerCommands.post(crone::Commands::Id::SET_PARAM_COMPRESSOR,
-                               crone::CompressorParam::THRESHOLD, arg0);
+                                      crone::CompressorParam::THRESHOLD, arg0);
 }
 
 void crone_set_param_compressor_attack(float arg0) {
   crone::Commands::mixerCommands.post(crone::Commands::Id::SET_PARAM_COMPRESSOR,
-                               crone::CompressorParam::ATTACK, arg0);
+                                      crone::CompressorParam::ATTACK, arg0);
 }
 
 void crone_set_param_compressor_release(float arg0) {
   crone::Commands::mixerCommands.post(crone::Commands::Id::SET_PARAM_COMPRESSOR,
-                               crone::CompressorParam::RELEASE, arg0);
+                                      crone::CompressorParam::RELEASE, arg0);
 }
 
 void crone_set_param_compressor_gain_pre(float arg0) {
   crone::Commands::mixerCommands.post(crone::Commands::Id::SET_PARAM_COMPRESSOR,
-                               crone::CompressorParam::GAIN_PRE, arg0);
+                                      crone::CompressorParam::GAIN_PRE, arg0);
 }
 
 void crone_set_param_compressor_gain_post(float arg0) {
   crone::Commands::mixerCommands.post(crone::Commands::Id::SET_PARAM_COMPRESSOR,
-                               crone::CompressorParam::GAIN_POST, arg0);
+                                      crone::CompressorParam::GAIN_POST, arg0);
 }
 
 void crone_set_param_reverb_pre_del(float arg0) {
   crone::Commands::mixerCommands.post(crone::Commands::Id::SET_PARAM_REVERB,
-                               crone::ReverbParam::PRE_DEL, arg0);
+                                      crone::ReverbParam::PRE_DEL, arg0);
 }
 
 void crone_set_param_reverb_lf_fc(float arg0) {
   crone::Commands::mixerCommands.post(crone::Commands::Id::SET_PARAM_REVERB,
-                               crone::ReverbParam::LF_FC, arg0);
+                                      crone::ReverbParam::LF_FC, arg0);
 }
 
 void crone_set_param_reverb_low_rt60(float arg0) {
   crone::Commands::mixerCommands.post(crone::Commands::Id::SET_PARAM_REVERB,
-                               crone::ReverbParam::LOW_RT60, arg0);
+                                      crone::ReverbParam::LOW_RT60, arg0);
 }
 
 void crone_set_param_reverb_mid_rt60(float arg0) {
   crone::Commands::mixerCommands.post(crone::Commands::Id::SET_PARAM_REVERB,
-                               crone::ReverbParam::MID_RT60, arg0);
+                                      crone::ReverbParam::MID_RT60, arg0);
 }
 
 void crone_set_param_reverb_hf_damp(float arg0) {
   crone::Commands::mixerCommands.post(crone::Commands::Id::SET_PARAM_REVERB,
-                               crone::ReverbParam::HF_DAMP, arg0);
+                                      crone::ReverbParam::HF_DAMP, arg0);
 }
 
 void crone_set_enabled_cut(int arg0, float arg1) {
-  crone::Commands::softcutCommands.post(crone::Commands::Id::SET_ENABLED_CUT, arg0, arg1);
+  crone::Commands::softcutCommands.post(crone::Commands::Id::SET_ENABLED_CUT,
+                                        arg0, arg1);
 }
 
 void crone_set_level_cut(int arg0, float arg1) {
-  crone::Commands::softcutCommands.post(crone::Commands::Id::SET_LEVEL_CUT, arg0, arg1);
+  crone::Commands::softcutCommands.post(crone::Commands::Id::SET_LEVEL_CUT,
+                                        arg0, arg1);
 }
 
 void crone_set_pan_cut(int arg0, float arg1) {
-  crone::Commands::softcutCommands.post(crone::Commands::Id::SET_PAN_CUT, arg0, arg1);
+  crone::Commands::softcutCommands.post(crone::Commands::Id::SET_PAN_CUT, arg0,
+                                        arg1);
 }
 
 void crone_set_level_adc_cut(float arg0) {
-  crone::Commands::mixerCommands.post(crone::Commands::Id::SET_LEVEL_ADC_CUT, arg0);
+  crone::Commands::mixerCommands.post(crone::Commands::Id::SET_LEVEL_ADC_CUT,
+                                      arg0);
 }
 
 void crone_set_level_ext_cut(float arg0) {
-  crone::Commands::mixerCommands.post(crone::Commands::Id::SET_LEVEL_EXT_CUT, arg0);
+  crone::Commands::mixerCommands.post(crone::Commands::Id::SET_LEVEL_EXT_CUT,
+                                      arg0);
 }
 
 void crone_set_level_tape_cut(float arg0) {
-  crone::Commands::mixerCommands.post(crone::Commands::Id::SET_LEVEL_TAPE_CUT, arg0);
+  crone::Commands::mixerCommands.post(crone::Commands::Id::SET_LEVEL_TAPE_CUT,
+                                      arg0);
 }
 
 void crone_set_level_cut_rev(float arg0) {
-  crone::Commands::mixerCommands.post(crone::Commands::Id::SET_LEVEL_CUT_AUX, arg0);
+  crone::Commands::mixerCommands.post(crone::Commands::Id::SET_LEVEL_CUT_AUX,
+                                      arg0);
 }
 
 void crone_set_level_in_cut(int arg0, int arg1, float arg2) {
-  crone::Commands::softcutCommands.post(crone::Commands::Id::SET_LEVEL_IN_CUT, arg0, arg1,
-                                 arg2);
+  crone::Commands::softcutCommands.post(crone::Commands::Id::SET_LEVEL_IN_CUT,
+                                        arg0, arg1, arg2);
 }
 
 void crone_set_level_cut_cut(int arg0, int arg1, float arg2) {
-  crone::Commands::softcutCommands.post(crone::Commands::Id::SET_LEVEL_CUT_CUT, arg0, arg1,
-                                 arg2);
+  crone::Commands::softcutCommands.post(crone::Commands::Id::SET_LEVEL_CUT_CUT,
+                                        arg0, arg1, arg2);
 }
 
 void crone_set_param_cut_rate(int arg0, float arg1) {
-  crone::Commands::softcutCommands.post(crone::Commands::Id::SET_CUT_RATE, arg0, arg1);
+  crone::Commands::softcutCommands.post(crone::Commands::Id::SET_CUT_RATE, arg0,
+                                        arg1);
 }
 
 void crone_set_param_cut_loop_start(int arg0, float arg1) {
-  crone::Commands::softcutCommands.post(crone::Commands::Id::SET_CUT_LOOP_START, arg0, arg1);
+  crone::Commands::softcutCommands.post(crone::Commands::Id::SET_CUT_LOOP_START,
+                                        arg0, arg1);
 }
 
 void crone_set_param_cut_loop_end(int arg0, float arg1) {
-  crone::Commands::softcutCommands.post(crone::Commands::Id::SET_CUT_LOOP_END, arg0, arg1);
+  crone::Commands::softcutCommands.post(crone::Commands::Id::SET_CUT_LOOP_END,
+                                        arg0, arg1);
 }
 
 void crone_set_param_cut_loop_flag(int arg0, float arg1) {
-  crone::Commands::softcutCommands.post(crone::Commands::Id::SET_CUT_LOOP_FLAG, arg0, arg1);
+  crone::Commands::softcutCommands.post(crone::Commands::Id::SET_CUT_LOOP_FLAG,
+                                        arg0, arg1);
 }
 
 void crone_set_param_cut_fade_time(int arg0, float arg1) {
-  crone::Commands::softcutCommands.post(crone::Commands::Id::SET_CUT_FADE_TIME, arg0, arg1);
+  crone::Commands::softcutCommands.post(crone::Commands::Id::SET_CUT_FADE_TIME,
+                                        arg0, arg1);
 }
 
 void crone_set_param_cut_rec_level(int arg0, float arg1) {
-  crone::Commands::softcutCommands.post(crone::Commands::Id::SET_CUT_REC_LEVEL, arg0, arg1);
+  crone::Commands::softcutCommands.post(crone::Commands::Id::SET_CUT_REC_LEVEL,
+                                        arg0, arg1);
 }
 
 void crone_set_param_cut_pre_level(int arg0, float arg1) {
-  crone::Commands::softcutCommands.post(crone::Commands::Id::SET_CUT_PRE_LEVEL, arg0, arg1);
+  crone::Commands::softcutCommands.post(crone::Commands::Id::SET_CUT_PRE_LEVEL,
+                                        arg0, arg1);
 }
 
 void crone_set_param_cut_rec_flag(int arg0, float arg1) {
-  crone::Commands::softcutCommands.post(crone::Commands::Id::SET_CUT_REC_FLAG, arg0, arg1);
+  crone::Commands::softcutCommands.post(crone::Commands::Id::SET_CUT_REC_FLAG,
+                                        arg0, arg1);
 }
 
 void crone_set_param_cut_play_flag(int arg0, float arg1) {
-  crone::Commands::softcutCommands.post(crone::Commands::Id::SET_CUT_PLAY_FLAG, arg0, arg1);
+  crone::Commands::softcutCommands.post(crone::Commands::Id::SET_CUT_PLAY_FLAG,
+                                        arg0, arg1);
 }
 
 void crone_set_param_cut_rec_offset(int arg0, float arg1) {
-  crone::Commands::softcutCommands.post(crone::Commands::Id::SET_CUT_REC_OFFSET, arg0, arg1);
+  crone::Commands::softcutCommands.post(crone::Commands::Id::SET_CUT_REC_OFFSET,
+                                        arg0, arg1);
 }
 
 void crone_set_param_cut_position(int arg0, float arg1) {
-  crone::Commands::softcutCommands.post(crone::Commands::Id::SET_CUT_POSITION, arg0, arg1);
+  crone::Commands::softcutCommands.post(crone::Commands::Id::SET_CUT_POSITION,
+                                        arg0, arg1);
 }
 
 void crone_set_param_cut_pre_filter_fc(int arg0, float arg1) {
-  crone::Commands::softcutCommands.post(crone::Commands::Id::SET_CUT_PRE_FILTER_FC, arg0,
-                                 arg1);
+  crone::Commands::softcutCommands.post(
+      crone::Commands::Id::SET_CUT_PRE_FILTER_FC, arg0, arg1);
 }
 
 void crone_set_param_cut_pre_filter_fc_mod(int arg0, float arg1) {
-  crone::Commands::softcutCommands.post(crone::Commands::Id::SET_CUT_PRE_FILTER_FC_MOD, arg0,
-                                 arg1);
+  crone::Commands::softcutCommands.post(
+      crone::Commands::Id::SET_CUT_PRE_FILTER_FC_MOD, arg0, arg1);
 }
 
 void crone_set_param_cut_pre_filter_rq(int arg0, float arg1) {
-  crone::Commands::softcutCommands.post(crone::Commands::Id::SET_CUT_PRE_FILTER_RQ, arg0,
-                                 arg1);
+  crone::Commands::softcutCommands.post(
+      crone::Commands::Id::SET_CUT_PRE_FILTER_RQ, arg0, arg1);
 }
 
 void crone_set_param_cut_pre_filter_lp(int arg0, float arg1) {
-  crone::Commands::softcutCommands.post(crone::Commands::Id::SET_CUT_PRE_FILTER_LP, arg0,
-                                 arg1);
+  crone::Commands::softcutCommands.post(
+      crone::Commands::Id::SET_CUT_PRE_FILTER_LP, arg0, arg1);
 }
 
 void crone_set_param_cut_pre_filter_hp(int arg0, float arg1) {
-  crone::Commands::softcutCommands.post(crone::Commands::Id::SET_CUT_PRE_FILTER_HP, arg0,
-                                 arg1);
+  crone::Commands::softcutCommands.post(
+      crone::Commands::Id::SET_CUT_PRE_FILTER_HP, arg0, arg1);
 }
 
 void crone_set_param_cut_pre_filter_bp(int arg0, float arg1) {
-  crone::Commands::softcutCommands.post(crone::Commands::Id::SET_CUT_PRE_FILTER_BP, arg0,
-                                 arg1);
+  crone::Commands::softcutCommands.post(
+      crone::Commands::Id::SET_CUT_PRE_FILTER_BP, arg0, arg1);
 }
 
 void crone_set_param_cut_pre_filter_br(int arg0, float arg1) {
-  crone::Commands::softcutCommands.post(crone::Commands::Id::SET_CUT_PRE_FILTER_BR, arg0,
-                                 arg1);
+  crone::Commands::softcutCommands.post(
+      crone::Commands::Id::SET_CUT_PRE_FILTER_BR, arg0, arg1);
 }
 
 void crone_set_param_cut_pre_filter_dry(int arg0, float arg1) {
-  crone::Commands::softcutCommands.post(crone::Commands::Id::SET_CUT_PRE_FILTER_DRY, arg0,
-                                 arg1);
+  crone::Commands::softcutCommands.post(
+      crone::Commands::Id::SET_CUT_PRE_FILTER_DRY, arg0, arg1);
 }
 
 void crone_set_param_cut_post_filter_rq(int arg0, float arg1) {
-  crone::Commands::softcutCommands.post(crone::Commands::Id::SET_CUT_POST_FILTER_RQ, arg0,
-                                 arg1);
+  crone::Commands::softcutCommands.post(
+      crone::Commands::Id::SET_CUT_POST_FILTER_RQ, arg0, arg1);
 }
 
 void crone_set_param_cut_post_filter_lp(int arg0, float arg1) {
-  crone::Commands::softcutCommands.post(crone::Commands::Id::SET_CUT_POST_FILTER_LP, arg0,
-                                 arg1);
+  crone::Commands::softcutCommands.post(
+      crone::Commands::Id::SET_CUT_POST_FILTER_LP, arg0, arg1);
 }
 
 void crone_set_param_cut_post_filter_hp(int arg0, float arg1) {
-  crone::Commands::softcutCommands.post(crone::Commands::Id::SET_CUT_POST_FILTER_HP, arg0,
-                                 arg1);
+  crone::Commands::softcutCommands.post(
+      crone::Commands::Id::SET_CUT_POST_FILTER_HP, arg0, arg1);
 }
 
 void crone_set_param_cut_post_filter_bp(int arg0, float arg1) {
-  crone::Commands::softcutCommands.post(crone::Commands::Id::SET_CUT_POST_FILTER_BP, arg0,
-                                 arg1);
+  crone::Commands::softcutCommands.post(
+      crone::Commands::Id::SET_CUT_POST_FILTER_BP, arg0, arg1);
 }
 
 void crone_set_param_cut_post_filter_br(int arg0, float arg1) {
-  crone::Commands::softcutCommands.post(crone::Commands::Id::SET_CUT_POST_FILTER_BR, arg0,
-                                 arg1);
+  crone::Commands::softcutCommands.post(
+      crone::Commands::Id::SET_CUT_POST_FILTER_BR, arg0, arg1);
 }
 
 void crone_set_param_cut_post_filter_dry(int arg0, float arg1) {
-  crone::Commands::softcutCommands.post(crone::Commands::Id::SET_CUT_POST_FILTER_DRY, arg0,
-                                 arg1);
+  crone::Commands::softcutCommands.post(
+      crone::Commands::Id::SET_CUT_POST_FILTER_DRY, arg0, arg1);
 }
 
 void crone_set_param_cut_voice_sync(int arg0, int arg1, float arg2) {
-    crone::Commands::softcutCommands.post(crone::Commands::Id::SET_CUT_VOICE_SYNC, arg0, arg1,
-                                 arg2);
+  crone::Commands::softcutCommands.post(crone::Commands::Id::SET_CUT_VOICE_SYNC,
+                                        arg0, arg1, arg2);
 }
 
 void crone_set_param_cut_pre_fade_window(int arg0, float arg1) {
-
-// FIXME: this escaped the script because it is converting ->f to int. is that on purpose?
-//  float x = argv[0]->f;
-float x = arg0;
-  auto t = std::thread([x] { 
+  // FIXME: this escaped the script because it is converting ->f to int. is that
+  // on purpose?
+  //  float x = argv[0]->f;
+  float x = arg0;
+  auto t = std::thread([x] {
     // FIXME
-    //softcut::FadeCurves::setPreWindowRatio(x);
-    });
+    // softcut::FadeCurves::setPreWindowRatio(x);
+  });
   t.detach();
 }
 
 void crone_set_param_cut_rec_fade_delay(int arg0, float arg1) {
-// FIXME: this escaped the script because it is converting ->f to int. is that on purpose?
-//  float x = argv[0]->f;
-float x = arg0;
-  auto t = std::thread([x] { 
+  // FIXME: this escaped the script because it is converting ->f to int. is that
+  // on purpose?
+  //  float x = argv[0]->f;
+  float x = arg0;
+  auto t = std::thread([x] {
     // FIXME
-    // softcut::FadeCurves::setRecDelayRatio(x); 
+    // softcut::FadeCurves::setRecDelayRatio(x);
   });
   t.detach();
 }
 
 void crone_set_param_cut_pre_fade_shape(int arg0, float arg1) {
-// FIXME: this escaped the script because it is converting ->f to int. is that on purpose?
-//  float x = argv[0]->f;
-float x = arg0;
-  auto t = std::thread(
-      [x] { 
-        // FIXME
-        // softcut::FadeCurves::setPreShape(static_cast<softcut::FadeCurves::Shape>(x));
-      });
+  // FIXME: this escaped the script because it is converting ->f to int. is that
+  // on purpose?
+  //  float x = argv[0]->f;
+  float x = arg0;
+  auto t = std::thread([x] {
+    // FIXME
+    // softcut::FadeCurves::setPreShape(static_cast<softcut::FadeCurves::Shape>(x));
+  });
   t.detach();
 }
 
 void crone_set_param_cut_rec_fade_shape(int arg0, float arg1) {
-// FIXME: this escaped the script because it is converting ->f to int. is that on purpose?
-//  float x = argv[0]->f;
-float x = arg0; 
-auto t = std::thread([x] { 
-        // FIXME
-        // softcut::FadeCurves::setRecShape(static_cast<softcut::FadeCurves::Shape>(x));
-});
+  // FIXME: this escaped the script because it is converting ->f to int. is that
+  // on purpose?
+  //  float x = argv[0]->f;
+  float x = arg0;
+  auto t = std::thread([x] {
+    // FIXME
+    // softcut::FadeCurves::setRecShape(static_cast<softcut::FadeCurves::Shape>(x));
+  });
   t.detach();
 }
 
 void crone_set_param_cut_level_slew_time(int arg0, float arg1) {
-  crone::Commands::softcutCommands.post(crone::Commands::Id::SET_CUT_LEVEL_SLEW_TIME, arg0,
-                                 arg1);
+  crone::Commands::softcutCommands.post(
+      crone::Commands::Id::SET_CUT_LEVEL_SLEW_TIME, arg0, arg1);
 }
 
-void crone_set_param_cut_pan_slew_time(int arg0, float arg1) { 
-  crone::Commands::softcutCommands.post(crone::Commands::Id::SET_CUT_PAN_SLEW_TIME, arg0,
-                                 arg1);
+void crone_set_param_cut_pan_slew_time(int arg0, float arg1) {
+  crone::Commands::softcutCommands.post(
+      crone::Commands::Id::SET_CUT_PAN_SLEW_TIME, arg0, arg1);
 }
 
 void crone_set_param_cut_recpre_slew_time(int arg0, float arg1) {
-  crone::Commands::softcutCommands.post(crone::Commands::Id::SET_CUT_RECPRE_SLEW_TIME, arg0,
-                                 arg1);
+  crone::Commands::softcutCommands.post(
+      crone::Commands::Id::SET_CUT_RECPRE_SLEW_TIME, arg0, arg1);
 }
 
 void crone_set_param_cut_rate_slew_time(int arg0, float arg1) {
-  crone::Commands::softcutCommands.post(crone::Commands::Id::SET_CUT_RATE_SLEW_TIME, arg0,
-                                 arg1);
+  crone::Commands::softcutCommands.post(
+      crone::Commands::Id::SET_CUT_RATE_SLEW_TIME, arg0, arg1);
 }
 
 void crone_set_param_cut_buffer(int arg0, int arg1) {
-  crone::Commands::softcutCommands.post(crone::Commands::Id::SET_CUT_BUFFER, arg0, arg1);
+  crone::Commands::softcutCommands.post(crone::Commands::Id::SET_CUT_BUFFER,
+                                        arg0, arg1);
 }
 
 void crone_cut_buffer_read_mono(const char *arg0, float arg1, float arg2,
-                                    float arg3, int arg4, int arg5, float arg6,
-                                    float arg7) {
-
-// FIXME: defaults
+                                float arg3, int arg4, int arg5, float arg6,
+                                float arg7) {
+  // FIXME: defaults
   float startSrc = 0.f;
   float startDst = 0.f;
   float dur = -1.f;
@@ -370,9 +400,9 @@ void crone_cut_buffer_read_mono(const char *arg0, float arg1, float arg2,
 }
 
 void crone_cut_buffer_read_stereo(const char *arg0, float arg1, float arg2,
-                                      float arg3, float arg4, float arg5) {
-                                        // FIXME: defaults
-// FIXME: default args
+                                  float arg3, float arg4, float arg5) {
+  // FIXME: defaults
+  // FIXME: default args
   float startSrc = 0.f;
   float startDst = 0.f;
   float dur = -1.f;
@@ -383,8 +413,8 @@ void crone_cut_buffer_read_stereo(const char *arg0, float arg1, float arg2,
 }
 
 void crone_cut_buffer_write_mono(const char *arg0, float arg1, float arg2,
-                                     int arg3) {
-  // FIXME: defaults  
+                                 int arg3) {
+  // FIXME: defaults
   float start = 0.f;
   float dur = -1.f;
   int chan = 0;
@@ -392,13 +422,11 @@ void crone_cut_buffer_write_mono(const char *arg0, float arg1, float arg2,
   softCutClient->writeBufferMono(str, start, dur, chan);
 }
 
-void crone_cut_buffer_write_stereo(const char *arg0, float arg1,
-                                       float arg2) {
-  
+void crone_cut_buffer_write_stereo(const char *arg0, float arg1, float arg2) {
   // FIXME: default args
   float start = 0.f;
   float dur = -1.f;
-  
+
   const char *str = arg0;
   softCutClient->writeBufferStereo(str, start, dur);
 }
@@ -412,19 +440,19 @@ void crone_cut_buffer_clear_channel(int arg0) {
   softCutClient->clearBuffer(arg0);
 }
 
-void crone_cut_buffer_clear_region(float start, float dur, float fade_time, float preserve) {
-  softCutClient->clearBuffer(0, start, dur, fade_time, preserve);
-  softCutClient->clearBuffer(1, dur, fade_time, preserve);
+void crone_cut_buffer_clear_region(float start, float dur, float fade_time,
+                                   float preserve) {
+  softCutClient->clearBufferWithFade(0, start, dur, fade_time, preserve);
+  softCutClient->clearBufferWithFade(1, start, dur, fade_time, preserve);
 }
 
-void crone_cut_buffer_clear_region_channel(int arg0, float arg1,
-                                               float arg2) {
-  softCutClient->clearBuffer(arg0, arg1, arg2);
+void crone_cut_buffer_clear_region_channel(int ch, float start, float dur,
+                                           float fade_time, float preserve) {
+  softCutClient->clearBufferWithFade(ch, start, dur, fade_time, preserve);
 }
 
 void crone_cut_buffer_clear_fade_region(float arg0, float arg1, float arg2,
-                                            float arg3) {
-                                            
+                                        float arg3) {
   // FIXME: default args
   float dur = -1;
   float fadeTime = 0;
@@ -434,8 +462,8 @@ void crone_cut_buffer_clear_fade_region(float arg0, float arg1, float arg2,
 }
 
 void crone_cut_buffer_clear_fade_region_channel(int arg0, float arg1,
-                                                    float arg2, float arg3,
-                                                    float arg4) {
+                                                float arg2, float arg3,
+                                                float arg4) {
   // FIXME: default args
   float dur = -1;
   float fadeTime = 0;
@@ -444,8 +472,7 @@ void crone_cut_buffer_clear_fade_region_channel(int arg0, float arg1,
 }
 
 void crone_cut_buffer_copy_mono(int arg0, int arg1, float arg2, float arg3,
-                                    float arg4, float arg5, float arg6,
-                                    int arg7) {
+                                float arg4, float arg5, float arg6, int arg7) {
   // FIXME: default args
   float dur = -1.f;
   float fadeTime = 0.f;
@@ -457,7 +484,7 @@ void crone_cut_buffer_copy_mono(int arg0, int arg1, float arg2, float arg3,
 }
 
 void crone_cut_buffer_copy_stereo(float arg0, float arg1, float arg2,
-                                      float arg3, float arg4, int arg5) {
+                                  float arg3, float arg4, int arg5) {
   // FIXME: default args
   float dur = -1.f;
   float fadeTime = 0.f;
@@ -491,7 +518,6 @@ void crone_cut_query_position(int arg0) {
 }
 
 void crone_cut_reset() {
-
   softCutClient->clearBuffer(0, 0, -1);
   softCutClient->clearBuffer(1, 0, -1);
 
@@ -502,12 +528,10 @@ void crone_cut_reset() {
 }
 
 void crone_set_param_cut_phase_quant(int arg0, float arg1) {
-
   softCutClient->setPhaseQuant(arg0, arg1);
 }
 
 void crone_set_param_cut_phase_offset(int arg0, float arg1) {
-
   softCutClient->setPhaseOffset(arg0, arg1);
 }
 
@@ -524,7 +548,6 @@ void crone_tape_rec_start() { mixerClient->startTapeRecord(); }
 void crone_tape_rec_stop() { mixerClient->stopTapeRecord(); }
 
 void crone_tape_play_open(const char *arg0) {
-
   mixerClient->openTapePlayback(arg0);
 }
 
@@ -533,11 +556,13 @@ void crone_tape_play_start() { mixerClient->startTapePlayback(); }
 void crone_tape_play_stop() { mixerClient->stopTapePlayback(); }
 
 void crone_set_level_tape(float arg0) {
-  crone::Commands::mixerCommands.post(crone::Commands::Id::SET_LEVEL_TAPE, arg0);
+  crone::Commands::mixerCommands.post(crone::Commands::Id::SET_LEVEL_TAPE,
+                                      arg0);
 }
 
 void crone_set_level_tape_rev(float arg0) {
-  crone::Commands::mixerCommands.post(crone::Commands::Id::SET_LEVEL_TAPE_AUX, arg0);
+  crone::Commands::mixerCommands.post(crone::Commands::Id::SET_LEVEL_TAPE_AUX,
+                                      arg0);
 }
 
 #endif

--- a/crone/src/crone_param_dispatch.cpp
+++ b/crone/src/crone_param_dispatch.cpp
@@ -1,0 +1,110 @@
+#include <functional>
+#include <map>
+#include <stdexcept>
+
+#include "crone.h"
+#include "crone_param_dispatch.h"
+
+
+std::map<const std::string &, std::function<void(int, float)>>
+  cut_param_fn_map = {
+        {"play_flag", crone_set_param_cut_play_flag},
+        { "rate", crone_set_param_cut_rate },
+	{ "loop_start", crone_set_param_cut_loop_start },
+	{ "loop_end", crone_set_param_cut_loop_end },
+	{ "loop_flag", crone_set_param_cut_loop_flag },
+	{ "fade_time", crone_set_param_cut_fade_time },
+	{ "rec_level", crone_set_param_cut_rec_level },
+	{ "pre_level", crone_set_param_cut_pre_level },
+	{ "rec_flag", crone_set_param_cut_rec_flag },
+	{ "rec_offset", crone_set_param_cut_rec_offset },
+	{ "position", crone_set_param_cut_position },
+	{ "buffer", crone_set_param_cut_buffer },
+	{ "voice_sync", crone_set_param_cut_voice_sync },
+	{ "pre_filter_fc", crone_set_param_cut_pre_filter_fc },
+	{ "pre_filter_fc_mod", crone_set_param_cut_pre_filter_fc_mod },
+	{ "pre_filter_rq", crone_set_param_cut_pre_filter_rq },
+	{ "pre_filter_lp", crone_set_param_cut_pre_filter_lp },
+	{ "pre_filter_hp", crone_set_param_cut_pre_filter_hp },
+	{ "pre_filter_bp", crone_set_param_cut_pre_filter_bp },
+	{ "pre_filter_br", crone_set_param_cut_pre_filter_br },
+	{ "pre_filter_dry", crone_set_param_cut_pre_filter_dry },
+	{ "post_filter_fc", crone_set_param_cut_post_filter_fc },
+	{ "post_filter_rq", crone_set_param_cut_post_filter_rq },
+	{ "post_filter_lp", crone_set_param_cut_post_filter_lp },
+	{ "post_filter_hp", crone_set_param_cut_post_filter_hp },
+	{ "post_filter_bp", crone_set_param_cut_post_filter_bp },
+	{ "post_filter_br", crone_set_param_cut_post_filter_br },
+	{ "post_filter_dry", crone_set_param_cut_post_filter_dry },
+	{ "level_slew_time", crone_set_param_cut_level_slew_time },
+	{ "pan_slew_time", crone_set_param_cut_pan_slew_time },
+	{ "recpre_slew_time", crone_set_param_cut_recpre_slew_time },
+	{ "rate_slew_time", crone_set_param_cut_rate_slew_time }
+};
+
+std::map<const std::string &, std::function<void(int, int)>>
+    cut_param_fn_map_ii = {
+        {"play_flag", crone_set_param_cut_play_flag},
+};
+
+
+std::map<const std::string &, std::function<void(int, int, float)>>
+    cut_param_fn_map_iif = {
+        {"play_flag", crone_set_param_cut_play_flag},
+};
+
+
+
+void crone_set_cut_param(const char *name, int voice, float value) {
+  const std::string k(name);
+  try {
+    auto fn = voice_param_fn_map.at(k);
+    fn(voice, value);
+  } catch (std::out_of_range) {
+    std::cerr << "unknown softcut parameter:" << name << std::endl;
+  }
+}
+
+void crone_set_cut_param_ii(const char *name, int voice, int value) {}
+
+void crone_set_cut_param_iif(const char *name, int a, int b, float value) {}
+
+
+
+// enum class softcut_param {
+// play_flag,
+// rate,
+// loop_start,
+// loop_end,
+// loop_flag,
+// fade_time,
+// rec_level,
+// pre_level,
+// rec_flag,
+// rec_offset,
+// position,
+// buffer,
+// voice_sync,
+// pre_filter_fc,
+// pre_filter_fc_mod,
+// pre_filter_rq,
+// pre_filter_lp,
+// pre_filter_hp,
+// pre_filter_bp,
+// pre_filter_br,
+// pre_filter_dry,
+// post_filter_fc,
+// post_filter_fc,
+// post_filter_rq,
+// post_filter_lp,
+// post_filter_hp,
+// post_filter_bp,
+// post_filter_br,
+// post_filter_dry,
+// level_slew_time,
+// pan_slew_time,
+// recpre_slew_time,
+// rate_slew_time,
+// phase_quant,
+// phase_offset,
+// };

--- a/crone/src/crone_param_dispatch.cpp
+++ b/crone/src/crone_param_dispatch.cpp
@@ -35,7 +35,8 @@ std::map<const std::string, std::function<void(int, float)>> cut_param_fn_map =
      {"level_slew_time", crone_set_param_cut_level_slew_time},
      {"pan_slew_time", crone_set_param_cut_pan_slew_time},
      {"recpre_slew_time", crone_set_param_cut_recpre_slew_time},
-     {"rate_slew_time", crone_set_param_cut_rate_slew_time}};
+     {"rate_slew_time", crone_set_param_cut_rate_slew_time}
+};
 
 std::map<const std::string, std::function<void(int, int)>> cut_param_fn_map_ii =
     {
@@ -45,6 +46,26 @@ std::map<const std::string, std::function<void(int, int)>> cut_param_fn_map_ii =
 std::map<const std::string, std::function<void(int, int, float)>>
     cut_param_fn_map_iif = {
         {"voice_sync", crone_set_param_cut_voice_sync},
+};
+
+std::map<const std::string, std::function<void(float)>>
+reverb_param_fn_map = {
+  {"hf_damp", crone_set_param_reverb_hf_damp},
+  {"mid_rt60", crone_set_param_reverb_mid_rt60},
+  {"low_rt60", crone_set_param_reverb_low_rt60},
+  {"lf_fc", crone_set_param_reverb_lf_fc},
+  {"pre_del", crone_set_param_reverb_pre_del},
+};
+
+std::map<const std::string, std::function<void(float)>>
+compressor_param_fn_map = {
+  {"ratio", crone_set_param_compressor_ratio},
+  {"threshold", crone_set_param_compressor_threshold},
+  {"attack", crone_set_param_compressor_attack},
+  {"release", crone_set_param_compressor_release},
+  {"gain_pre", crone_set_param_compressor_gain_pre},
+  {"gain_post", crone_set_param_compressor_gain_post},
+  
 };
 
 void crone_set_cut_param(const char* name, int voice, float value) {
@@ -77,50 +98,22 @@ void crone_set_cut_param_iif(const char* name, int a, int b, float value) {
   }
 }
 
+void crone_set_reverb_param(const char* name, float value) {
+  const std::string k(name);
+  try {
+    auto fn = reverb_param_fn_map.at(k);
+    fn(value);
+  } catch (std::out_of_range& ex) {
+    std::cerr << "unknown reverb parameter:" << name << std::endl;
+  }
+}
 
-
-////////////////////////////////////////////////////////////////////////
-////////////////////////////////////////////////
-////////////////////////
-/// big TODO: FX parameters
-
-
-
-
-// enum class softcut_param {
-// play_flag,
-// rate,
-// loop_start,
-// loop_end,
-// loop_flag,
-// fade_time,
-// rec_level,
-// pre_level,
-// rec_flag,
-// rec_offset,
-// position,
-// buffer,
-// voice_sync,
-// pre_filter_fc,
-// pre_filter_fc_mod,
-// pre_filter_rq,
-// pre_filter_lp,
-// pre_filter_hp,
-// pre_filter_bp,
-// pre_filter_br,
-// pre_filter_dry,
-// post_filter_fc,
-// post_filter_fc,
-// post_filter_rq,
-// post_filter_lp,
-// post_filter_hp,
-// post_filter_bp,
-// post_filter_br,
-// post_filter_dry,
-// level_slew_time,
-// pan_slew_time,
-// recpre_slew_time,
-// rate_slew_time,
-// phase_quant,
-// phase_offset,
-// };
+void crone_set_compressor_param(const char* name, float value) {
+  const std::string k(name);
+  try {
+    auto fn = compressor_param_fn_map.at(k);
+    fn(value);
+  } catch (std::out_of_range& ex) {
+    std::cerr << "unknown compressor parameter:" << name << std::endl;
+  }
+}

--- a/crone/src/crone_param_dispatch.cpp
+++ b/crone/src/crone_param_dispatch.cpp
@@ -6,49 +6,45 @@
 #include "crone_param_dispatch.h"
 
 std::map<const std::string, std::function<void(int, float)>> cut_param_fn_map =
-    {
-        {"play_flag", crone_set_param_cut_play_flag},
-        {"rate", crone_set_param_cut_rate},
-        // {"loop_start", crone_set_param_cut_loop_start},
-        // {"loop_end", crone_set_param_cut_loop_end},
-        // {"loop_flag", crone_set_param_cut_loop_flag},
-        // {"fade_time", crone_set_param_cut_fade_time},
-        // {"rec_level", crone_set_param_cut_rec_level},
-        // {"pre_level", crone_set_param_cut_pre_level},
-        // {"rec_flag", crone_set_param_cut_rec_flag},
-        // {"rec_offset", crone_set_param_cut_rec_offset},
-        // {"position", crone_set_param_cut_position},
-        // //{"buffer", crone_set_param_cut_buffer},
-        // //
-        // {"pre_filter_fc", crone_set_param_cut_pre_filter_fc},
-        // {"pre_filter_fc_mod", crone_set_param_cut_pre_filter_fc_mod},
-        // {"pre_filter_rq", crone_set_param_cut_pre_filter_rq},
-        // {"pre_filter_lp", crone_set_param_cut_pre_filter_lp},
-        // {"pre_filter_hp", crone_set_param_cut_pre_filter_hp},
-        // {"pre_filter_bp", crone_set_param_cut_pre_filter_bp},
-        // {"pre_filter_br", crone_set_param_cut_pre_filter_br},
-        // {"pre_filter_dry", crone_set_param_cut_pre_filter_dry},
-        // {"post_filter_fc", crone_set_param_cut_post_filter_fc},
-        // {"post_filter_rq", crone_set_param_cut_post_filter_rq},
-        // {"post_filter_lp", crone_set_param_cut_post_filter_lp},
-        // {"post_filter_hp", crone_set_param_cut_post_filter_hp},
-        // {"post_filter_bp", crone_set_param_cut_post_filter_bp},
-        // {"post_filter_br", crone_set_param_cut_post_filter_br},
-        // {"post_filter_dry", crone_set_param_cut_post_filter_dry},
-        // {"level_slew_time", crone_set_param_cut_level_slew_time},
-        // {"pan_slew_time", crone_set_param_cut_pan_slew_time},
-        // {"recpre_slew_time", crone_set_param_cut_recpre_slew_time},
-        // {"rate_slew_time", crone_set_param_cut_rate_slew_time}
-};
+    {{"play_flag", crone_set_param_cut_play_flag},
+     {"rate", crone_set_param_cut_rate},
+     {"loop_start", crone_set_param_cut_loop_start},
+     {"loop_end", crone_set_param_cut_loop_end},
+     {"loop_flag", crone_set_param_cut_loop_flag},
+     {"fade_time", crone_set_param_cut_fade_time},
+     {"rec_level", crone_set_param_cut_rec_level},
+     {"pre_level", crone_set_param_cut_pre_level},
+     {"rec_flag", crone_set_param_cut_rec_flag},
+     {"rec_offset", crone_set_param_cut_rec_offset},
+     {"position", crone_set_param_cut_position},
+     {"pre_filter_fc", crone_set_param_cut_pre_filter_fc},
+     {"pre_filter_fc_mod", crone_set_param_cut_pre_filter_fc_mod},
+     {"pre_filter_rq", crone_set_param_cut_pre_filter_rq},
+     {"pre_filter_lp", crone_set_param_cut_pre_filter_lp},
+     {"pre_filter_hp", crone_set_param_cut_pre_filter_hp},
+     {"pre_filter_bp", crone_set_param_cut_pre_filter_bp},
+     {"pre_filter_br", crone_set_param_cut_pre_filter_br},
+     {"pre_filter_dry", crone_set_param_cut_pre_filter_dry},
+     {"post_filter_fc", crone_set_param_cut_post_filter_fc},
+     {"post_filter_rq", crone_set_param_cut_post_filter_rq},
+     {"post_filter_lp", crone_set_param_cut_post_filter_lp},
+     {"post_filter_hp", crone_set_param_cut_post_filter_hp},
+     {"post_filter_bp", crone_set_param_cut_post_filter_bp},
+     {"post_filter_br", crone_set_param_cut_post_filter_br},
+     {"post_filter_dry", crone_set_param_cut_post_filter_dry},
+     {"level_slew_time", crone_set_param_cut_level_slew_time},
+     {"pan_slew_time", crone_set_param_cut_pan_slew_time},
+     {"recpre_slew_time", crone_set_param_cut_recpre_slew_time},
+     {"rate_slew_time", crone_set_param_cut_rate_slew_time}};
 
 std::map<const std::string, std::function<void(int, int)>> cut_param_fn_map_ii =
     {
-        //    { "buffer", crone_set_param_cut_buffer },
+        {"buffer", crone_set_param_cut_buffer},
 };
 
 std::map<const std::string, std::function<void(int, int, float)>>
     cut_param_fn_map_iif = {
-        //   { "voice_sync", crone_set_param_cut_voice_sync },
+        {"voice_sync", crone_set_param_cut_voice_sync},
 };
 
 void crone_set_cut_param(const char* name, int voice, float value) {
@@ -80,6 +76,16 @@ void crone_set_cut_param_iif(const char* name, int a, int b, float value) {
     std::cerr << "unknown softcut parameter:" << name << std::endl;
   }
 }
+
+
+
+////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////
+////////////////////////
+/// big TODO: FX parameters
+
+
+
 
 // enum class softcut_param {
 // play_flag,

--- a/crone/src/crone_param_dispatch.cpp
+++ b/crone/src/crone_param_dispatch.cpp
@@ -5,71 +5,81 @@
 #include "crone.h"
 #include "crone_param_dispatch.h"
 
-
-std::map<const std::string &, std::function<void(int, float)>>
-  cut_param_fn_map = {
+std::map<const std::string, std::function<void(int, float)>> cut_param_fn_map =
+    {
         {"play_flag", crone_set_param_cut_play_flag},
-        { "rate", crone_set_param_cut_rate },
-	{ "loop_start", crone_set_param_cut_loop_start },
-	{ "loop_end", crone_set_param_cut_loop_end },
-	{ "loop_flag", crone_set_param_cut_loop_flag },
-	{ "fade_time", crone_set_param_cut_fade_time },
-	{ "rec_level", crone_set_param_cut_rec_level },
-	{ "pre_level", crone_set_param_cut_pre_level },
-	{ "rec_flag", crone_set_param_cut_rec_flag },
-	{ "rec_offset", crone_set_param_cut_rec_offset },
-	{ "position", crone_set_param_cut_position },
-	{ "buffer", crone_set_param_cut_buffer },
-	{ "voice_sync", crone_set_param_cut_voice_sync },
-	{ "pre_filter_fc", crone_set_param_cut_pre_filter_fc },
-	{ "pre_filter_fc_mod", crone_set_param_cut_pre_filter_fc_mod },
-	{ "pre_filter_rq", crone_set_param_cut_pre_filter_rq },
-	{ "pre_filter_lp", crone_set_param_cut_pre_filter_lp },
-	{ "pre_filter_hp", crone_set_param_cut_pre_filter_hp },
-	{ "pre_filter_bp", crone_set_param_cut_pre_filter_bp },
-	{ "pre_filter_br", crone_set_param_cut_pre_filter_br },
-	{ "pre_filter_dry", crone_set_param_cut_pre_filter_dry },
-	{ "post_filter_fc", crone_set_param_cut_post_filter_fc },
-	{ "post_filter_rq", crone_set_param_cut_post_filter_rq },
-	{ "post_filter_lp", crone_set_param_cut_post_filter_lp },
-	{ "post_filter_hp", crone_set_param_cut_post_filter_hp },
-	{ "post_filter_bp", crone_set_param_cut_post_filter_bp },
-	{ "post_filter_br", crone_set_param_cut_post_filter_br },
-	{ "post_filter_dry", crone_set_param_cut_post_filter_dry },
-	{ "level_slew_time", crone_set_param_cut_level_slew_time },
-	{ "pan_slew_time", crone_set_param_cut_pan_slew_time },
-	{ "recpre_slew_time", crone_set_param_cut_recpre_slew_time },
-	{ "rate_slew_time", crone_set_param_cut_rate_slew_time }
+        {"rate", crone_set_param_cut_rate},
+        // {"loop_start", crone_set_param_cut_loop_start},
+        // {"loop_end", crone_set_param_cut_loop_end},
+        // {"loop_flag", crone_set_param_cut_loop_flag},
+        // {"fade_time", crone_set_param_cut_fade_time},
+        // {"rec_level", crone_set_param_cut_rec_level},
+        // {"pre_level", crone_set_param_cut_pre_level},
+        // {"rec_flag", crone_set_param_cut_rec_flag},
+        // {"rec_offset", crone_set_param_cut_rec_offset},
+        // {"position", crone_set_param_cut_position},
+        // //{"buffer", crone_set_param_cut_buffer},
+        // //
+        // {"pre_filter_fc", crone_set_param_cut_pre_filter_fc},
+        // {"pre_filter_fc_mod", crone_set_param_cut_pre_filter_fc_mod},
+        // {"pre_filter_rq", crone_set_param_cut_pre_filter_rq},
+        // {"pre_filter_lp", crone_set_param_cut_pre_filter_lp},
+        // {"pre_filter_hp", crone_set_param_cut_pre_filter_hp},
+        // {"pre_filter_bp", crone_set_param_cut_pre_filter_bp},
+        // {"pre_filter_br", crone_set_param_cut_pre_filter_br},
+        // {"pre_filter_dry", crone_set_param_cut_pre_filter_dry},
+        // {"post_filter_fc", crone_set_param_cut_post_filter_fc},
+        // {"post_filter_rq", crone_set_param_cut_post_filter_rq},
+        // {"post_filter_lp", crone_set_param_cut_post_filter_lp},
+        // {"post_filter_hp", crone_set_param_cut_post_filter_hp},
+        // {"post_filter_bp", crone_set_param_cut_post_filter_bp},
+        // {"post_filter_br", crone_set_param_cut_post_filter_br},
+        // {"post_filter_dry", crone_set_param_cut_post_filter_dry},
+        // {"level_slew_time", crone_set_param_cut_level_slew_time},
+        // {"pan_slew_time", crone_set_param_cut_pan_slew_time},
+        // {"recpre_slew_time", crone_set_param_cut_recpre_slew_time},
+        // {"rate_slew_time", crone_set_param_cut_rate_slew_time}
 };
 
-std::map<const std::string &, std::function<void(int, int)>>
-    cut_param_fn_map_ii = {
-        {"play_flag", crone_set_param_cut_play_flag},
+std::map<const std::string, std::function<void(int, int)>> cut_param_fn_map_ii =
+    {
+        //    { "buffer", crone_set_param_cut_buffer },
 };
 
-
-std::map<const std::string &, std::function<void(int, int, float)>>
+std::map<const std::string, std::function<void(int, int, float)>>
     cut_param_fn_map_iif = {
-        {"play_flag", crone_set_param_cut_play_flag},
+        //   { "voice_sync", crone_set_param_cut_voice_sync },
 };
 
-
-
-void crone_set_cut_param(const char *name, int voice, float value) {
+void crone_set_cut_param(const char* name, int voice, float value) {
   const std::string k(name);
   try {
-    auto fn = voice_param_fn_map.at(k);
+    auto fn = cut_param_fn_map.at(k);
     fn(voice, value);
-  } catch (std::out_of_range) {
+  } catch (std::out_of_range& ex) {
     std::cerr << "unknown softcut parameter:" << name << std::endl;
   }
 }
 
-void crone_set_cut_param_ii(const char *name, int voice, int value) {}
+void crone_set_cut_param_ii(const char* name, int voice, int value) {
+  const std::string k(name);
+  try {
+    auto fn = cut_param_fn_map_ii.at(k);
+    fn(voice, value);
+  } catch (std::out_of_range& ex) {
+    std::cerr << "unknown softcut parameter:" << name << std::endl;
+  }
+}
 
-void crone_set_cut_param_iif(const char *name, int a, int b, float value) {}
-
-
+void crone_set_cut_param_iif(const char* name, int a, int b, float value) {
+  const std::string k(name);
+  try {
+    auto fn = cut_param_fn_map_iif.at(k);
+    fn(a, b, value);
+  } catch (std::out_of_range& ex) {
+    std::cerr << "unknown softcut parameter:" << name << std::endl;
+  }
+}
 
 // enum class softcut_param {
 // play_flag,

--- a/crone/src/crone_param_dispatch.h
+++ b/crone/src/crone_param_dispatch.h
@@ -5,4 +5,7 @@ void crone_set_cut_param(const char* name, int voice, float value);
 void crone_set_cut_param_ii(const char *name, int voice, int value);
 void crone_set_cut_param_iif(const char *name, int a, int b, float value);
 
+void crone_set_compressor_param(const char* name, float value);
+void crone_set_reverb_param(const char* name, float value);
+
 #endif

--- a/crone/src/crone_param_dispatch.h
+++ b/crone/src/crone_param_dispatch.h
@@ -1,0 +1,8 @@
+#ifndef _CRONE_PARAM_DISPATCH_H_
+#define _CRONE_PARAM_DISPATCH_H_
+
+void crone_set_cut_param(const char* name, int voice, float value);
+void crone_set_cut_param_ii(const char *name, int voice, int value);
+void crone_set_cut_param_iif(const char *name, int a, int b, float value);
+
+#endif

--- a/crone/src/main.cpp
+++ b/crone/src/main.cpp
@@ -12,6 +12,8 @@
 #include "OscInterface.h"
 #include "BufDiskWorker.h"
 
+#include "crone.h"
+
 static inline void sleep(int ms) {
     std::this_thread::sleep_for(std::chrono::milliseconds(ms));
 }
@@ -38,6 +40,7 @@ int crone_main() {
 
     m = std::make_unique<MixerClient>();
     sc = std::make_unique<SoftcutClient>();
+    crone_init (m.get(), sc.get());
 
     cout << "initializing buffer management worker.." << endl;
     BufDiskWorker::init(48000);

--- a/matron/src/oracle.cc
+++ b/matron/src/oracle.cc
@@ -23,8 +23,9 @@
 #include "oracle.h"
 
 #include "crone.h"
+#include "crone_param_dispatch.h"
 
-// address of external DSP environment (e.g. supercollider)
+// address of external audio process (e.g. supercollider)
 static lo_address ext_addr;
 // address of crone process
 static lo_address crone_addr;
@@ -456,17 +457,17 @@ void o_set_level_ext(float level) { crone_set_level_ext(level); }
 void o_set_level_monitor(float level) { crone_set_level_monitor(level); }
 
 void o_set_monitor_mix_mono() {
-  lo_send(crone_addr, "/set/level/monitor_mix", "if", 0, 0.5);
-  lo_send(crone_addr, "/set/level/monitor_mix", "if", 1, 0.5);
-  lo_send(crone_addr, "/set/level/monitor_mix", "if", 2, 0.5);
-  lo_send(crone_addr, "/set/level/monitor_mix", "if", 3, 0.5);
+    crone_set_level_monitor_mix(0, 0.5f);
+    crone_set_level_monitor_mix(1, 0.5f);
+    crone_set_level_monitor_mix(2, 0.5f;
+    crone_set_level_monitor_mix(3, 0.5f);
 }
 
 void o_set_monitor_mix_stereo() {
-  lo_send(crone_addr, "/set/level/monitor_mix", "if", 0, 1.0);
-  lo_send(crone_addr, "/set/level/monitor_mix", "if", 1, 0.0);
-  lo_send(crone_addr, "/set/level/monitor_mix", "if", 2, 0.0);
-  lo_send(crone_addr, "/set/level/monitor_mix", "if", 3, 1.0);
+    crone_set_level_monitor_mix(0, 1.f);
+    crone_set_level_monitor_mix(1, 0.f);
+    crone_set_level_monitor_mix(2, 0.f);
+    crone_set_level_monitor_mix(3, 1.f);
 }
 
 void o_set_audio_pitch_on() { lo_send(ext_addr, "/audio/pitch/on", NULL); }
@@ -517,20 +518,18 @@ void o_set_pan_cut(int index, float value) { crone_set_pan_cut(index, value); }
 
 void o_set_cut_param(const char *name, int voice, float value) {
     (void)name; (void)voice; (void)value;
-  // FIXME
-  // crone_set_cut_param( name, voice, value);
+    crone
+  crone_set_cut_param( name, voice, value);
 }
 
 void o_set_cut_param_ii(const char *name, int voice, int value) {
     (void)name; (void)voice; (void)value;
-  // FIXME
-  // crone_set_cut_param_ii(name, voice, value);
+    crone_set_cut_param_ii(name, voice, value);
 }
 
 void o_set_cut_param_iif(const char *name, int a, int b, float v) {
     (void)name; (void)a; (void)b; (void)v;
-  // FIXME
-  // crone_set_cut_param_iif(name, a, b, v);
+  crone_set_cut_param_iif(name, a, b, v);
 }
 
 void o_set_level_input_cut(int src, int dst, float level) {

--- a/matron/src/oracle.cc
+++ b/matron/src/oracle.cc
@@ -23,9 +23,8 @@
 #include "oracle.h"
 
 #include "crone.h"
-#include "crone_param_dispatch.h"
 
-// address of external audio process (e.g. supercollider)
+// address of external DSP environment (e.g. supercollider)
 static lo_address ext_addr;
 // address of crone process
 static lo_address crone_addr;
@@ -457,17 +456,17 @@ void o_set_level_ext(float level) { crone_set_level_ext(level); }
 void o_set_level_monitor(float level) { crone_set_level_monitor(level); }
 
 void o_set_monitor_mix_mono() {
-    crone_set_level_monitor_mix(0, 0.5f);
-    crone_set_level_monitor_mix(1, 0.5f);
-    crone_set_level_monitor_mix(2, 0.5f;
-    crone_set_level_monitor_mix(3, 0.5f);
+  lo_send(crone_addr, "/set/level/monitor_mix", "if", 0, 0.5);
+  lo_send(crone_addr, "/set/level/monitor_mix", "if", 1, 0.5);
+  lo_send(crone_addr, "/set/level/monitor_mix", "if", 2, 0.5);
+  lo_send(crone_addr, "/set/level/monitor_mix", "if", 3, 0.5);
 }
 
 void o_set_monitor_mix_stereo() {
-    crone_set_level_monitor_mix(0, 1.f);
-    crone_set_level_monitor_mix(1, 0.f);
-    crone_set_level_monitor_mix(2, 0.f);
-    crone_set_level_monitor_mix(3, 1.f);
+  lo_send(crone_addr, "/set/level/monitor_mix", "if", 0, 1.0);
+  lo_send(crone_addr, "/set/level/monitor_mix", "if", 1, 0.0);
+  lo_send(crone_addr, "/set/level/monitor_mix", "if", 2, 0.0);
+  lo_send(crone_addr, "/set/level/monitor_mix", "if", 3, 1.0);
 }
 
 void o_set_audio_pitch_on() { lo_send(ext_addr, "/audio/pitch/on", NULL); }
@@ -518,18 +517,20 @@ void o_set_pan_cut(int index, float value) { crone_set_pan_cut(index, value); }
 
 void o_set_cut_param(const char *name, int voice, float value) {
     (void)name; (void)voice; (void)value;
-    crone
-  crone_set_cut_param( name, voice, value);
+  // FIXME
+  // crone_set_cut_param( name, voice, value);
 }
 
 void o_set_cut_param_ii(const char *name, int voice, int value) {
     (void)name; (void)voice; (void)value;
-    crone_set_cut_param_ii(name, voice, value);
+  // FIXME
+  // crone_set_cut_param_ii(name, voice, value);
 }
 
 void o_set_cut_param_iif(const char *name, int a, int b, float v) {
     (void)name; (void)a; (void)b; (void)v;
-  crone_set_cut_param_iif(name, a, b, v);
+  // FIXME
+  // crone_set_cut_param_iif(name, a, b, v);
 }
 
 void o_set_level_input_cut(int src, int dst, float level) {

--- a/matron/src/oracle.cc
+++ b/matron/src/oracle.cc
@@ -615,16 +615,11 @@ void o_set_level_monitor_rev(float value) {
 }
 
 void o_set_rev_param(const char *name, float value) {
-  /// FIXME
-  //    crone_set_rev_param(const char *name, float value);
+  crone_set_reverb_param(name,  value);
 }
 
 void o_set_comp_param(const char *name, float value) {
-  /// FIXME
-  // crone_set_comp_param(const char *name, float value);
-  //   static char buf[128];
-  //   sprintf(buf, "/set/param/compressor/%s", name);
-  //   lo_send(crone_addr, buf, "f", value);
+  crone_set_compressor_param(name, value);
 }
 
 /////////////////////

--- a/matron/src/oracle.cc
+++ b/matron/src/oracle.cc
@@ -506,7 +506,7 @@ void o_set_level_cut_rev(float value) { crone_set_level_cut_rev(value); }
 void o_set_level_cut_master(float value) { crone_set_level_cut_master(value); }
 
 void o_set_level_cut(int index, float value) {
-  crone_set_level_cut(index, float value);
+  crone_set_level_cut(index, value);
 }
 
 void o_set_level_cut_cut(int src, int dest, float value) {
@@ -516,22 +516,25 @@ void o_set_level_cut_cut(int src, int dest, float value) {
 void o_set_pan_cut(int index, float value) { crone_set_pan_cut(index, value); }
 
 void o_set_cut_param(const char *name, int voice, float value) {
+    (void)name; (void)voice; (void)value;
   // FIXME
   // crone_set_cut_param( name, voice, value);
 }
 
 void o_set_cut_param_ii(const char *name, int voice, int value) {
+    (void)name; (void)voice; (void)value;
   // FIXME
   // crone_set_cut_param_ii(name, voice, value);
 }
 
 void o_set_cut_param_iif(const char *name, int a, int b, float v) {
+    (void)name; (void)a; (void)b; (void)v;
   // FIXME
   // crone_set_cut_param_iif(name, a, b, v);
 }
 
 void o_set_level_input_cut(int src, int dst, float level) {
-  crone_set_level_input_cut(src, dst, level);
+  crone_set_level_in_cut(src, dst, level);
 }
 
 void o_cut_buffer_clear() { crone_cut_buffer_clear(); }
@@ -574,11 +577,11 @@ void o_cut_buffer_read_stereo(char *file, float start_src, float start_dst,
 }
 
 void o_cut_buffer_write_mono(char *file, float start, float dur, int ch) {
-  crone_cut_buffer_write_mono(*file, start, dur, ch);
+  crone_cut_buffer_write_mono(file, start, dur, ch);
 }
 
 void o_cut_buffer_write_stereo(char *file, float start, float dur) {
-  crone_cut_buffer_write_stereo(*file, start, dur);
+  crone_cut_buffer_write_stereo(file, start, dur);
 }
 
 void o_cut_buffer_render(int ch, float start, float dur, int samples) {
@@ -591,16 +594,16 @@ void o_cut_reset() { crone_cut_reset(); }
 
 //--- rev effects controls
 // enable / disable rev fx processing
-void o_set_rev_on() { crone_set_rev_on(); }
+void o_set_rev_on() { crone_set_enabled_reverb(1); }
 
-void o_set_rev_off() { crone_set_rev_off(); }
+void o_set_rev_off() { crone_set_enabled_reverb(0); }
 
 //--- comp effects controls
-void o_set_comp_on() { crone_set_comp_on(); }
+void o_set_comp_on() { crone_set_enabled_compressor(1); }
 
-void o_set_comp_off() { crone_set_comp_off(); }
+void o_set_comp_off() { crone_set_enabled_compressor(0); }
 
-void o_set_comp_mix(float value) { crone_set_comp_mix(value); }
+void o_set_comp_mix(float value) { crone_set_level_compressor_mix(value); }
 
 // stereo output -> rev
 void o_set_level_ext_rev(float value) { crone_set_level_ext_rev(value); }

--- a/matron/src/oracle.cc
+++ b/matron/src/oracle.cc
@@ -410,38 +410,37 @@ void o_request_poll_value(int idx) {
 //---- audio context control
 
 void o_poll_start_vu() {
-    lo_send(crone_addr, "/poll/start/vu", NULL);
+    crone_poll_start_vu();
 }
 
 void o_poll_stop_vu() {
-    lo_send(crone_addr, "/poll/stop/vu", NULL);
+    crone_poll_stop_vu();
 }
 
 void o_poll_start_cut_phase() {
+    crone_poll_start_cut_phase();
     lo_send(crone_addr, "/poll/start/cut/phase", NULL);
 }
 
 void o_poll_stop_cut_phase() {
-    lo_send(crone_addr, "/poll/stop/cut/phase", NULL);
+    crone_poll_stop_cut_phase();
 }
 
 void o_set_level_adc(float level) {
     crone_set_level_adc(level);
-    //lo_send(crone_addr, "/set/level/adc", "f", level);
 }
 
 void o_set_level_dac(float level) {
     fprintf(stderr, "setting DAC level (main thread): %f\n", level);
     crone_set_level_dac(level);
-//    lo_send(crone_addr, "/set/level/dac", "f", level);
 }
 
 void o_set_level_ext(float level) {
-    lo_send(crone_addr, "/set/level/ext", "f", level);
+  crone_set_level_ext( level);
 }
 
 void o_set_level_monitor(float level) {
-    lo_send(crone_addr, "/set/level/monitor", "f", level);
+  crone_set_level_monitor( level);
 }
 
 void o_set_monitor_mix_mono() {
@@ -472,117 +471,107 @@ void o_restart_audio() {
 
 //---- tape controls
 void o_set_level_tape(float level) {
-    lo_send(crone_addr, "/set/level/tape", "f", level);
+  crone_set_level_tape( level);
 }
 
 void o_set_level_tape_rev(float level) {
-    lo_send(crone_addr, "/set/level/tape_rev", "f", level);
+  crone_set_level_tape_rev( level);
 }
 
 void o_tape_rec_open(char *file) {
-    lo_send(crone_addr, "/tape/record/open", "s", file);
+  crone_tape_rec_open(file);
 }
 
 void o_tape_rec_start() {
-    lo_send(crone_addr, "/tape/record/start", NULL);
+  crone_tape_rec_start();
 }
 
 void o_tape_rec_stop() {
-    lo_send(crone_addr, "/tape/record/stop", NULL);
+  crone_tape_rec_stop();
 }
 
 void o_tape_play_open(char *file) {
-    lo_send(crone_addr, "/tape/play/open", "s", file);
+  crone_tape_play_open(file);
 }
 
 void o_tape_play_start() {
-    lo_send(crone_addr, "/tape/play/start", NULL);
+  crone_tape_play_start();
 }
 
 void o_tape_play_stop() {
-    lo_send(crone_addr, "/tape/play/stop", NULL);
+  crone_tape_play_stop();
 }
 
 //--- cut
 void o_cut_enable(int i, float value) {
-    lo_send(crone_addr, "/set/enabled/cut", "if", i, value);
+  crone_cut_enable( i, value);
 }
 
 void o_set_level_adc_cut(float value) {
-    lo_send(crone_addr, "/set/level/adc_cut", "f", value);
+  crone_set_level_adc_cut( value);
 }
 
 void o_set_level_ext_cut(float value) {
-    lo_send(crone_addr, "/set/level/ext_cut", "f", value);
+  crone_set_level_ext_cut( value);
 }
 
 void o_set_level_tape_cut(float value) {
-    lo_send(crone_addr, "/set/level/tape_cut", "f", value);
+  crone_set_level_tape_cut( value);
 }
 
 void o_set_level_cut_rev(float value) {
-    lo_send(crone_addr, "/set/level/cut_rev", "f", value);
+  crone_set_level_cut_rev( value);
 }
 
 void o_set_level_cut_master(float value) {
-    lo_send(crone_addr, "/set/level/cut_master", "f", value);
+  crone_set_level_cut_master( value);
 }
 
 void o_set_level_cut(int index, float value) {
-    lo_send(crone_addr, "/set/level/cut", "if", index, value);
+  crone_set_level_cut( index, float value);
 }
 
 void o_set_level_cut_cut(int src, int dest, float value) {
-    lo_send(crone_addr, "/set/level/cut_cut", "iif", src, dest, value);
+  crone_set_level_cut_cut( src,  dest,  value);
 }
 
 void o_set_pan_cut(int index, float value) {
-    lo_send(crone_addr, "/set/pan/cut", "if", index, value);
+  crone_set_pan_cut( index,  value);
 }
 
 void o_set_cut_param(const char *name, int voice, float value) {
-    static char buf[128];
-    sprintf(buf, "/set/param/cut/%s", name);
-    lo_send(crone_addr, buf, "if", voice, value);
+  crone_set_cut_param( name, voice, value);
 }
 
 void o_set_cut_param_ii(const char *name, int voice, int value) {
-    static char buf[128];
-    sprintf(buf, "/set/param/cut/%s", name);
-    lo_send(crone_addr, buf, "ii", voice, value);
+  crone_set_cut_param_ii(name, voice, value);
 }
 
 void o_set_cut_param_iif(const char *name, int a, int b, float v) {
-    static char buf[128];
-    sprintf(buf, "/set/param/cut/%s", name);
-    lo_send(crone_addr, buf, "iif", a, b, v);
+  crone_set_cut_param_iif(name, a, b, v);
 }
 
 void o_set_level_input_cut(int src, int dst, float level) {
-    lo_send(crone_addr, "/set/level/in_cut", "iif", src, dst, level);
+  crone_set_level_input_cut( src, dst, level);
 }
 
 void o_cut_buffer_clear() {
-    lo_send(crone_addr, "/softcut/buffer/clear", "");
+  crone_cut_buffer_clear();
 }
 
 void o_cut_buffer_clear_channel(int ch) {
-    lo_send(crone_addr, "/softcut/buffer/clear_channel", "i", ch);
+  crone_cut_buffer_clear_channel( ch);
 }
 
 void o_cut_buffer_clear_region(float start, float dur, float fade_time, float preserve) {
-    lo_send(crone_addr, "/softcut/buffer/clear_fade_region", "ffff", start, dur, fade_time, preserve);
+  crone_cut_buffer_clear_region( start,  dur,  fade_time,  preserve);
 }
 
 void o_cut_buffer_clear_region_channel(int ch, float start, float dur, float fade_time, float preserve) {
-    lo_send(crone_addr, "/softcut/buffer/clear_fade_region_channel", "iffff", ch, start, dur, fade_time, preserve);
+  crone_cut_buffer_clear_region_channel( ch,  start,  dur,  fade_time,  preserve);
 }
 
-void o_cut_buffer_copy_mono(int src_ch, int dst_ch,
-                            float src_start, float dst_start, float dur,
-                            float fade_time, float preserve, int reverse) {
-    lo_send(crone_addr, "/softcut/buffer/copy_mono", "iifffffi",
-            src_ch, dst_ch, src_start, dst_start, dur, fade_time, preserve, reverse);
+void o_cut_buffer_copy_mono(
 }
 
 void o_cut_buffer_copy_stereo(float src_start, float dst_start, float dur,
@@ -592,81 +581,82 @@ void o_cut_buffer_copy_stereo(float src_start, float dst_start, float dur,
 }
 
 void o_cut_buffer_read_mono(char *file, float start_src, float start_dst, float dur, int ch_src, int ch_dst, float preserve, float mix) {
-    lo_send(crone_addr, "/softcut/buffer/read_mono", "sfffiiff", file, start_src, start_dst, dur, ch_src, ch_dst, preserve, mix);
+  crone_cut_buffer_read_mono(file,  start_src,  start_dst,  dur,  ch_src,  ch_dst,  preserve,  mix);
 }
 
 void o_cut_buffer_read_stereo(char *file, float start_src, float start_dst, float dur, float preserve, float mix) {
-    lo_send(crone_addr, "/softcut/buffer/read_stereo", "sfffff", file, start_src, start_dst, dur, preserve, mix);
+  crone_cut_buffer_read_stereo( file,  start_src,  start_dst,  dur,  preserve,  mix);
 }
 
 void o_cut_buffer_write_mono(char *file, float start, float dur, int ch) {
-    lo_send(crone_addr, "/softcut/buffer/write_mono", "sffi", file, start, dur, ch);
+  crone_cut_buffer_write_mono( *file,  start,  dur,  ch);
 }
 
 void o_cut_buffer_write_stereo(char *file, float start, float dur) {
-    lo_send(crone_addr, "/softcut/buffer/write_stereo", "sff", file, start, dur);
+  crone_cut_buffer_write_stereo( *file,  start,  dur);
 }
 
 void o_cut_buffer_render(int ch, float start, float dur, int samples) {
-    lo_send(crone_addr, "/softcut/buffer/render", "iffi", ch, start, dur, samples);
+  crone_cut_buffer_render( ch,  start,  dur,  samples);
 }
 
 void o_cut_query_position(int i) {
-    lo_send(crone_addr, "/softcut/query/position", "i", i);
+  crone_cut_query_position( i);
 }
 
 void o_cut_reset() {
-    lo_send(crone_addr, "/softcut/reset", "");
+  crone_cut_reset();
 }
 
 //--- rev effects controls
 // enable / disable rev fx processing
 void o_set_rev_on() {
-    lo_send(crone_addr, "/set/enabled/reverb", "f", 1.0);
+  crone_set_rev_on();
 }
 
 void o_set_rev_off() {
-    lo_send(crone_addr, "/set/enabled/reverb", "f", 0.0);
+  crone_set_rev_off();
 }
 
 //--- comp effects controls
 void o_set_comp_on() {
-    lo_send(crone_addr, "/set/enabled/compressor", "f", 1.0);
+  crone_set_comp_on();
 }
 
 void o_set_comp_off() {
-    lo_send(crone_addr, "/set/enabled/compressor", "f", 0.0);
+  crone_set_comp_off();
 }
 
 void o_set_comp_mix(float value) {
-    lo_send(crone_addr, "/set/level/compressor_mix", "f", value);
+  crone_set_comp_mix( value);
 }
 
 // stereo output -> rev
 void o_set_level_ext_rev(float value) {
-    lo_send(crone_addr, "/set/level/ext_rev", "f", value);
+  crone_set_level_ext_rev( value);
 }
 
 // rev return -> dac
 void o_set_level_rev_dac(float value) {
-    lo_send(crone_addr, "/set/level/rev_dac", "f", value);
+  crone_set_level_rev_dac( value);
 }
 
 // monitor mix -> rev level
 void o_set_level_monitor_rev(float value) {
-    lo_send(crone_addr, "/set/level/monitor_rev", "f", value);
+  crone_set_level_monitor_rev( value);
 }
 
 void o_set_rev_param(const char *name, float value) {
-    static char buf[128];
-    sprintf(buf, "/set/param/reverb/%s", name);
-    lo_send(crone_addr, buf, "f", value);
+    /// FIXME
+  //    crone_set_rev_param(const char *name, float value);
 }
 
 void o_set_comp_param(const char *name, float value) {
-    static char buf[128];
-    sprintf(buf, "/set/param/compressor/%s", name);
-    lo_send(crone_addr, buf, "f", value);
+    /// FIXME
+  // crone_set_comp_param(const char *name, float value);
+  //   static char buf[128];
+  //   sprintf(buf, "/set/param/compressor/%s", name);
+  //   lo_send(crone_addr, buf, "f", value);
 }
 
 /////////////////////

--- a/matron/src/oracle.cc
+++ b/matron/src/oracle.cc
@@ -46,7 +46,7 @@ int num_polls = 0;
 // state flags for receiving command/poll/param reports
 bool needCommandReport;
 bool needPollReport;
-bool needParamReport = false; // FIXME
+bool needParamReport = false;  // FIXME
 
 // max count of any single desciptor type
 #define MAX_NUM_DESC 1024
@@ -78,59 +78,74 @@ static void o_set_command(int idx, const char *name, const char *format);
 static void o_set_num_desc(int *dst, int num);
 
 //--- OSC handlers
-static int handle_crone_ready(const char *path, const char *types, lo_arg **argv, int argc,
-			      lo_message data, void *user_data);
-static int handle_engine_report_start(const char *path, const char *types, lo_arg **argv, int argc,
-				      lo_message data, void *user_data);
-static int handle_engine_report_entry(const char *path, const char *types, lo_arg **argv, int argc,
-				      lo_message data, void *user_data);
-static int handle_engine_report_end(const char *path, const char *types, lo_arg **argv, int argc,
-				    lo_message data, void *user_data);
-static int handle_command_report_start(const char *path, const char *types, lo_arg **argv, int argc,
-				       lo_message data, void *user_data);
-static int handle_command_report_entry(const char *path, const char *types, lo_arg **argv, int argc,
-				       lo_message data, void *user_data);
-static int handle_command_report_end(const char *path, const char *types, lo_arg **argv, int argc,
-				     lo_message data, void *user_data);
-static int handle_poll_report_start(const char *path, const char *types, lo_arg **argv, int argc,
-				    lo_message data, void *user_data);
-static int handle_poll_report_entry(const char *path, const char *types, lo_arg **argv, int argc,
-				    lo_message data, void *user_data);
-static int handle_poll_report_end(const char *path, const char *types, lo_arg **argv, int argc,
-				  lo_message data, void *user_data);
-static int handle_poll_value(const char *path, const char *types, lo_arg **argv, int argc,
-			     lo_message data, void *user_data);
-static int handle_poll_data(const char *path, const char *types, lo_arg **argv, int argc,
-			    lo_message data, void *user_data);
+static int handle_crone_ready(const char *path, const char *types,
+                              lo_arg **argv, int argc, lo_message data,
+                              void *user_data);
+static int handle_engine_report_start(const char *path, const char *types,
+                                      lo_arg **argv, int argc, lo_message data,
+                                      void *user_data);
+static int handle_engine_report_entry(const char *path, const char *types,
+                                      lo_arg **argv, int argc, lo_message data,
+                                      void *user_data);
+static int handle_engine_report_end(const char *path, const char *types,
+                                    lo_arg **argv, int argc, lo_message data,
+                                    void *user_data);
+static int handle_command_report_start(const char *path, const char *types,
+                                       lo_arg **argv, int argc, lo_message data,
+                                       void *user_data);
+static int handle_command_report_entry(const char *path, const char *types,
+                                       lo_arg **argv, int argc, lo_message data,
+                                       void *user_data);
+static int handle_command_report_end(const char *path, const char *types,
+                                     lo_arg **argv, int argc, lo_message data,
+                                     void *user_data);
+static int handle_poll_report_start(const char *path, const char *types,
+                                    lo_arg **argv, int argc, lo_message data,
+                                    void *user_data);
+static int handle_poll_report_entry(const char *path, const char *types,
+                                    lo_arg **argv, int argc, lo_message data,
+                                    void *user_data);
+static int handle_poll_report_end(const char *path, const char *types,
+                                  lo_arg **argv, int argc, lo_message data,
+                                  void *user_data);
+static int handle_poll_value(const char *path, const char *types, lo_arg **argv,
+                             int argc, lo_message data, void *user_data);
+static int handle_poll_data(const char *path, const char *types, lo_arg **argv,
+                            int argc, lo_message data, void *user_data);
 /* static int handle_poll_wave(const char *path, const char *types, */
 /*                              lo_arg **argv, int argc, */
-/*                              
+/*
 lo_message data, void *user_data); */
-static int handle_poll_io_levels(const char *path, const char *types, lo_arg **argv, int argc,
-				 lo_message data, void *user_data);
+static int handle_poll_io_levels(const char *path, const char *types,
+                                 lo_arg **argv, int argc, lo_message data,
+                                 void *user_data);
 
-static int handle_poll_softcut_phase(const char *path, const char *types, lo_arg **argv, int argc,
-				     lo_message data, void *user_data);
+static int handle_poll_softcut_phase(const char *path, const char *types,
+                                     lo_arg **argv, int argc, lo_message data,
+                                     void *user_data);
 
-static int handle_softcut_render(const char *path, const char *types, lo_arg **argv, int argc,
-				 lo_message data, void *user_data);
+static int handle_softcut_render(const char *path, const char *types,
+                                 lo_arg **argv, int argc, lo_message data,
+                                 void *user_data);
 
-static int handle_softcut_position(const char *path, const char *types, lo_arg **argv, int argc,
-				 lo_message data, void *user_data);
+static int handle_softcut_position(const char *path, const char *types,
+                                   lo_arg **argv, int argc, lo_message data,
+                                   void *user_data);
 
-static int handle_tape_play_state(const char *path, const char *types, lo_arg **argv, int argc,
-				  lo_message data, void *user_data);
+static int handle_tape_play_state(const char *path, const char *types,
+                                  lo_arg **argv, int argc, lo_message data,
+                                  void *user_data);
 
 static void lo_error_handler(int num, const char *m, const char *path);
 
 static void set_need_reports() {
-    needCommandReport = true;
-    needPollReport = true;
-    needParamReport = false; // FIXME true;
+  needCommandReport = true;
+  needPollReport = true;
+  needParamReport = false;  // FIXME true;
 }
 
 static bool get_need_reports() {
-    return needCommandReport || needPollReport || needParamReport;
+  return needCommandReport || needPollReport || needParamReport;
 }
 
 static void test_engine_load_done();
@@ -139,520 +154,472 @@ static void test_engine_load_done();
 //---- extern function definitions
 
 void o_query_startup(void) {
-    // fprintf(stderr, "sending /ready: %d", rem_port);
-    lo_send(ext_addr, "/ready", "");
+  // fprintf(stderr, "sending /ready: %d", rem_port);
+  lo_send(ext_addr, "/ready", "");
 }
 
 //--- init
 void o_init(void) {
-    const char *local_port = args_local_port();
-    const char *ext_port = args_ext_port();
-    const char *crone_port = args_crone_port();
+  const char *local_port = args_local_port();
+  const char *ext_port = args_ext_port();
+  const char *crone_port = args_crone_port();
 
-    fprintf(stderr, "OSC rx port: %s \nOSC crone port: %s\nOSC ext port: %s\nOSC remote port: %s\n", local_port, crone_port, ext_port, args_remote_port());
+  fprintf(stderr,
+          "OSC rx port: %s \nOSC crone port: %s\nOSC ext port: %s\nOSC remote "
+          "port: %s\n",
+          local_port, crone_port, ext_port, args_remote_port());
 
-    o_init_descriptors();
+  o_init_descriptors();
 
-    ext_addr = lo_address_new("127.0.0.1", ext_port);
-    crone_addr = lo_address_new("127.0.0.1", crone_port);
-    st = lo_server_thread_new(local_port, lo_error_handler);
+  ext_addr = lo_address_new("127.0.0.1", ext_port);
+  crone_addr = lo_address_new("127.0.0.1", crone_port);
+  st = lo_server_thread_new(local_port, lo_error_handler);
 
-    // crone ready
-    lo_server_thread_add_method(st, "/crone/ready", "", handle_crone_ready, NULL);
-    // engine report sequence
-    lo_server_thread_add_method(st, "/report/engines/start", "i", handle_engine_report_start, NULL);
-    lo_server_thread_add_method(st, "/report/engines/entry", "is", handle_engine_report_entry, NULL);
-    lo_server_thread_add_method(st, "/report/engines/end", "", handle_engine_report_end, NULL);
+  // crone ready
+  lo_server_thread_add_method(st, "/crone/ready", "", handle_crone_ready, NULL);
+  // engine report sequence
+  lo_server_thread_add_method(st, "/report/engines/start", "i",
+                              handle_engine_report_start, NULL);
+  lo_server_thread_add_method(st, "/report/engines/entry", "is",
+                              handle_engine_report_entry, NULL);
+  lo_server_thread_add_method(st, "/report/engines/end", "",
+                              handle_engine_report_end, NULL);
 
-    // command report sequence
-    lo_server_thread_add_method(st, "/report/commands/start", "i", handle_command_report_start, NULL);
-    lo_server_thread_add_method(st, "/report/commands/entry", "iss", handle_command_report_entry, NULL);
-    lo_server_thread_add_method(st, "/report/commands/end", "", handle_command_report_end, NULL);
+  // command report sequence
+  lo_server_thread_add_method(st, "/report/commands/start", "i",
+                              handle_command_report_start, NULL);
+  lo_server_thread_add_method(st, "/report/commands/entry", "iss",
+                              handle_command_report_entry, NULL);
+  lo_server_thread_add_method(st, "/report/commands/end", "",
+                              handle_command_report_end, NULL);
 
-    // poll report sequence
-    lo_server_thread_add_method(st, "/report/polls/start", "i", handle_poll_report_start, NULL);
-    lo_server_thread_add_method(st, "/report/polls/entry", "isi", handle_poll_report_entry, NULL);
-    lo_server_thread_add_method(st, "/report/polls/end", "", handle_poll_report_end, NULL);
-    //// poll results
-    // generic single value
-    lo_server_thread_add_method(st, "/poll/value", "if", handle_poll_value, NULL);
-    // generic data blob
-    lo_server_thread_add_method(st, "/poll/data", "ib", handle_poll_data, NULL);
-    // dedicated path for audio I/O levels
-    lo_server_thread_add_method(st, "/poll/vu", "b", handle_poll_io_levels, NULL);
-    // softcut polls
-    lo_server_thread_add_method(st, "/poll/softcut/phase", "if", handle_poll_softcut_phase, NULL);
-    // tape reports
-    lo_server_thread_add_method(st, "/tape/play/state", "s", handle_tape_play_state, NULL);
+  // poll report sequence
+  lo_server_thread_add_method(st, "/report/polls/start", "i",
+                              handle_poll_report_start, NULL);
+  lo_server_thread_add_method(st, "/report/polls/entry", "isi",
+                              handle_poll_report_entry, NULL);
+  lo_server_thread_add_method(st, "/report/polls/end", "",
+                              handle_poll_report_end, NULL);
+  //// poll results
+  // generic single value
+  lo_server_thread_add_method(st, "/poll/value", "if", handle_poll_value, NULL);
+  // generic data blob
+  lo_server_thread_add_method(st, "/poll/data", "ib", handle_poll_data, NULL);
+  // dedicated path for audio I/O levels
+  lo_server_thread_add_method(st, "/poll/vu", "b", handle_poll_io_levels, NULL);
+  // softcut polls
+  lo_server_thread_add_method(st, "/poll/softcut/phase", "if",
+                              handle_poll_softcut_phase, NULL);
+  // tape reports
+  lo_server_thread_add_method(st, "/tape/play/state", "s",
+                              handle_tape_play_state, NULL);
 
-    // softcut buffer content
-    lo_server_thread_add_method(st, "/softcut/buffer/render_callback", "iffb", handle_softcut_render, NULL);
-    lo_server_thread_add_method(st, "/poll/softcut/position", "if", handle_softcut_position, NULL);
+  // softcut buffer content
+  lo_server_thread_add_method(st, "/softcut/buffer/render_callback", "iffb",
+                              handle_softcut_render, NULL);
+  lo_server_thread_add_method(st, "/poll/softcut/position", "if",
+                              handle_softcut_position, NULL);
 
-    lo_server_thread_start(st);
+  lo_server_thread_start(st);
 }
 
 void o_deinit(void) {
-    fprintf(stderr, "killing audio engine\n");
-    lo_send(ext_addr, "/engine/kill", "");
-    fprintf(stderr, "stopping OSC server\n");
-    lo_server_thread_free(st);
-    lo_address_free(ext_addr);
-    lo_address_free(crone_addr);
+  fprintf(stderr, "killing audio engine\n");
+  lo_send(ext_addr, "/engine/kill", "");
+  fprintf(stderr, "stopping OSC server\n");
+  lo_server_thread_free(st);
+  lo_address_free(ext_addr);
+  lo_address_free(crone_addr);
 }
 
 //--- descriptor access
-int o_get_num_engines(void) {
-    return num_engines;
-}
+int o_get_num_engines(void) { return num_engines; }
 
-int o_get_num_commands(void) {
-    return num_commands;
-}
+int o_get_num_commands(void) { return num_commands; }
 
-int o_get_num_polls(void) {
-    return num_polls;
-}
+int o_get_num_polls(void) { return num_polls; }
 
-const char **o_get_engine_names(void) {
-    return (const char **)engine_names;
-}
+const char **o_get_engine_names(void) { return (const char **)engine_names; }
 
 const struct engine_command *o_get_commands(void) {
-    return (const struct engine_command *)commands;
+  return (const struct engine_command *)commands;
 }
 
 const struct engine_poll *o_get_polls(void) {
-    return (const struct engine_poll *)polls;
+  return (const struct engine_poll *)polls;
 }
 
 //-- mutex access
 void o_lock_descriptors() {
-    int res = pthread_mutex_lock(&desc_lock);
-    if (res) {
-        fprintf(stderr, "o_lock_descriptors failed with code %d \b", res);
-    }
+  int res = pthread_mutex_lock(&desc_lock);
+  if (res) {
+    fprintf(stderr, "o_lock_descriptors failed with code %d \b", res);
+  }
 }
 
 void o_unlock_descriptors() {
-    int res = pthread_mutex_unlock(&desc_lock);
-    if (res) {
-        fprintf(stderr, "o_unlock_descriptors failed with code %d \b", res);
-    }
+  int res = pthread_mutex_unlock(&desc_lock);
+  if (res) {
+    fprintf(stderr, "o_unlock_descriptors failed with code %d \b", res);
+  }
 }
 
 //--- tranmission to audio engine
 
 void o_request_engine_report(void) {
-    // fprintf(stderr, "requesting engine report... \n");
-    lo_send(ext_addr, "/report/engines", "");
+  // fprintf(stderr, "requesting engine report... \n");
+  lo_send(ext_addr, "/report/engines", "");
 }
 
 void o_load_engine(const char *name) {
-    set_need_reports();
-    lo_send(ext_addr, "/engine/load/name", "s", name);
+  set_need_reports();
+  lo_send(ext_addr, "/engine/load/name", "s", name);
 }
 
-void o_free_engine() {
-    lo_send(ext_addr, "/engine/free", "");
-}
+void o_free_engine() { lo_send(ext_addr, "/engine/free", ""); }
 
 void o_send_command(const char *name, lo_message msg) {
-    char *path;
-    // FIXME: better not to allocate here
-    size_t len = sizeof(char) * (strlen(name) + 10);
-    path = (char*)malloc(len);
-    sprintf(path, "/command/%s", name);
-    lo_send_message(ext_addr, path, msg);
-    free(path);
+  char *path;
+  // FIXME: better not to allocate here
+  size_t len = sizeof(char) * (strlen(name) + 10);
+  path = (char *)malloc(len);
+  sprintf(path, "/command/%s", name);
+  lo_send_message(ext_addr, path, msg);
+  free(path);
 }
 
 void o_send(const char *name, lo_message msg) {
-    lo_send_message(ext_addr, name, msg);
-    free(msg);
+  lo_send_message(ext_addr, name, msg);
+  free(msg);
 }
 
 void o_set_poll_state(int idx, bool state) {
-    if (state) {
-        lo_send(ext_addr, "/poll/start", "i", idx);
-    } else {
-        lo_send(ext_addr, "/poll/stop", "i", idx);
-    }
+  if (state) {
+    lo_send(ext_addr, "/poll/start", "i", idx);
+  } else {
+    lo_send(ext_addr, "/poll/stop", "i", idx);
+  }
 }
 
 //-------------------------
 //--- static function definitions
 void o_init_descriptors(void) {
-    pthread_mutex_init(&desc_lock, NULL);
-    for (int i = 0; i < MAX_NUM_DESC; i++) {
-        engine_names[i] = NULL;
-        commands[i].name = NULL;
-        commands[i].format = NULL;
-    }
+  pthread_mutex_init(&desc_lock, NULL);
+  for (int i = 0; i < MAX_NUM_DESC; i++) {
+    engine_names[i] = NULL;
+    commands[i].name = NULL;
+    commands[i].format = NULL;
+  }
 }
 
 void o_clear_engine_names(void) {
-    o_lock_descriptors();
-    for (int i = 0; i < num_engines; i++) {
-        if (engine_names[i] != NULL) {
-            free(engine_names[i]);
-            engine_names[i] = NULL;
-        } else {
-            fprintf(stderr, "o_clear_engine_names: encountered unexpected null entry\n");
-        }
+  o_lock_descriptors();
+  for (int i = 0; i < num_engines; i++) {
+    if (engine_names[i] != NULL) {
+      free(engine_names[i]);
+      engine_names[i] = NULL;
+    } else {
+      fprintf(stderr,
+              "o_clear_engine_names: encountered unexpected null entry\n");
     }
-    o_unlock_descriptors();
+  }
+  o_unlock_descriptors();
 }
 
 void o_clear_commands(void) {
-    o_lock_descriptors();
-    for (int i = 0; i < num_commands; i++) {
-        if ((commands[i].name != NULL) && (commands[i].format != NULL)) {
-            free(commands[i].name);
-            free(commands[i].format);
-            commands[i].name = NULL;
-            commands[i].format = NULL;
-        } else {
-            fprintf(stderr, "o_clear_commands: encountered unexpected null entry\n");
-        }
+  o_lock_descriptors();
+  for (int i = 0; i < num_commands; i++) {
+    if ((commands[i].name != NULL) && (commands[i].format != NULL)) {
+      free(commands[i].name);
+      free(commands[i].format);
+      commands[i].name = NULL;
+      commands[i].format = NULL;
+    } else {
+      fprintf(stderr, "o_clear_commands: encountered unexpected null entry\n");
     }
-    o_unlock_descriptors();
+  }
+  o_unlock_descriptors();
 }
 
 void o_clear_polls(void) {
-    o_lock_descriptors();
-    for (int i = 0; i < num_polls; i++) {
-        if ((polls[i].name != NULL)) {
-            free(polls[i].name);
-            polls[i].name = NULL;
-        } else {
-            fprintf(stderr, "o_clear_polls: encountered unexpected null entry\n");
-        }
+  o_lock_descriptors();
+  for (int i = 0; i < num_polls; i++) {
+    if ((polls[i].name != NULL)) {
+      free(polls[i].name);
+      polls[i].name = NULL;
+    } else {
+      fprintf(stderr, "o_clear_polls: encountered unexpected null entry\n");
     }
-    o_unlock_descriptors();
+  }
+  o_unlock_descriptors();
 }
 
 // set a given entry in engine name list
 void o_set_engine_name(int idx, const char *name) {
-    size_t len;
-    o_lock_descriptors();
-    if (engine_names[idx] != NULL) {
-        fprintf(stderr, "refusing to allocate engine name %d; already exists", idx);
+  size_t len;
+  o_lock_descriptors();
+  if (engine_names[idx] != NULL) {
+    fprintf(stderr, "refusing to allocate engine name %d; already exists", idx);
+  } else {
+    len = strlen(name) + 1;  // include null terminator
+    engine_names[idx] = (char *)malloc(len);
+    if (engine_names[idx] == NULL) {
+      fprintf(stderr, "failure to malloc for engine name %d : %s\n", idx, name);
     } else {
-        len = strlen(name) + 1; // include null terminator
-        engine_names[idx] = (char*)malloc(len);
-        if (engine_names[idx] == NULL) {
-            fprintf(stderr, "failure to malloc for engine name %d : %s\n", idx, name);
-        } else {
-            strncpy(engine_names[idx], name, len);
-        }
+      strncpy(engine_names[idx], name, len);
     }
-    o_unlock_descriptors();
+  }
+  o_unlock_descriptors();
 }
 
 // set a given entry in command list
 void o_set_command(int idx, const char *name, const char *format) {
-    size_t name_len, format_len;
-    o_lock_descriptors();
-    if ((commands[idx].name != NULL) || (commands[idx].format != NULL)) {
-        fprintf(stderr, "refusing to allocate command name %d; already exists", idx);
+  size_t name_len, format_len;
+  o_lock_descriptors();
+  if ((commands[idx].name != NULL) || (commands[idx].format != NULL)) {
+    fprintf(stderr, "refusing to allocate command name %d; already exists",
+            idx);
+  } else {
+    name_len = strlen(name);
+    format_len = strlen(format);
+    commands[idx].name = (char *)malloc(name_len + 1);
+    commands[idx].format = (char *)malloc(format_len + 1);
+    if ((commands[idx].name == NULL) || (commands[idx].format == NULL)) {
+      fprintf(stderr, "failure to malloc for command %d : %s %s\n", idx, name,
+              format);
     } else {
-        name_len = strlen(name);
-        format_len = strlen(format);
-        commands[idx].name = (char*)malloc(name_len + 1);
-        commands[idx].format = (char*)malloc(format_len + 1);
-        if ((commands[idx].name == NULL) || (commands[idx].format == NULL)) {
-            fprintf(stderr, "failure to malloc for command %d : %s %s\n", idx, name, format);
-        } else {
-            strncpy(commands[idx].name, name, name_len + 1);
-            strncpy(commands[idx].format, format, format_len + 1);
-        }
+      strncpy(commands[idx].name, name, name_len + 1);
+      strncpy(commands[idx].format, format, format_len + 1);
     }
-    o_unlock_descriptors();
+  }
+  o_unlock_descriptors();
 }
 
 // set a given entry in polls list
 void o_set_poll(int idx, const char *name, poll_type_t type) {
-    size_t name_len;
-    o_lock_descriptors();
-    if (polls[idx].name != NULL) {
-        fprintf(stderr, "refusing to allocate poll name %d; already exists", idx);
+  size_t name_len;
+  o_lock_descriptors();
+  if (polls[idx].name != NULL) {
+    fprintf(stderr, "refusing to allocate poll name %d; already exists", idx);
+  } else {
+    name_len = strlen(name);
+    polls[idx].name = (char *)malloc(name_len + 1);
+    if ((polls[idx].name == NULL)) {
+      fprintf(stderr, "failure to malloc for poll %d : %s\n", idx, name);
     } else {
-        name_len = strlen(name);
-        polls[idx].name = (char*)malloc(name_len + 1);
-        if ((polls[idx].name == NULL)) {
-            fprintf(stderr, "failure to malloc for poll %d : %s\n", idx, name);
-        } else {
-            strncpy(polls[idx].name, name, name_len + 1);
-        }
-        polls[idx].type = type;
+      strncpy(polls[idx].name, name, name_len + 1);
     }
-    o_unlock_descriptors();
+    polls[idx].type = type;
+  }
+  o_unlock_descriptors();
 }
 
 // set a given descriptor count variable
 void o_set_num_desc(int *dst, int num) {
-    o_lock_descriptors();
-    *dst = num;
-    o_unlock_descriptors();
+  o_lock_descriptors();
+  *dst = num;
+  o_unlock_descriptors();
 }
 
 // set poll period
 void o_set_poll_time(int idx, float dt) {
-    lo_send(ext_addr, "/poll/time", "if", idx, dt);
+  lo_send(ext_addr, "/poll/time", "if", idx, dt);
 }
 
 // request current value of poll
 void o_request_poll_value(int idx) {
-    lo_send(ext_addr, "/poll/request/value", "i", idx);
+  lo_send(ext_addr, "/poll/request/value", "i", idx);
 }
 
 //---- audio context control
 
-void o_poll_start_vu() {
-    crone_poll_start_vu();
-}
+void o_poll_start_vu() { crone_poll_start_vu(); }
 
-void o_poll_stop_vu() {
-    crone_poll_stop_vu();
-}
+void o_poll_stop_vu() { crone_poll_stop_vu(); }
 
 void o_poll_start_cut_phase() {
-    crone_poll_start_cut_phase();
-    lo_send(crone_addr, "/poll/start/cut/phase", NULL);
+  crone_poll_start_cut_phase();
+  lo_send(crone_addr, "/poll/start/cut/phase", NULL);
 }
 
-void o_poll_stop_cut_phase() {
-    crone_poll_stop_cut_phase();
-}
+void o_poll_stop_cut_phase() { crone_poll_stop_cut_phase(); }
 
-void o_set_level_adc(float level) {
-    crone_set_level_adc(level);
-}
+void o_set_level_adc(float level) { crone_set_level_adc(level); }
 
 void o_set_level_dac(float level) {
-    fprintf(stderr, "setting DAC level (main thread): %f\n", level);
-    crone_set_level_dac(level);
+  fprintf(stderr, "setting DAC level (main thread): %f\n", level);
+  crone_set_level_dac(level);
 }
 
-void o_set_level_ext(float level) {
-  crone_set_level_ext( level);
-}
+void o_set_level_ext(float level) { crone_set_level_ext(level); }
 
-void o_set_level_monitor(float level) {
-  crone_set_level_monitor( level);
-}
+void o_set_level_monitor(float level) { crone_set_level_monitor(level); }
 
 void o_set_monitor_mix_mono() {
-    lo_send(crone_addr, "/set/level/monitor_mix", "if", 0, 0.5);
-    lo_send(crone_addr, "/set/level/monitor_mix", "if", 1, 0.5);
-    lo_send(crone_addr, "/set/level/monitor_mix", "if", 2, 0.5);
-    lo_send(crone_addr, "/set/level/monitor_mix", "if", 3, 0.5);
+  lo_send(crone_addr, "/set/level/monitor_mix", "if", 0, 0.5);
+  lo_send(crone_addr, "/set/level/monitor_mix", "if", 1, 0.5);
+  lo_send(crone_addr, "/set/level/monitor_mix", "if", 2, 0.5);
+  lo_send(crone_addr, "/set/level/monitor_mix", "if", 3, 0.5);
 }
 
 void o_set_monitor_mix_stereo() {
-    lo_send(crone_addr, "/set/level/monitor_mix", "if", 0, 1.0);
-    lo_send(crone_addr, "/set/level/monitor_mix", "if", 1, 0.0);
-    lo_send(crone_addr, "/set/level/monitor_mix", "if", 2, 0.0);
-    lo_send(crone_addr, "/set/level/monitor_mix", "if", 3, 1.0);
+  lo_send(crone_addr, "/set/level/monitor_mix", "if", 0, 1.0);
+  lo_send(crone_addr, "/set/level/monitor_mix", "if", 1, 0.0);
+  lo_send(crone_addr, "/set/level/monitor_mix", "if", 2, 0.0);
+  lo_send(crone_addr, "/set/level/monitor_mix", "if", 3, 1.0);
 }
 
-void o_set_audio_pitch_on() {
-    lo_send(ext_addr, "/audio/pitch/on", NULL);
-}
+void o_set_audio_pitch_on() { lo_send(ext_addr, "/audio/pitch/on", NULL); }
 
-void o_set_audio_pitch_off() {
-    lo_send(ext_addr, "/audio/pitch/off", NULL);
-}
+void o_set_audio_pitch_off() { lo_send(ext_addr, "/audio/pitch/off", NULL); }
 
-void o_restart_audio() {
-    lo_send(ext_addr, "/recompile", NULL);
-}
+void o_restart_audio() { lo_send(ext_addr, "/recompile", NULL); }
 
 //---- tape controls
-void o_set_level_tape(float level) {
-  crone_set_level_tape( level);
-}
+void o_set_level_tape(float level) { crone_set_level_tape(level); }
 
-void o_set_level_tape_rev(float level) {
-  crone_set_level_tape_rev( level);
-}
+void o_set_level_tape_rev(float level) { crone_set_level_tape_rev(level); }
 
-void o_tape_rec_open(char *file) {
-  crone_tape_rec_open(file);
-}
+void o_tape_rec_open(char *file) { crone_tape_rec_open(file); }
 
-void o_tape_rec_start() {
-  crone_tape_rec_start();
-}
+void o_tape_rec_start() { crone_tape_rec_start(); }
 
-void o_tape_rec_stop() {
-  crone_tape_rec_stop();
-}
+void o_tape_rec_stop() { crone_tape_rec_stop(); }
 
-void o_tape_play_open(char *file) {
-  crone_tape_play_open(file);
-}
+void o_tape_play_open(char *file) { crone_tape_play_open(file); }
 
-void o_tape_play_start() {
-  crone_tape_play_start();
-}
+void o_tape_play_start() { crone_tape_play_start(); }
 
-void o_tape_play_stop() {
-  crone_tape_play_stop();
-}
+void o_tape_play_stop() { crone_tape_play_stop(); }
 
 //--- cut
-void o_cut_enable(int i, float value) {
-  crone_cut_enable( i, value);
-}
+void o_cut_enable(int i, float value) { crone_set_enabled_cut(i, value); }
 
-void o_set_level_adc_cut(float value) {
-  crone_set_level_adc_cut( value);
-}
+void o_set_level_adc_cut(float value) { crone_set_level_adc_cut(value); }
 
-void o_set_level_ext_cut(float value) {
-  crone_set_level_ext_cut( value);
-}
+void o_set_level_ext_cut(float value) { crone_set_level_ext_cut(value); }
 
-void o_set_level_tape_cut(float value) {
-  crone_set_level_tape_cut( value);
-}
+void o_set_level_tape_cut(float value) { crone_set_level_tape_cut(value); }
 
-void o_set_level_cut_rev(float value) {
-  crone_set_level_cut_rev( value);
-}
+void o_set_level_cut_rev(float value) { crone_set_level_cut_rev(value); }
 
-void o_set_level_cut_master(float value) {
-  crone_set_level_cut_master( value);
-}
+void o_set_level_cut_master(float value) { crone_set_level_cut_master(value); }
 
 void o_set_level_cut(int index, float value) {
-  crone_set_level_cut( index, float value);
+  crone_set_level_cut(index, float value);
 }
 
 void o_set_level_cut_cut(int src, int dest, float value) {
-  crone_set_level_cut_cut( src,  dest,  value);
+  crone_set_level_cut_cut(src, dest, value);
 }
 
-void o_set_pan_cut(int index, float value) {
-  crone_set_pan_cut( index,  value);
-}
+void o_set_pan_cut(int index, float value) { crone_set_pan_cut(index, value); }
 
 void o_set_cut_param(const char *name, int voice, float value) {
-  crone_set_cut_param( name, voice, value);
+  // FIXME
+  // crone_set_cut_param( name, voice, value);
 }
 
 void o_set_cut_param_ii(const char *name, int voice, int value) {
-  crone_set_cut_param_ii(name, voice, value);
+  // FIXME
+  // crone_set_cut_param_ii(name, voice, value);
 }
 
 void o_set_cut_param_iif(const char *name, int a, int b, float v) {
-  crone_set_cut_param_iif(name, a, b, v);
+  // FIXME
+  // crone_set_cut_param_iif(name, a, b, v);
 }
 
 void o_set_level_input_cut(int src, int dst, float level) {
-  crone_set_level_input_cut( src, dst, level);
+  crone_set_level_input_cut(src, dst, level);
 }
 
-void o_cut_buffer_clear() {
-  crone_cut_buffer_clear();
+void o_cut_buffer_clear() { crone_cut_buffer_clear(); }
+
+void o_cut_buffer_clear_channel(int ch) { crone_cut_buffer_clear_channel(ch); }
+
+void o_cut_buffer_clear_region(float start, float dur, float fade_time,
+                               float preserve) {
+  crone_cut_buffer_clear_region(start, dur, fade_time, preserve);
 }
 
-void o_cut_buffer_clear_channel(int ch) {
-  crone_cut_buffer_clear_channel( ch);
+void o_cut_buffer_clear_region_channel(int ch, float start, float dur,
+                                       float fade_time, float preserve) {
+  crone_cut_buffer_clear_region_channel(ch, start, dur, fade_time, preserve);
 }
 
-void o_cut_buffer_clear_region(float start, float dur, float fade_time, float preserve) {
-  crone_cut_buffer_clear_region( start,  dur,  fade_time,  preserve);
-}
-
-void o_cut_buffer_clear_region_channel(int ch, float start, float dur, float fade_time, float preserve) {
-  crone_cut_buffer_clear_region_channel( ch,  start,  dur,  fade_time,  preserve);
-}
-
-void o_cut_buffer_copy_mono(
+void o_cut_buffer_copy_mono(int src_ch, int dst_ch, float src_start,
+                            float dst_start, float dur, float fade_time,
+                            float preserve, int reverse) {
+  crone_cut_buffer_copy_mono(src_ch, dst_ch, src_start, dst_start, dur,
+                                 fade_time, preserve, reverse);
 }
 
 void o_cut_buffer_copy_stereo(float src_start, float dst_start, float dur,
                               float fade_time, float preserve, int reverse) {
-    lo_send(crone_addr, "/softcut/buffer/copy_stereo", "fffffi",
-            src_start, dst_start, dur, fade_time, preserve, reverse);
+  crone_cut_buffer_copy_stereo(src_start, dst_start, dur, fade_time, preserve,
+                               reverse);
 }
 
-void o_cut_buffer_read_mono(char *file, float start_src, float start_dst, float dur, int ch_src, int ch_dst, float preserve, float mix) {
-  crone_cut_buffer_read_mono(file,  start_src,  start_dst,  dur,  ch_src,  ch_dst,  preserve,  mix);
+void o_cut_buffer_read_mono(char *file, float start_src, float start_dst,
+                            float dur, int ch_src, int ch_dst, float preserve,
+                            float mix) {
+  crone_cut_buffer_read_mono(file, start_src, start_dst, dur, ch_src, ch_dst,
+                             preserve, mix);
 }
 
-void o_cut_buffer_read_stereo(char *file, float start_src, float start_dst, float dur, float preserve, float mix) {
-  crone_cut_buffer_read_stereo( file,  start_src,  start_dst,  dur,  preserve,  mix);
+void o_cut_buffer_read_stereo(char *file, float start_src, float start_dst,
+                              float dur, float preserve, float mix) {
+  crone_cut_buffer_read_stereo(file, start_src, start_dst, dur, preserve, mix);
 }
 
 void o_cut_buffer_write_mono(char *file, float start, float dur, int ch) {
-  crone_cut_buffer_write_mono( *file,  start,  dur,  ch);
+  crone_cut_buffer_write_mono(*file, start, dur, ch);
 }
 
 void o_cut_buffer_write_stereo(char *file, float start, float dur) {
-  crone_cut_buffer_write_stereo( *file,  start,  dur);
+  crone_cut_buffer_write_stereo(*file, start, dur);
 }
 
 void o_cut_buffer_render(int ch, float start, float dur, int samples) {
-  crone_cut_buffer_render( ch,  start,  dur,  samples);
+  crone_cut_buffer_render(ch, start, dur, samples);
 }
 
-void o_cut_query_position(int i) {
-  crone_cut_query_position( i);
-}
+void o_cut_query_position(int i) { crone_cut_query_position(i); }
 
-void o_cut_reset() {
-  crone_cut_reset();
-}
+void o_cut_reset() { crone_cut_reset(); }
 
 //--- rev effects controls
 // enable / disable rev fx processing
-void o_set_rev_on() {
-  crone_set_rev_on();
-}
+void o_set_rev_on() { crone_set_rev_on(); }
 
-void o_set_rev_off() {
-  crone_set_rev_off();
-}
+void o_set_rev_off() { crone_set_rev_off(); }
 
 //--- comp effects controls
-void o_set_comp_on() {
-  crone_set_comp_on();
-}
+void o_set_comp_on() { crone_set_comp_on(); }
 
-void o_set_comp_off() {
-  crone_set_comp_off();
-}
+void o_set_comp_off() { crone_set_comp_off(); }
 
-void o_set_comp_mix(float value) {
-  crone_set_comp_mix( value);
-}
+void o_set_comp_mix(float value) { crone_set_comp_mix(value); }
 
 // stereo output -> rev
-void o_set_level_ext_rev(float value) {
-  crone_set_level_ext_rev( value);
-}
+void o_set_level_ext_rev(float value) { crone_set_level_ext_rev(value); }
 
 // rev return -> dac
-void o_set_level_rev_dac(float value) {
-  crone_set_level_rev_dac( value);
-}
+void o_set_level_rev_dac(float value) { crone_set_level_rev_dac(value); }
 
 // monitor mix -> rev level
 void o_set_level_monitor_rev(float value) {
-  crone_set_level_monitor_rev( value);
+  crone_set_level_monitor_rev(value);
 }
 
 void o_set_rev_param(const char *name, float value) {
-    /// FIXME
+  /// FIXME
   //    crone_set_rev_param(const char *name, float value);
 }
 
 void o_set_comp_param(const char *name, float value) {
-    /// FIXME
+  /// FIXME
   // crone_set_comp_param(const char *name, float value);
   //   static char buf[128];
   //   sprintf(buf, "/set/param/compressor/%s", name);
@@ -669,186 +636,184 @@ void o_set_comp_param(const char *name, float value) {
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 
-int handle_crone_ready(const char *path, const char *types, lo_arg **argv, int argc,
-		       lo_message data, void *user_data) {
-    norns_hello_ok();
-    return 0;
+int handle_crone_ready(const char *path, const char *types, lo_arg **argv,
+                       int argc, lo_message data, void *user_data) {
+  norns_hello_ok();
+  return 0;
 }
 
-int handle_engine_report_start(const char *path, const char *types, lo_arg **argv, int argc,
-			       lo_message data, void *user_data) {
-    assert(argc > 0);
-    // arg 1: count of engines
-    o_clear_engine_names();
-    o_set_num_desc(&num_engines, argv[0]->i);
-    return 0;
+int handle_engine_report_start(const char *path, const char *types,
+                               lo_arg **argv, int argc, lo_message data,
+                               void *user_data) {
+  assert(argc > 0);
+  // arg 1: count of engines
+  o_clear_engine_names();
+  o_set_num_desc(&num_engines, argv[0]->i);
+  return 0;
 }
 
-int handle_engine_report_entry(const char *path, const char *types, lo_arg **argv, int argc,
-			       lo_message data, void *user_data) {
-    assert(argc > 1);
-    // arg 1: engine index
-    // arg 2: engine
-    // NB: yes, this is the correct way to read a string from a lo_arg!
-    o_set_engine_name(argv[0]->i, &argv[1]->s);
-    return 0;
+int handle_engine_report_entry(const char *path, const char *types,
+                               lo_arg **argv, int argc, lo_message data,
+                               void *user_data) {
+  assert(argc > 1);
+  // arg 1: engine index
+  // arg 2: engine
+  // NB: yes, this is the correct way to read a string from a lo_arg!
+  o_set_engine_name(argv[0]->i, &argv[1]->s);
+  return 0;
 }
 
-int handle_engine_report_end(const char *path, const char *types, lo_arg **argv, int argc,
-			     lo_message data, void *user_data) {
-    // no arguments; post event
-    event_post(event_data_new(EVENT_ENGINE_REPORT));
-    return 0;
+int handle_engine_report_end(const char *path, const char *types, lo_arg **argv,
+                             int argc, lo_message data, void *user_data) {
+  // no arguments; post event
+  event_post(event_data_new(EVENT_ENGINE_REPORT));
+  return 0;
 }
 
 //---------------------
 //--- command report
 
-int handle_command_report_start(const char *path, const char *types, lo_arg **argv, int argc,
-				lo_message data, void *user_data) {
-    assert(argc > 0);
-    o_clear_commands();
-    o_set_num_desc(&num_commands, argv[0]->i);
-    return 0;
+int handle_command_report_start(const char *path, const char *types,
+                                lo_arg **argv, int argc, lo_message data,
+                                void *user_data) {
+  assert(argc > 0);
+  o_clear_commands();
+  o_set_num_desc(&num_commands, argv[0]->i);
+  return 0;
 }
 
-int handle_command_report_entry(const char *path, const char *types, lo_arg **argv, int argc,
-				lo_message data, void *user_data) {
-    assert(argc > 2);
-    o_set_command(argv[0]->i, &argv[1]->s, &argv[2]->s);
-    return 0;
+int handle_command_report_entry(const char *path, const char *types,
+                                lo_arg **argv, int argc, lo_message data,
+                                void *user_data) {
+  assert(argc > 2);
+  o_set_command(argv[0]->i, &argv[1]->s, &argv[2]->s);
+  return 0;
 }
 
-int handle_command_report_end(const char *path, const char *types, lo_arg **argv, int argc,
-			      lo_message data, void *user_data) {
-    needCommandReport = false;
-    test_engine_load_done();
-    return 0;
+int handle_command_report_end(const char *path, const char *types,
+                              lo_arg **argv, int argc, lo_message data,
+                              void *user_data) {
+  needCommandReport = false;
+  test_engine_load_done();
+  return 0;
 }
 
 //---------------------
 //--- poll report
 
-int handle_poll_report_start(const char *path, const char *types, lo_arg **argv, int argc,
-			     lo_message data, void *user_data) {
-
-    assert(argc > 0);
-    o_clear_polls();
-    o_set_num_desc(&num_polls, argv[0]->i);
-    return 0;
+int handle_poll_report_start(const char *path, const char *types, lo_arg **argv,
+                             int argc, lo_message data, void *user_data) {
+  assert(argc > 0);
+  o_clear_polls();
+  o_set_num_desc(&num_polls, argv[0]->i);
+  return 0;
 }
 
-int handle_poll_report_entry(const char *path, const char *types, lo_arg **argv, int argc,
-			     lo_message data, void *user_data) {
-
-    assert(argc > 2);
-    o_set_poll(argv[0]->i, &argv[1]->s, (poll_type_t)argv[2]->i);
-    return 0;
+int handle_poll_report_entry(const char *path, const char *types, lo_arg **argv,
+                             int argc, lo_message data, void *user_data) {
+  assert(argc > 2);
+  o_set_poll(argv[0]->i, &argv[1]->s, (poll_type_t)argv[2]->i);
+  return 0;
 }
 
-int handle_poll_report_end(const char *path, const char *types, lo_arg **argv, int argc,
-			   lo_message data, void *user_data) {
-
-    // event_post( event_data_new(EVENT_POLL_REPORT) );
-    needPollReport = false;
-    test_engine_load_done();
-    return 0;
+int handle_poll_report_end(const char *path, const char *types, lo_arg **argv,
+                           int argc, lo_message data, void *user_data) {
+  // event_post( event_data_new(EVENT_POLL_REPORT) );
+  needPollReport = false;
+  test_engine_load_done();
+  return 0;
 }
 
-int handle_poll_value(const char *path, const char *types, lo_arg **argv, int argc,
-		      lo_message data, void *user_data) {
-
-    assert(argc > 1);
-    union event_data *ev = event_data_new(EVENT_POLL_VALUE);
-    ev->poll_value.idx = argv[0]->i;
-    ev->poll_value.value = argv[1]->f;
-    event_post(ev);
-    return 0;
+int handle_poll_value(const char *path, const char *types, lo_arg **argv,
+                      int argc, lo_message data, void *user_data) {
+  assert(argc > 1);
+  union event_data *ev = event_data_new(EVENT_POLL_VALUE);
+  ev->poll_value.idx = argv[0]->i;
+  ev->poll_value.value = argv[1]->f;
+  event_post(ev);
+  return 0;
 }
 
-int handle_poll_data(const char *path, const char *types, lo_arg **argv, int argc,
-		     lo_message data, void *user_data) {
-
-    assert(argc > 1);
-    union event_data *ev = event_data_new(EVENT_POLL_DATA);
-    ev->poll_data.idx = argv[0]->i;
-    uint8_t *blobdata = (uint8_t *)lo_blob_dataptr((lo_blob)argv[1]);
-    int sz = lo_blob_datasize((lo_blob)argv[1]);
-    ev->poll_data.size = sz;
-    ev->poll_data.data = (uint8_t*)calloc(1, sz);
-    memcpy(ev->poll_data.data, blobdata, sz);
-    event_post(ev);
-    return 0;
+int handle_poll_data(const char *path, const char *types, lo_arg **argv,
+                     int argc, lo_message data, void *user_data) {
+  assert(argc > 1);
+  union event_data *ev = event_data_new(EVENT_POLL_DATA);
+  ev->poll_data.idx = argv[0]->i;
+  uint8_t *blobdata = (uint8_t *)lo_blob_dataptr((lo_blob)argv[1]);
+  int sz = lo_blob_datasize((lo_blob)argv[1]);
+  ev->poll_data.size = sz;
+  ev->poll_data.data = (uint8_t *)calloc(1, sz);
+  memcpy(ev->poll_data.data, blobdata, sz);
+  event_post(ev);
+  return 0;
 }
 
-int handle_poll_io_levels(const char *path, const char *types, lo_arg **argv, int argc,
-			  lo_message data, void *user_data) {
-
-    assert(argc > 0);
-    union event_data *ev = event_data_new(EVENT_POLL_IO_LEVELS);
-    uint8_t *blobdata = (uint8_t *)lo_blob_dataptr((lo_blob)argv[0]);
-    int sz = lo_blob_datasize((lo_blob)argv[0]);
-    assert(sz == sizeof(quad_levels_t));
-    ev->poll_io_levels.value.uint = *((uint32_t *)blobdata);
-    event_post(ev);
-    return 0;
+int handle_poll_io_levels(const char *path, const char *types, lo_arg **argv,
+                          int argc, lo_message data, void *user_data) {
+  assert(argc > 0);
+  union event_data *ev = event_data_new(EVENT_POLL_IO_LEVELS);
+  uint8_t *blobdata = (uint8_t *)lo_blob_dataptr((lo_blob)argv[0]);
+  int sz = lo_blob_datasize((lo_blob)argv[0]);
+  assert(sz == sizeof(quad_levels_t));
+  ev->poll_io_levels.value.uint = *((uint32_t *)blobdata);
+  event_post(ev);
+  return 0;
 }
 
-int handle_poll_softcut_phase(const char *path, const char *types, lo_arg **argv, int argc,
-			      lo_message data, void *user_data) {
-
-    assert(argc > 1);
-    union event_data *ev = event_data_new(EVENT_POLL_SOFTCUT_PHASE);
-    ev->softcut_phase.idx = argv[0]->i;
-    ev->softcut_phase.value = argv[1]->f;
-    event_post(ev);
-    return 0;
+int handle_poll_softcut_phase(const char *path, const char *types,
+                              lo_arg **argv, int argc, lo_message data,
+                              void *user_data) {
+  assert(argc > 1);
+  union event_data *ev = event_data_new(EVENT_POLL_SOFTCUT_PHASE);
+  ev->softcut_phase.idx = argv[0]->i;
+  ev->softcut_phase.value = argv[1]->f;
+  event_post(ev);
+  return 0;
 }
 
-int handle_tape_play_state(const char *path, const char *types, lo_arg **argv, int argc,
-			   lo_message data, void *user_data) {
-
-    // assert(argc > 0);
-    // fprintf(stderr, "tape_play_status %s\n", &argv[0]->s);
-    return 0;
+int handle_tape_play_state(const char *path, const char *types, lo_arg **argv,
+                           int argc, lo_message data, void *user_data) {
+  // assert(argc > 0);
+  // fprintf(stderr, "tape_play_status %s\n", &argv[0]->s);
+  return 0;
 }
 
-int handle_softcut_render(const char *path, const char *types, lo_arg **argv, int argc,
-			  lo_message data, void *user_data) {
-    assert(argc > 2);
-    union event_data *ev = event_data_new(EVENT_SOFTCUT_RENDER);
-    ev->softcut_render.idx = argv[0]->i;
-    ev->softcut_render.sec_per_sample = argv[1]->f;
-    ev->softcut_render.start = argv[2]->f;
+int handle_softcut_render(const char *path, const char *types, lo_arg **argv,
+                          int argc, lo_message data, void *user_data) {
+  assert(argc > 2);
+  union event_data *ev = event_data_new(EVENT_SOFTCUT_RENDER);
+  ev->softcut_render.idx = argv[0]->i;
+  ev->softcut_render.sec_per_sample = argv[1]->f;
+  ev->softcut_render.start = argv[2]->f;
 
-    int sz = lo_blob_datasize((lo_blob)argv[3]);
-    float *samples = (float*)lo_blob_dataptr((lo_blob)argv[3]);
-    ev->softcut_render.size = sz / sizeof(float);
-    ev->softcut_render.data = (float*)calloc(1, sz);
-    memcpy(ev->softcut_render.data, samples, sz);
-    event_post(ev);
-    return 0;
+  int sz = lo_blob_datasize((lo_blob)argv[3]);
+  float *samples = (float *)lo_blob_dataptr((lo_blob)argv[3]);
+  ev->softcut_render.size = sz / sizeof(float);
+  ev->softcut_render.data = (float *)calloc(1, sz);
+  memcpy(ev->softcut_render.data, samples, sz);
+  event_post(ev);
+  return 0;
 }
 
-int handle_softcut_position(const char *path, const char *types, lo_arg **argv, int argc,
-			  lo_message data, void *user_data) {
-    assert(argc > 1);
-    union event_data *ev = event_data_new(EVENT_SOFTCUT_POSITION);
-    ev->softcut_position.idx = argv[0]->i;
-    ev->softcut_position.pos = argv[1]->f;
-    event_post(ev);
-    return 0;
+int handle_softcut_position(const char *path, const char *types, lo_arg **argv,
+                            int argc, lo_message data, void *user_data) {
+  assert(argc > 1);
+  union event_data *ev = event_data_new(EVENT_SOFTCUT_POSITION);
+  ev->softcut_position.idx = argv[0]->i;
+  ev->softcut_position.pos = argv[1]->f;
+  event_post(ev);
+  return 0;
 }
 
 void lo_error_handler(int num, const char *m, const char *path) {
-    fprintf(stderr, "liblo error %d in path %s: %s\n", num, path, m);
+  fprintf(stderr, "liblo error %d in path %s: %s\n", num, path, m);
 }
 
 void test_engine_load_done() {
-    if (!get_need_reports()) {
-        union event_data *ev = event_data_new(EVENT_ENGINE_LOADED);
-        event_post(ev);
-    }
+  if (!get_need_reports()) {
+    union event_data *ev = event_data_new(EVENT_ENGINE_LOADED);
+    event_post(ev);
+  }
 }
 
 #pragma GCC diagnostic pop

--- a/matron/src/oracle.cc
+++ b/matron/src/oracle.cc
@@ -23,6 +23,7 @@
 #include "oracle.h"
 
 #include "crone.h"
+#include "crone_param_dispatch.h"
 
 // address of external DSP environment (e.g. supercollider)
 static lo_address ext_addr;
@@ -517,20 +518,17 @@ void o_set_pan_cut(int index, float value) { crone_set_pan_cut(index, value); }
 
 void o_set_cut_param(const char *name, int voice, float value) {
     (void)name; (void)voice; (void)value;
-  // FIXME
-  // crone_set_cut_param( name, voice, value);
+  crone_set_cut_param( name, voice, value);
 }
 
 void o_set_cut_param_ii(const char *name, int voice, int value) {
     (void)name; (void)voice; (void)value;
-  // FIXME
-  // crone_set_cut_param_ii(name, voice, value);
+  crone_set_cut_param_ii(name, voice, value);
 }
 
 void o_set_cut_param_iif(const char *name, int a, int b, float v) {
     (void)name; (void)a; (void)b; (void)v;
-  // FIXME
-  // crone_set_cut_param_iif(name, a, b, v);
+  crone_set_cut_param_iif(name, a, b, v);
 }
 
 void o_set_level_input_cut(int src, int dst, float level) {

--- a/norns/wscript
+++ b/norns/wscript
@@ -44,6 +44,8 @@ def build(bld):
         ]
 
     crone_sources = [
+        '../crone/src/crone_param_dispatch.cpp',
+        '../crone/src/crone.cpp',
         '../crone/src/main.cpp',
         '../crone/src/BufDiskWorker.cpp',
         '../crone/src/Commands.cpp',


### PR DESCRIPTION
mostly complete replacement of OSC->crone with direct calls in `oracle.cc`

one tricky point concerns the use of parameter strings from lua. these are used in generic sofcut and FX param setters simply to avoid LOC in glue modules.  this made more sense with OSC as endpoint (matches on strings anyway). now it feels a little sillier, but for now instead of adding lots of LOC, added a dispatch module mapping `std::string` to setter funcs. have not completed this for FX params, only softcut params.

compiles but still quite untested. opening PR early for visibility.
