### PR TITLE
matron: embed lua-cjson module

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "crone/lib/readerwriterqueue"]
 	path = crone/lib/readerwriterqueue
 	url = https://github.com/cameron314/readerwriterqueue.git
+[submodule "third-party/lua-cjson"]
+	path = third-party/lua-cjson
+	url = https://github.com/mpx/lua-cjson.git

--- a/lua/core/script.lua
+++ b/lua/core/script.lua
@@ -27,6 +27,9 @@ Script.clear = function()
     package.loaded['asl'] = nil
   end
 
+  -- reset embedded modules
+  json = _json
+
   -- script local state
   local state = { }
 

--- a/lua/core/startup.lua
+++ b/lua/core/startup.lua
@@ -29,6 +29,9 @@ paramset = require 'core/paramset'
 params = paramset.new()
 norns.pmap = require 'core/pmap'
 
+-- embedded global modules
+json = _json
+
 -- load menu
 require 'core/menu'
 

--- a/matron/src/weaver.c
+++ b/matron/src/weaver.c
@@ -343,7 +343,7 @@ static void lua_register_cjson() {
 #if HAVE_LUA_CJSON
     luaopen_cjson(lvm);
     lua_pushvalue(lvm, -1);
-    lua_setglobal(lvm, "json");
+    lua_setglobal(lvm, "_json");
 #endif
 }
 

--- a/matron/src/weaver.c
+++ b/matron/src/weaver.c
@@ -47,6 +47,10 @@
 #include "system_cmd.h"
 #include "weaver.h"
 
+#if HAVE_LUA_CJSON
+int luaopen_cjson(lua_State *l);
+#endif
+
 // registered lua functions require the LVM state as a parameter.
 // but often we don't need it.
 // use pragma instead of casting to void as a workaround.
@@ -335,6 +339,14 @@ static void lua_register_norns_class(const char *class_name, const luaL_Reg *met
     }
 }
 
+static void lua_register_cjson() {
+#if HAVE_LUA_CJSON
+    luaopen_cjson(lvm);
+    lua_pushvalue(lvm, -1);
+    lua_setglobal(lvm, "json");
+#endif
+}
+
 ////////////////////////////////
 //// extern function definitions
 
@@ -343,6 +355,9 @@ void w_init(void) {
     lvm = luaL_newstate();
     luaL_openlibs(lvm);
     lua_pcall(lvm, 0, 0, 0);
+
+   // initialize embedded third-party modules
+   lua_register_cjson();
 
     ////////////////////////
     // FIXME: document these in lua in some deliberate fashion

--- a/matron/wscript
+++ b/matron/wscript
@@ -81,11 +81,13 @@ def build(bld):
         matron_libs += ['stdc++']
         matron_use += ['LIBLINK_C']
 
-    
+    if bld.env.ENABLE_LUA_CJSON:
+        matron_use += ['LUA_CJSON']
+
     matron_cflags=['-O3', '-Wall', '-std=c11']
 
     if bld.env.NORNS_RELEASE:
-        matron_cflags += [ 
+        matron_cflags += [
             '-mcpu=cortex-a53',
             '-mtune=cortex-a53',
             '-mfpu=neon-fp-armv8',

--- a/third-party/wscript
+++ b/third-party/wscript
@@ -21,6 +21,34 @@ def build_link(bld):
         ],
         name='LIBLINK_C')
 
+def build_cjson(bld):
+    bld.stlib(features='c cxx cxxstlib',
+        source=[
+            'lua-cjson/lua_cjson.c',
+            'lua-cjson/strbuf.c',
+            'lua-cjson/fpconv.c'
+        ],
+        target='lua-cjson',
+        includes=[
+            'lua-cjson',
+        ],
+        cflags=[
+            '-O3',
+            '-Wall',
+            '-Wimplicit-fallthrough=0', # NOTE: GCC7+ warns by default which results in Werror build failures
+            '-pedantic',
+        ],
+        defines=[
+            'NDEBUG'
+        ],
+        use=[
+            'LUA53'
+        ],
+        name='LUA_CJSON'
+    )
+
 def build(bld):
     if bld.env.ENABLE_ABLETON_LINK:
         build_link(bld)
+    if bld.env.ENABLE_LUA_CJSON:
+        build_cjson(bld)

--- a/wscript
+++ b/wscript
@@ -15,6 +15,7 @@ def options(opt):
     opt.add_option('--desktop', action='store_true', default=False)
     opt.add_option('--release', action='store_true', default=False)
     opt.add_option('--enable-ableton-link', action='store_true', default=True)
+    opt.add_option('--enable-lua-cjson', action='store_true', default=True)
     opt.add_option('--profile-matron', action='store_true', default=False)
 
     opt.recurse('maiden-repl')
@@ -64,6 +65,9 @@ def configure(conf):
 
     conf.env.ENABLE_ABLETON_LINK = conf.options.enable_ableton_link
     conf.define('HAVE_ABLETON_LINK', conf.options.enable_ableton_link)
+
+    conf.env.ENABLE_LUA_CJSON = conf.options.enable_lua_cjson
+    conf.define('HAVE_LUA_CJSON', conf.options.enable_lua_cjson)
 
     conf.recurse('maiden-repl')
 


### PR DESCRIPTION
this is a quick pass at building and statically linking the `cjson` module directly into matron. i've minimally tested this by calling `json.encode(...)` and `json.decode(...)` in the repl.

details to consider:
- this registers the module as `json` in the global environment
- embedded modules can't be accessed via `require(...)` since there is nothing to search for, this is maybe confusing for people
- ~~if a scripts assigns a value to `json` it effective overwrites the module registration making it inaccessible until matron is restarted~~

my recollection was that we did something to guard against global modules getting overwritten but in looking around i couldn't find anything that appeared to protect (or restore) the say `screen` or `grid` after a script ran. i did notice that we have this https://github.com/monome/norns/blob/main/lua/core/script.lua#L33-L40 - which if i'm understanding it correctly will prevent new globals from leaking into the environment but it doesn't seem to prevent overwriting of globals.

EDIT:  i've pushed an additional commit which instead registers the modules as `_json` global and then assigns that to `json` at startup and script cleanup. this doesn't prevent the table itself from being altered but it does help to recover from accidental assignment to `json` 

EDIT2: if we wanted to retain the use of `require`ing the module i could also simply add a trivial `json.lua` file which returns the `_json` global or a copy of the table.

/cc @schollz 