### PR TITLE
update readme-setup with packages, component descriptions

### DIFF
--- a/readme-setup.md
+++ b/readme-setup.md
@@ -2,21 +2,17 @@
 
 ## build prerequisites
 
-### packages
-```
-sudo apt-get install libevdev-dev liblo-dev libudev-dev libcairo2-dev liblua5.3-dev libavahi-compat-libdnssd-dev libasound2-dev libncurses5-dev libncursesw5-dev libsndfile1-dev
-```
+### standard packages
 
-### sources
-
-build and install:
+these can be installed from the default Debian repositories: 
 
 ```
-https://github.com/monome/libmonome.git
-https://github.com/nanomsg/nanomsg.git
+sudo apt-get install libevdev-dev liblo-dev libudev-dev libcairo2-dev liblua5.3-dev libavahi-compat-libdnssd-dev libasound2-dev libncurses5-dev libncursesw5-dev libsndfile1-dev libjack-dev liboost-dev
 ```
 
-or use the debian repository as follows:
+### other packages / sources
+
+on norns / raspberry pi, the following should be installed from monome's repositories:
 
 ```
 curl https://keybase.io/artfwo/pgp_keys.asc | sudo apt-key add -
@@ -24,6 +20,24 @@ echo "deb https://package.monome.org/ stretch main" | sudo tee /etc/apt/sources.
 sudo apt update
 sudo apt install libmonome-dev libnanomsg-dev supercollider-language supercollider-server supercollider-dev
 ```
+
+for other platforms (x86, amd64), these packages can again use the standard repositories:
+
+```
+sudo apt install libnanomsg-dev supercollider-language supercollider-server supercollider-dev
+```
+
+and `libmonome` must be build and installed from source:
+
+- clone, build, and install:
+```
+git clone https://github.com/monome/libmonome
+cd libmonome
+./waf configure && ./waf && sudo ./waf install
+```
+
+- add `/usr/local/lib` to library search paths. the recommended way to do this is by editing `/etc/ld.so.conf`. (use of the `LD_LIBRARY_PATH` variable is deprecated, since it willl override binary-specific settings.)
+
 
 ## building norns
 
@@ -35,9 +49,17 @@ git submodule update --init --recursive
 ./waf
 ```
 
-this should build all the c-based components (`matron` and `ws-wrapper`.)
+this should build several executables under `norns/build/<name>/`:
 
-the `crone` audio engine consists of supercollider classes. copy files to the default location for user SC extensions
+- `matron`: the main norns system application: runs scripts, interfaces with controllers and screens
+- `crone`: the norns "audio backend," a JACK application which routes audio, runs the `softcut` buffer processing system, and hosts built-in effects
+- `ws-wrapper`: utility which wraps the standard I/O of a process in websockets; used to expose `matron` and `sclang` to the web IDE
+- `watcher`: watchdog utility
+- `maiden-repl`: command-line interface to `matron` and `sclang` REPLs
+
+(note that the `maiden` webserver/IDE is managed separately, in its own repository.)
+
+norns also uses some custom supercollider classes. thess files must be copied to the default location for user SC extensions; we provide a script to do so:
 
 ```
 pushd sc
@@ -45,38 +67,21 @@ pushd sc
 popd
 ```
 
-## configure
-
-- add `/usr/local/lib` to library search paths (if libmonome is installed from sources.)
-the recommended way to do this is by editing `/etc/ld.so.conf`. (use of the `LD_LIBRARY_PATH` variable is deprecated, since it willl override binary-specific settings.)
-
 
 ## launching components
 
-### 1. launch `crone` (audio engine)
+in normal use, the component executables should be managed by `systemd` services, which take care of websocket wrapping.
 
-run `crone.sh` from the norns directory. this creates a `sclang` process wrapped with `ws-wrapper`
+for development, it is often useful to run component processes manually from an `ssh` session. this is best accomplished using three different sessions (`screen` is an option), each launching the following in this order:
 
-if the crone classes are installed correctly, you should see some lines like this in output from sclang initialization:
+- 0. first, ensure that JACK is running: `systemctl start norns-jack`
+- 1. `norns/build/crone/crone` - runs the norns audio backend; prints some status stuff, but is not interactive
+- 2. `sclang` - runs supercollider, spawns a `scynth` instance which is then routed through `crone`; provides a nice REPL
+- 3. `norns/build/matron/matron` - runs the main norns system; provides a very basic REPL (no readline)
 
-```
--------------------------------------------------
- Crone startup
+in general, changes to `matron` sources require only building and relaunching `matron`, changes to supercollider classes require relaunching `sclang`+`matron`, and changes to `crone` sources require relaunching all three.
 
- OSC rx port: 57120
- OSC tx port: 8888
---------------------------------------------------
-```
-
-and immediately after sclang init, you should see the server being booted and some jack/alsa related messages.
-
-### 2. launch `matron` (lua interpreter)
-
-with the audio engine running, run `matron.sh` from the norns directory. this creates a `matron` process wrapped with `ws-wrapper`
-
-matron waits for crone to finish loading before entering the main event loop.
-
-### 3. launch `maiden` (web UI client)
+## launching `maiden` (web UI client)
 
 get most [recent version](https://github.com/monome/maiden/releases)
 
@@ -84,8 +89,7 @@ download to `~/maiden/` and untar
 
 execute with `./maiden.arm -debug -site ./app/build -data ~/norns/lua/`
 
-
-## docs addendum
+## docs
 
 if you want to generate the docs (using ldoc) first install:
 

--- a/readme-setup.md
+++ b/readme-setup.md
@@ -39,6 +39,13 @@ cd libmonome
 - add `/usr/local/lib` to library search paths. the recommended way to do this is by editing `/etc/ld.so.conf`. (use of the `LD_LIBRARY_PATH` variable is deprecated, since it willl override binary-specific settings.)
 
 
+### desktop
+
+using the `desktop` build option has additional requirements:
+```
+sudo apt install libsdl2-dev
+```
+
 ## building norns
 
 ```
@@ -59,6 +66,7 @@ this should build several executables under `norns/build/<name>/`:
 
 (note that the `maiden` webserver/IDE is managed separately, in its own repository.)
 
+### supercollider 
 norns also uses some custom supercollider classes. thess files must be copied to the default location for user SC extensions; we provide a script to do so:
 
 ```
@@ -66,6 +74,17 @@ pushd sc
 ./install.sh
 popd
 ```
+
+### desktop
+
+for building on desktop, add the `--desktop` option to both `waf` steps (configure and build):
+
+```
+./waf configure --desktop
+./waf build --desktop
+```
+
+(NB: `waf` assumes `build` as the default command, which is why we can omit it above.)
 
 
 ## launching components
@@ -89,6 +108,10 @@ download to `~/maiden/` and untar
 
 execute with `./maiden.arm -debug -site ./app/build -data ~/norns/lua/`
 
+## launching on desktop / other platforms:
+
+when running norns on desktop computers or custom hardware platforms, you will want to provide `matron` with appropriate runtime configuration options using the `matronrc.lua` file. this should be copied to the user's home directory and customized there. see the comments in that file.
+
 ## docs
 
 if you want to generate the docs (using ldoc) first install:
@@ -103,3 +126,4 @@ to generate the docs:
 `ldoc .` in the root norns folder
 
 To read the documentation, point the browser window with Maiden loaded to [http://norns.local/doc](http://norns.local/doc) (or use IP address if this doesn't work).
+


### PR DESCRIPTION
- some required packages were missing (`jack-dev`, `libboost-dev`)

(yes yes, we should remove boost dependency.)

- general description of system components was very old (particularly bits about supercollider)

- included some pointers on how to run individual components during development