### PR TITLE
Attempts to improve readability of README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -25,6 +25,6 @@ git submodule update --init --recursive
 
 ## acknowledgments
 
-`matron` (control system) and `crone` (audio system) were created by @catfact. `maiden` (editor) was created by @ngwese. Each grew with contributions from @artfwo, @jah, @simon, @rv, @pq, @markwheeler, @csboling and many others.
+`matron` (control system) and `crone` (audio system) were created by [@catfact](https://github.com/catfact). `maiden` (editor) was created by [@ngwese](https://github.com/ngwese). Each grew with contributions from [@artfwo](https://github.com/artfwo), [@antonhornquist](https://github.com/antonhornquist), [@simonvanderveldt](https://github.com/simonvanderveldt),[@ranch-verdin](https://github.com/ranch-verdin), [@pq](https://github.com/pq), [@markwheeler](https://github.com/markwheeler), [@csboling](https://github.com/csboling) and many others.
 
-norns was initiated by @tehn (monome).
+norns was initiated by [@tehn](https://github.com/tehn) (monome).

--- a/readme.md
+++ b/readme.md
@@ -1,17 +1,9 @@
 # norns
+_changes. travels. is open to possibilities._
 
-- general usage documentation: [monome.org/docs/norns](https://monome.org/docs/norns).
-- API docs: [monome.org/docs/norns/api](https://monome.org/docs/norns/api).
-- build, install, configuration, and execution: [readme-setup.md](readme-setup.md)
-- community discussion and help: [llllllll.co](https://llllllll.co)
+**norns is primarily intended to run on a pi-based sound computer designed by [monome](https://monome.org/norns).**
 
-norns is primarily intended to run on a pi-based sound computer designed by [monome](https://monome.org/norns), which has some supporting repositories:
-
-- maiden, the editor: [github.com/monome/maiden](https://github.com/monome/maiden/)
-- softcut (part of `matron`): [github.com/monome/softcut-lib](https://github.com/monome/softcut-lib)
-- raspbian-based disk image: [github.com/monome/norns-image](https://github.com/monome/norns-image)
-- modified linux kernel: [github.com/monome/linux/](https://github.com/monome/linux/)
-- shield, the DIY open-source hardware variant: [github.com/monome/norns-shield](https://github.com/monome/norns-shield)
+norns is many sound instruments. it connects to grids, MIDI, and other objects. norns lets you define its behavior with scripts and DSP.
 
 ## quick reference
 
@@ -22,6 +14,22 @@ git submodule update --init --recursive
 ./waf configure
 ./waf
 ```
+
+## documentation
+- [user docs](https://monome.org/docs/norns)
+- [API docs](https://monome.org/docs/norns/api)
+- [building and execution](readme-setup.md)
+- [discussion and help](https://llllllll.co)
+
+## related
+### supporting repositories
+- [maiden](https://github.com/monome/maiden/) | editing interface
+- [softcut](https://github.com/monome/softcut-lib) | sample-cutting editor part of `matron`
+
+### tools
+- [norns disk image](https://github.com/monome/norns-image) | raspbian-based disk image
+- [monome linux kernel](https://github.com/monome/linux/) | custom, monome-flavored linux kernel
+- [DIY shield instructions](https://github.com/monome/norns-shield) | the DIY open-source hardware variant
 
 ## acknowledgments
 


### PR DESCRIPTION
## Changes
1. Links to tagged github users: if the developers are being credited, I figured linking to their github user accounts is even better! Ideally this should happen automatically within the GitHub world, but the tags weren't becoming hyperlinks by default :(
2. Updates tagged names of github users that have been changed—I discovered they had been changed from viewing the documentation at the [monome norns site](https://monome.org/docs/norns/)
3. Creates sections for content to break up text, making documentation easier to scan and comprehend.
4. Adds information describing norns to quicken understanding and introduction to newcomers.
5. Changes github link text to nouns instead of the urls to lessen cluter created by full url strings

## Summary
As I was passing through this repo on my quest to learn more about norns, I had difficulty understanding quite what norns actually _was_, who the folks were who helped develop it, and where I should go next to learn more.

My situation may be a limited user-scenario, but I realized a few ways to hopefully help newcomers, like myself, learn more—and more quickly—through some formatting changes of the README.

If the maintainers do not, in fact, find this helpful, I completely understand; I just wanted to _try_ to contribute in a very small way to a very cool community in hopefully a helpful (but slightly _less_ cool) way.

Cheers ❤️ 