### PR TITLE
Fix boost requirement

### DIFF
--- a/readme-setup.md
+++ b/readme-setup.md
@@ -7,7 +7,7 @@
 these can be installed from the default Debian repositories: 
 
 ```
-sudo apt-get install libevdev-dev liblo-dev libudev-dev libcairo2-dev liblua5.3-dev libavahi-compat-libdnssd-dev libasound2-dev libncurses5-dev libncursesw5-dev libsndfile1-dev libjack-dev libboost-dev libnanomsg-dev
+sudo apt-get install libevdev-dev liblo-dev libudev-dev libcairo2-dev liblua5.3-dev libavahi-compat-libdnssd-dev libasound2-dev libncurses5-dev libncursesw5-dev libsndfile1-dev libjack-dev libnanomsg-dev
 ```
 
 ### other packages / sources

--- a/wscript
+++ b/wscript
@@ -11,7 +11,7 @@ def get_version_hash():
         return ''
 
 def options(opt):
-    opt.load('compiler_c compiler_cxx boost')
+    opt.load('compiler_c compiler_cxx')
     opt.add_option('--desktop', action='store_true', default=False)
     opt.add_option('--enable-ableton-link', action='store_true', default=True)
     opt.add_option('--profile-matron', action='store_true', default=False)
@@ -19,7 +19,7 @@ def options(opt):
     opt.recurse('maiden-repl')
 
 def configure(conf):
-    conf.load('compiler_c compiler_cxx boost')
+    conf.load('compiler_c compiler_cxx')
 
     conf.define('VERSION_MAJOR', 0)
     conf.define('VERSION_MINOR', 0)
@@ -51,8 +51,6 @@ def configure(conf):
         lib='monome',
         header_name='monome.h',
         uselib_store='LIBMONOME')
-
-    conf.check_boost()
 
     if conf.options.desktop:
         conf.check_cfg(package='sdl2', args=['--cflags', '--libs'])


### PR DESCRIPTION
ok lets try this again. 

actually removed boost requirement from wscript this time.

also, importantly, updated `softcut` submodule to remove boost functions from softcut-lib.