### PR TITLE
avoid adding duplicate/colliding param IDs

### DIFF
--- a/lua/core/paramset.lua
+++ b/lua/core/paramset.lua
@@ -118,6 +118,13 @@ function ParamSet:add(args)
     end
   end
 
+  for _,p in pairs(self.params) do
+    if param.id == p.id then
+      print("paramset.add() error: id '"..param.id.."' is already used and will not be added")
+      return nil
+    end
+  end
+
   param.save = true
 
   table.insert(self.params, param)

--- a/lua/core/paramset.lua
+++ b/lua/core/paramset.lua
@@ -118,11 +118,8 @@ function ParamSet:add(args)
     end
   end
 
-  for _,p in pairs(self.params) do
-    if param.id == p.id then
-      print("paramset.add() error: id '"..param.id.."' is already used and will not be added")
-      return nil
-    end
+  if self.lookup[param.id] ~= nil then
+    error("paramset.add() error: id '"..param.id.."' is already used by another parameter")
   end
 
   param.save = true
@@ -464,6 +461,7 @@ function ParamSet:clear()
   self.count = 0
   self.action_read = nil 
   self.action_write = nil
+  self.lookup = {}
 end
 
 return ParamSet


### PR DESCRIPTION
from https://llllllll.co/t/bounds/23336/68, the params system doesn't currently protect against ID collision, which can lead to unintentional overwrites. this implementation simply prints the error to matron, same as the other `paramset.add()` errors -- it seemed best to stick with this pattern, unless we want to actually force a load error?

i tested this approach with `bounds`, which positively surfaced the error and avoided the collision by not adding the script's `input_level` re-definition. also tested with scripts that have a lot of params and didn't see any noticeable load time lag with this iterative approach, but am totally interested/open to optimization of this rather brute-force approach!