### PR TITLE
fix softcut param types and _iif base

### DIFF
--- a/matron/src/weaver.c
+++ b/matron/src/weaver.c
@@ -2518,17 +2518,17 @@ int _set_cut_param(lua_State *l) {
 int _set_cut_param_ii(lua_State *l) {
     lua_check_num_args(3);
     const char *s = luaL_checkstring(l, 1);
-    int voice = (int)luaL_checkinteger(l, 2) - 1;
-    float val = (int)luaL_checkinteger(l, 3) - 1;
-    o_set_cut_param_ii((char *)s, voice, val);
+    int a = (int)luaL_checkinteger(l, 2) - 1;
+    int b = (int)luaL_checkinteger(l, 3) - 1;
+    o_set_cut_param_ii((char *)s, a, b);
     return 0;
 }
 
 int _set_cut_param_iif(lua_State *l) {
     lua_check_num_args(4);
     const char *s = luaL_checkstring(l, 1);
-    int a = (int)luaL_checkinteger(l, 2);
-    int b = (int)luaL_checkinteger(l, 3);
+    int a = (int)luaL_checkinteger(l, 2) - 1;
+    int b = (int)luaL_checkinteger(l, 3) - 1;
     float val = (float)luaL_checknumber(l, 4);
     o_set_cut_param_iif((char *)s, a, b, val);
     return 0;


### PR DESCRIPTION
two small changes:

- erroneous cast to `float` and back in softcut `_ii` parameter setter. looks like a copy/paste or codegen error. i am pretty sure this was benign.

- in weaver `_set_cut_param_iif`, indices **were not being converted from 1-base to 0-base**. this would cause a pretty serious bug. fortunately it was as un-serious as could be expected, since it only actually affects the `voice_sync` command which i believe is pretty rarely used. (i wonder if there are any scripts using it actually.)

(note that several other commands that are handled by `SoftcutClient` also accept `iif` parameters; but these are all "levels" and are processed through a different `weaver` function.)