### PR TITLE
More opt flags

### DIFF
--- a/crone/wscript
+++ b/crone/wscript
@@ -25,7 +25,7 @@ def build(bld):
     ]
 
     crone_flags = [ '-std=c++14',
-                    '-O2',
+                    '-O3',
                     '-Wall'
                   ]
 
@@ -35,18 +35,9 @@ def build(bld):
             '-mtune=cortex-a53',
             '-mfpu=neon-fp-armv8',
             '-mfloat-abi=hard',
-            #'-faggressive-loop-optimizations',
-            # '-funconstrained-commons',
-            #'-funsafe-math-optimizations',
-            #'-finline-functions',
-            #'-funswitch-loops',
-            #'-fpredictive-commoning',
-            #'-fgcse-after-reload',
-            #'-ftree-vectorize',
-            #'-fvect-cost-model',
-            #'-ftree-partial-p',
-            #'-ffast-math',
-            #'-fgcse-sm',
+            '-funconstrained-commons',
+            '-ffast-math',
+            '-fgcse-sm',
         ]
 
     bld.program( features='c cxx cxxprogram',

--- a/crone/wscript
+++ b/crone/wscript
@@ -30,12 +30,24 @@ def build(bld):
                   ]
 
     if bld.env.NORNS_RELEASE:
-        crone_flags += [ '-mcpu=cortex-a53',
-                         '-mtune=cortex-a53',
-                         '-mfpu=neon-fp-armv8',
-                         '-mfloat-abi=hard',
-                         '-funsafe-math-optimizations'
-                       ]
+        crone_flags += [ 
+            '-mcpu=cortex-a53',
+            '-mtune=cortex-a53',
+            '-mfpu=neon-fp-armv8',
+            '-mfloat-abi=hard',
+            #'-faggressive-loop-optimizations',
+            # '-funconstrained-commons',
+            #'-funsafe-math-optimizations',
+            #'-finline-functions',
+            #'-funswitch-loops',
+            #'-fpredictive-commoning',
+            #'-fgcse-after-reload',
+            #'-ftree-vectorize',
+            #'-fvect-cost-model',
+            #'-ftree-partial-p',
+            #'-ffast-math',
+            #'-fgcse-sm',
+        ]
 
     bld.program( features='c cxx cxxprogram',
                  source=crone_sources,

--- a/matron/wscript
+++ b/matron/wscript
@@ -82,7 +82,7 @@ def build(bld):
         matron_use += ['LIBLINK_C']
 
     
-    matron_cflags=['-O3', '-Wall', '-std=c11'],
+    matron_cflags=['-O3', '-Wall', '-std=c11']
 
     if bld.env.NORNS_RELEASE:
         matron_cflags += [ 

--- a/matron/wscript
+++ b/matron/wscript
@@ -18,7 +18,7 @@ def build(bld):
         'src/hardware/platform.c',
         'src/hardware/screen.c',
         'src/hardware/stat.c',
-	'src/hardware/screen/fbdev.c',
+	    'src/hardware/screen/fbdev.c',
         'src/hardware/input/gpio.c',
         'src/args.c',
         'src/events.c',
@@ -80,6 +80,17 @@ def build(bld):
         matron_includes += ['../third-party/link-c']
         matron_libs += ['stdc++']
         matron_use += ['LIBLINK_C']
+
+    
+    matron_cflags=['-O3', '-Wall', '-std=c11'],
+
+    if bld.env.NORNS_RELEASE:
+        matron_cflags += [ 
+            '-mcpu=cortex-a53',
+            '-mtune=cortex-a53',
+            '-mfpu=neon-fp-armv8',
+            '-mfloat-abi=hard',
+        ]
 
     if bld.env.PROFILE_MATRON:
       bld.env.append_unique('CFLAGS', ['-pg'])

--- a/matron/wscript
+++ b/matron/wscript
@@ -103,5 +103,5 @@ def build(bld):
         includes=matron_includes,
         use=matron_use,
         lib=matron_libs,
-        cflags=['-O3', '-Wall', '-std=c11'],
+        cflags=matron_cflags,
         ldflags=['-Wl,-export-dynamic'])


### PR DESCRIPTION
- changed `crone` opt level to `O3` and added a couple more flags on top for release builds. this squeezes another 2-3% of audio load headroom according to `baseline`. (not dramatic since we already had auto-vec stuff enabled at O2.)

- also propagated the CPU and FPU selections to `matron` for release builds. so that is probably a little faster too but we dont have as convenient a profiling mechanism.

the minor downside is that a few seconds have been added to compiation time.