### PR TITLE
fix #1490

### DIFF
--- a/lua/core/menu/devices.lua
+++ b/lua/core/menu/devices.lua
@@ -45,6 +45,14 @@ local function set_len_for_list()
   end
 end
 
+local function check_and_rename(dev_type,pos,name)
+  for i = 1,#dev_type.vports do
+    if i ~= pos and dev_type.vports[i].name == name then
+      dev_type.vports[i].name = "none"
+    end
+  end
+end
+
 m.key = function(n,z)
   if m.mode == "type" then
     if n==2 and z==1 then
@@ -95,15 +103,19 @@ m.key = function(n,z)
       local target_mode = "list"
       if m.section == "midi" then
         midi.vports[m.setpos].name = s
+        check_and_rename(midi,m.setpos,s)
         midi.update_devices()
       elseif m.section == "grid" then
         grid.vports[m.setpos].name = s
+        check_and_rename(grid,m.setpos,s)
         grid.update_devices()
       elseif m.section == "arc" then
         arc.vports[m.setpos].name = s
+        check_and_rename(arc,m.setpos,s)
         arc.update_devices()
       elseif m.section == "hid" then
         hid.vports[m.setpos].name = s
+        check_and_rename(hid,m.setpos,s)
         hid.update_devices()
       elseif m.section == "keyboard layout" then
         keyboard.set_map(s, true)


### PR DESCRIPTION
i added a local function to `lua/core/menu/devices.lua` to check if a newly-assigned vport shares its device name with any other previously-assigned vports of the same device type. if there's a match, then the other vports are unassigned by changing their name to 'none' ahead of running that device type's `update_device` function. this solves the midi device issue described in #1490 , but it also avoids this behavior across all other device types (eg. one grid being assigned to multiple ports)