### PR TITLE
remove unneeded (?) boost requirement

### DIFF
--- a/readme-setup.md
+++ b/readme-setup.md
@@ -7,7 +7,7 @@
 these can be installed from the default Debian repositories: 
 
 ```
-sudo apt-get install libevdev-dev liblo-dev libudev-dev libcairo2-dev liblua5.3-dev libavahi-compat-libdnssd-dev libasound2-dev libncurses5-dev libncursesw5-dev libsndfile1-dev libjack-dev libboost-dev libnanomsg-dev
+sudo apt-get install libevdev-dev liblo-dev libudev-dev libcairo2-dev liblua5.3-dev libavahi-compat-libdnssd-dev libasound2-dev libncurses5-dev libncursesw5-dev libsndfile1-dev libjack-dev libnanomsg-dev
 ```
 
 ### other packages / sources


### PR DESCRIPTION
so, i forgot that we actually removed all boost usage from crone/softcut already

but i guess failed to remove the requirement from `wscript`/readme, so this change does that.

the only thing that gives me pause is the references to boost in the `link` sources. but AFAICT it seems to work.