### PR TITLE
make param ID collision a scary warning instead

### DIFF
--- a/lua/core/paramset.lua
+++ b/lua/core/paramset.lua
@@ -119,7 +119,11 @@ function ParamSet:add(args)
   end
 
   if self.lookup[param.id] ~= nil then
-    error("paramset.add() error: id '"..param.id.."' is already used by another parameter")
+    print("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
+    print("!!!!! ERROR: parameter ID collision: ".. param.id .. ' - parameter not added!')
+    print("!!!!! please contact the script maintainer - this will cause a load failure in future updates")
+    print("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
+    return
   end
 
   param.save = true

--- a/lua/core/paramset.lua
+++ b/lua/core/paramset.lua
@@ -26,6 +26,56 @@ local ParamSet = {
   sets = {}
 }
 
+
+-- utility hack
+local system_param_ids  =  {
+  comp_release = true,
+  monitor_level = true,
+  cut_input_eng = true,
+  comp_attack = true,
+  COMPRESSOR = true,
+  rev_cut_input = true,
+  rev_return_level = true,
+  tape_level = true,
+  reverb = true,
+  comp_post_gain = true,
+  rev_pre_delay = true,
+  clock_crow_out_div = true,
+  compressor = true,
+  cut_input_tape = true,
+  rev_lf_fc = true,
+  clock_crow_out = true,
+  REVERB = true,
+  rev_low_time = true,
+  comp_threshold = true,
+  rev_monitor_input = true,
+  LEVELS = true,
+  rev_hf_damping = true,
+  rev_eng_input = true,
+  input_level = true,
+  rev_tape_input = true,
+  clock_midi_out = true,
+  comp_pre_gain = true,
+  link_start_stop_sync = true,
+  softcut_level = true,
+  clock_reset = true,
+  link_quantum = true,
+  engine_level = true,
+  clock_tempo = true,
+  clock_source = true,
+  CLOCK = true,
+  output_level = true,
+  clock_crow_in_div = true,
+  rev_mid_time = true,
+  cut_input_adc = true,
+  comp_mix = true,
+  SOFTCUT = true,
+  monitor_mode = true,
+  headphone_gain = true,
+  comp_ratio = true
+}
+
+
 ParamSet.__index = ParamSet
 
 --- constructor.
@@ -120,10 +170,14 @@ function ParamSet:add(args)
 
   if self.lookup[param.id] ~= nil then
     print("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
-    print("!!!!! ERROR: parameter ID collision: ".. param.id .. ' - parameter not added!')
-    print("!!!!! please contact the script maintainer - this will cause a load failure in future updates")
-    print("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
-    return
+    print("!!!!! ERROR: parameter ID collision: ".. param.id)
+    print("! please contact the script maintainer - this will cause a load failure in future updates")
+    if system_param_ids[param.id] ~= nil then
+      print("! since this is a system param ID, i am refusing to clobber it")
+      return
+    else
+      print("! BEWARE! clobbering a script or mod param")
+    end
   end
 
   param.save = true
@@ -467,5 +521,6 @@ function ParamSet:clear()
   self.action_write = nil
   self.lookup = {}
 end
+
 
 return ParamSet


### PR DESCRIPTION
reverting this error to a warning. 

i believe it should ultimately be an error, but that's not ideal for the moment without an extended beta period. i'm not quite convinced its doing what we want as i'm seeing some seemingly spurious/inconsistent examples that should be examined more thoroughly.

one obvious difficulty is that script params may collide with mod params! oy.

in any case, this change should make things better than before the error, because it adds an early return to the function instead of clobbering an existing param in the lookup table

...actually now that i think about it i'm not sure this is "better." scripts will still be broken because they have non-functional parameters. but they will not "steal" parameters from the system, breaking stuff even after the script is cleaned up.

should i add a more explicit set of tests for clobbering system parameters only? hm... @tehn et al, would appreciate opinions.