### PR TITLE
add param separators to lookup table

### DIFF
--- a/lua/core/paramset.lua
+++ b/lua/core/paramset.lua
@@ -407,6 +407,7 @@ end
 -- parameters are visible by default.
 -- @param index
 function ParamSet:visible(index)
+  if type(index)=="string" then index = self.lookup[index] end
   return not self.hidden[index]
 end
 

--- a/lua/core/paramset.lua
+++ b/lua/core/paramset.lua
@@ -100,7 +100,7 @@ end
 --- add separator.
 -- name is optional.
 -- separators have their own parameter index and
--- can be hidden or added to a paremeter group.
+-- can be hidden or added to a parameter group.
 -- @tparam string name
 function ParamSet:add_separator(name)
   local param = separator.new(name)
@@ -108,9 +108,7 @@ function ParamSet:add_separator(name)
   self.count = self.count + 1
   self.group = self.group - 1
   self.hidden[self.count] = false
-  if name == nil then
-    self.lookup["separator_"..self.count] = self.count
-  else
+  if name ~= nil then
     self.lookup[name] = self.count
   end
 end

--- a/lua/core/paramset.lua
+++ b/lua/core/paramset.lua
@@ -107,6 +107,9 @@ function ParamSet:add_separator(name)
   self.count = self.count + 1
   self.group = self.group - 1
   self.hidden[self.count] = false
+  if name ~= nil then
+    self.lookup[name] = self.count
+  end
 end
 
 --- add parameter group.

--- a/lua/core/paramset.lua
+++ b/lua/core/paramset.lua
@@ -107,7 +107,9 @@ function ParamSet:add_separator(name)
   self.count = self.count + 1
   self.group = self.group - 1
   self.hidden[self.count] = false
-  if name ~= nil then
+  if name == nil then
+    self.lookup["separator_"..self.count] = self.count
+  else
     self.lookup[name] = self.count
   end
 end


### PR DESCRIPTION
currently, param separators don't get registered to the lookup table, so there's no way to use `params:show` and `params:hide` -- rather, the user needs to do a bit of sleuthing to find the params ID and then directly change the `params.hidden` table.

i just added lookup registration if the separator is named, and then added a dummy name for unnamed separators -- lemme know if this is too much scaffolding and we can just document that a separator needs to be named in order to have its visibility changed with `:show` and `:hide`

i also adjusted `params:visible` so it could be queried with string or index, as `:hide` and `:show` are.
please lemme know if anything is missing!

test script:

```lua
function init()
  params:add_separator("visibility test")
end

function key(n,z)
  if n == 3 and z == 1 then
    if params:visible("visibility test") then
      params:hide("visibility test")
    else
      params:show("visibility test")
    end
    _menu.rebuild_params()
    redraw()
  end
end

function redraw()
  screen.clear()
  screen.move(32,32)
  if params:visible("visibility test") then
    screen.text("separator visible")
  else
    screen.text("separator hidden")
  end
  screen.update()
end
```