### PR TITLE
screen: draw to image support

### DIFF
--- a/lua/core/screen.lua
+++ b/lua/core/screen.lua
@@ -313,6 +313,11 @@ Screen.display_png = function(filename, x, y) _norns.screen_display_png(filename
 -- @param filename
 Screen.load_png = function(filename) return _norns.screen_load_png(filename) end
 
+--- create an image buffer
+-- @tparam number width image witdth
+-- @tparam number height image height
+Screen.create_image = function(width, height) return _norns.screen_create_image(width, height) end
+
 --- display image buffer
 -- @param image
 -- @tparam number x x position
@@ -329,6 +334,16 @@ Screen.display_image = function(image, x, y) _norns.screen_display_image(image, 
 -- @tparam number y y position
 Screen.display_image_region = function(image, left, top, width, height, x, y)
   _norns.screen_display_image_region(image, left, top, width, height, x, y)
+end
+
+--- direct screen drawing within the provide function into the image instead of the screen
+-- @tparam image image the image to draw into
+-- @tparam function func function called to perform drawing
+Screen.draw_to = function(image, func)
+  image:_context_focus()
+  local ok, result = pcall(func)
+  image:_context_defocus()
+  if not ok then print(result) else return result end
 end
 
 --- get a rectangle of screen content. returned buffer contains one byte (valued 0 - 15) per pixel, i.e. w * h bytes

--- a/matron/src/hardware/screen.h
+++ b/matron/src/hardware/screen.h
@@ -45,9 +45,18 @@ typedef struct {
     int height;
 } screen_surface_extents_t;
 
-extern void screen_surface_free(screen_surface_t *s);
+extern screen_surface_t *screen_surface_new(double width, double height);
 extern screen_surface_t *screen_surface_load_png(const char *filename);
+extern void screen_surface_free(screen_surface_t *s);
 extern bool screen_surface_get_extents(screen_surface_t *s, screen_surface_extents_t *e);
 extern void screen_surface_display(screen_surface_t *s, double x, double y);
 extern void screen_surface_display_region(screen_surface_t *s, double left, double top, double width, double height, double x, double y);
+
+typedef struct _screen_context screen_context_t;
+
+extern screen_context_t *screen_context_new(screen_surface_t *target);
+extern void screen_context_free(screen_context_t *context);
+extern const screen_context_t *screen_context_get_current(void);
+extern void screen_context_set(const screen_context_t *context);
+extern void screen_context_set_primary(void);
 


### PR DESCRIPTION
adds the ability to direct screen drawing to an image

the api is straightforward:
```lua
image = screen.create_image(32, 32)
screen.draw_to(image, function()
  local w, h = image:extents()
  screen.clear()
  screen.level(15)
  screen.aa(0)
  screen.rect(0, 0, w, h)
  screen.stroke()
  screen.update()
end)
```

under the hood a screen "context" (aka cairo_t) is allocated and attached to the image object when drawing to the image is first attempted. this is done lazily for simplicity of user experience and to avoid allocating additional data for images which are never draw to. during the execution of the `screen.draw_to(...)` function the cairo context associated with the screen swapped out for the context associated with the image, the contexts are independent so any changes made to settings like `aa` or `level` and/or transformation only affect the image drawing (and are incidentally carried across `screen.draw_to(...)` calls with the same image).  the `screen.draw_to(...)` function uses `pcall` internally to ensure that errors raised while drawing to the image do not prevent restoration of the screen context.

various tests (https://github.com/ngwese/image_demo/tree/main/test) were used to validate correctness, specifically
- performing drawing outside of any function (toplevel)
- nesting calls to `screen.draw_to(...)`
- raising errors within `screen.draw_to(...)`
- pushing the system to memory exhaustion

this change also includes some small polish on the image handling support such as raising lua errors when failures occur.

