### PR TITLE
Revert "stop after next loop+fade "

### DIFF
--- a/crone/osc-methods.txt
+++ b/crone/osc-methods.txt
@@ -44,7 +44,6 @@ osc methods:
  /set/param/cut/rec_level [if]
  /set/param/cut/pre_level [if]
  /set/param/cut/rec_flag [if]
- /set/param/cut/rec_once [if]
  /set/param/cut/play_flag [if]
  /set/param/cut/rec_offset [if]
  /set/param/cut/position [if]

--- a/crone/src/Commands.h
+++ b/crone/src/Commands.h
@@ -57,7 +57,6 @@ namespace crone {
 
             // params
             SET_CUT_REC_FLAG,
-            SET_CUT_REC_ONCE,
             SET_CUT_PLAY_FLAG,
 
             SET_CUT_RATE,

--- a/crone/src/OscInterface.cpp
+++ b/crone/src/OscInterface.cpp
@@ -376,11 +376,6 @@ void OscInterface::addServerMethods() {
         Commands::softcutCommands.post(Commands::Id::SET_CUT_REC_FLAG, argv[0]->i, argv[1]->f);
     });
 
-    addServerMethod("/set/param/cut/rec_once", "if", [](lo_arg **argv, int argc) {
-        if (argc < 2) { return; }
-        Commands::softcutCommands.post(Commands::Id::SET_CUT_REC_ONCE, argv[0]->i, argv[1]->f);
-    });
-
     addServerMethod("/set/param/cut/play_flag", "if", [](lo_arg **argv, int argc) {
         if (argc < 2) { return; }
         Commands::softcutCommands.post(Commands::Id::SET_CUT_PLAY_FLAG, argv[0]->i, argv[1]->f);
@@ -479,6 +474,7 @@ void OscInterface::addServerMethods() {
         if (argc < 3) { return; }
         Commands::softcutCommands.post(Commands::Id::SET_CUT_VOICE_SYNC, argv[0]->i, argv[1]->i, argv[2]->f);
     });
+
 
     ///////////////////////////////////////////
     /// FIXME: fade curve calculations are now per-voice,

--- a/crone/src/SoftcutClient.cpp
+++ b/crone/src/SoftcutClient.cpp
@@ -137,13 +137,6 @@ void crone::SoftcutClient::handleCommand(Commands::CommandPacket *p) {
     case Commands::Id::SET_CUT_REC_FLAG:
 	cut.setRecFlag(idx_0, value > 0.f);
 	break;
-    case Commands::Id::SET_CUT_REC_ONCE:
-	cut.setRecOnceFlag(idx_0,true);
-	if (value >= 0.f) {
-		clamp(value, 0.f, bufDur);
-		cut.cutToPos(idx_0,value);
-	}
-	break;
     case Commands::Id::SET_CUT_PLAY_FLAG:
 	cut.setPlayFlag(idx_0, value > 0.f);
 	break;

--- a/lua/core/softcut.lua
+++ b/lua/core/softcut.lua
@@ -108,10 +108,6 @@ SC.pre_level = function(voice,amp) _norns.cut_param("pre_level",voice,amp) end
 -- @tparam int voice : voice number (1-?)
 -- @tparam int state : off/on (0,1)
 SC.rec = function(voice,state) _norns.cut_param("rec_flag",voice,state) end
--- set to record one loop.
--- @tparam int voice : voice number (1-?)
--- @tparam float pos : position in seconds to initiate loop (optional). if omitted, then next cut will start
-SC.rec_once = function(src, pos) _norns.cut_param("rec_once",src,pos or -1) end
 --- set record head offset
 SC.rec_offset = function(voice,value) _norns.cut_param("rec_offset",voice,value) end
 --- set play position


### PR DESCRIPTION
Reverts monome/norns#1494

@schollz i apologize--- i misunderstood some of the technical issues with this PR (i misinterpreted the problem as pre-existing), and without a clean fix i'd prefer not to add technical debt to the project. i understand your soft-fix of pushing the play command later generally "works" but we'd need a robust fix prior to adding this feature to main.

furthermore there are some needed optimizations, as i learn more about the careful architecting done by @catfact in the dsp loop.

i'm reverting this PR as an overdue norns update is waiting, and i can't foresee a realistic timeline for fixing this issue.