### PR TITLE
move EVENT_GRID_TILT to the end of event_t enum

### DIFF
--- a/matron/src/event_types.h
+++ b/matron/src/event_types.h
@@ -4,6 +4,9 @@
 #include "osc.h"
 #include <stdint.h>
 
+// NOTE: new event types *must* be added to the end of the enum in the order
+// maintain ABI compatibility with compiled modules which interact with the
+// event system.
 typedef enum {
     // unused (do not remove)
     EVENT_FIRST_EVENT = 0,
@@ -33,8 +36,6 @@ typedef enum {
     EVENT_MONOME_REMOVE,
     // monome grid press/lift
     EVENT_GRID_KEY,
-    // monome grid tilt
-    EVENT_GRID_TILT,
     // monome arc encoder delta
     EVENT_ARC_ENCODER_DELTA,
     // monome arc encoder key
@@ -89,6 +90,8 @@ typedef enum {
     EVENT_SOFTCUT_POSITION,
     // custom events defined in lua extensions
     EVENT_CUSTOM,
+    // monome grid tilt
+    EVENT_GRID_TILT,
 } event_t;
 
 // a packed data structure for four volume levels


### PR DESCRIPTION
this change is to address the ABI breakage which was introduced as part of the addition of grid tilt support. the EVENT_GRID_TILT entry was moved to the end of the enum definition and a comment was added which states that new event types must be added to the end of the list.