### PR TITLE
add PSET number to PSET actions + add delete action

### DIFF
--- a/doc/modules/paramset.html
+++ b/doc/modules/paramset.html
@@ -229,11 +229,11 @@
     <td class="summary">delete from disk.</td>
     </tr>
     <tr>
-    <td class="name" nowrap><a href="#ParamSet.action_write">ParamSet.action_write (filename, name)</a></td>
+    <td class="name" nowrap><a href="#ParamSet.action_write">ParamSet.action_write (filename, name, pset_number)</a></td>
 	<td class="summary">static callback when a pset is created; user scripts can redefine</td>
 	</tr>
 	<tr>
-	<td class="name" nowrap><a href="#ParamSet.action_read">ParamSet.action_read (filename, silent)</a></td>
+	<td class="name" nowrap><a href="#ParamSet.action_read">ParamSet.action_read (filename, silent, pset_number)</a></td>
 	<td class="summary">static callback when a pset is read; user scripts can redefine</td>
 	</tr>
     <tr>

--- a/doc/modules/paramset.html
+++ b/doc/modules/paramset.html
@@ -224,6 +224,22 @@
 	<td class="name" nowrap><a href="#ParamSet:read">ParamSet:read (filename, silent)</a></td>
 	<td class="summary">read from disk.</td>
 	</tr>
+    <tr>
+    <td class="name" nowrap><a href="#ParamSet:delete">ParamSet:delete (filename, name, pset_number)</a></td>
+    <td class="summary">delete from disk.</td>
+    </tr>
+    <tr>
+    <td class="name" nowrap><a href="#ParamSet.action_write">ParamSet.action_write (filename, name)</a></td>
+	<td class="summary">static callback when a pset is created; user scripts can redefine</td>
+	</tr>
+	<tr>
+	<td class="name" nowrap><a href="#ParamSet.action_read">ParamSet.action_read (filename, silent)</a></td>
+	<td class="summary">static callback when a pset is read; user scripts can redefine</td>
+	</tr>
+    <tr>
+    <td class="name" nowrap><a href="#ParamSet.action_delete">ParamSet.action_delete (filename, name, pset_number)</a></td>
+    <td class="summary">static callback when a pset is deleted; user scripts can redefine</td>
+    </tr>
 	<tr>
 	<td class="name" nowrap><a href="#ParamSet:default">ParamSet:default ()</a></td>
 	<td class="summary">read default pset if present.</td>
@@ -1007,6 +1023,125 @@
         <li><span class="parameter">silent</span>
             <span class="types"><span class="type">boolean</span></span>
          if true, do not trigger parameter actions
+        </li>
+    </ul>
+
+
+
+
+
+</dd>
+    <dt>
+    <a name = "ParamSet:delete"></a>
+    <strong>ParamSet:delete (filename, name, pset_number)</strong>
+    </dt>
+    <dd>
+    delete from disk.
+
+
+    <h3>Parameters:</h3>
+    <ul>
+        <li><span class="parameter">filename</span>
+            <span class="types"><a class="type" href="../modules/paramset.html#ParamSet:string">string</a></span>
+        either an absolute path, number (to read [scriptname]-[number].pset from local data folder) or nil (to read pset number specified by pset-last.txt in the data folder)
+        </li>
+        <li><span class="parameter">name</span>
+            <span class="types"><a class="type" href="../modules/paramset.html#ParamSet:string">string</a></span>
+        the name of the pset, as entered in the norns pset menu, corresponding to the first line of [scriptname]-[number].pset in local data folder
+        </li>
+        <li><span class="parameter">pset_number</span>
+            <span class="types"><span class="type">number</span></span>
+        the number of the pset, as shown in the norns pset menu, corresponding to the [scriptname]-[number].pset in local data folder
+        </li>
+    </ul>
+
+
+
+
+
+</dd>
+    <dt>
+    <a name = "ParamSet.action_write"></a>
+    <strong>ParamSet.action_write (filename, name, pset_number)</strong>
+    </dt>
+    <dd>
+    static callback when any pset is written;
+    user scripts can redefine.
+
+
+    <h3>Parameters:</h3>
+    <ul>
+        <li><span class="parameter">filename</span>
+            <span class="types"><a class="type" href="../modules/paramset.html#ParamSet:string">string</a></span>
+        an absolute path to pset file, corresponds the local data folder by default if created via norns ui
+        </li>
+        <li><span class="parameter">name</span>
+            <span class="types"><a class="type" href="../modules/paramset.html#ParamSet:string">string</a></span>
+        the name of the pset, as entered in the norns pset menu, corresponding to the first line of [scriptname]-[number].pset in local data folder
+        </li>
+        <li><span class="parameter">pset_number</span>
+            <span class="types"><span class="type">number</span></span>
+        the number of the pset, as shown in the norns pset menu, corresponding to the [scriptname]-[number].pset in local data folder
+        </li>
+    </ul>
+
+
+
+
+
+</dd>
+    <dt>
+    <a name = "ParamSet.action_read"></a>
+    <strong>ParamSet.action_read (filename, name, pset_number)</strong>
+    </dt>
+    <dd>
+    static callback when any pset is read;
+    user scripts can redefine.
+
+
+    <h3>Parameters:</h3>
+    <ul>
+        <li><span class="parameter">filename</span>
+            <span class="types"><a class="type" href="../modules/paramset.html#ParamSet:string">string</a></span>
+        an absolute path to pset file, corresponds the local data folder by default if created via norns ui
+        </li>
+        <li><span class="parameter">name</span>
+            <span class="types"><a class="type" href="../modules/paramset.html#ParamSet:string">string</a></span>
+        the name of the pset, as entered in the norns pset menu, corresponding to the first line of [scriptname]-[number].pset in local data folder
+        </li>
+        <li><span class="parameter">pset_number</span>
+            <span class="types"><span class="type">number</span></span>
+        the number of the pset, as shown in the norns pset menu, corresponding to the [scriptname]-[number].pset in local data folder
+        </li>
+    </ul>
+
+
+
+
+
+</dd>
+    <dt>
+    <a name = "ParamSet.action_delete"></a>
+    <strong>ParamSet.action_delete (filename, name, pset_number)</strong>
+    </dt>
+    <dd>
+    static callback when any pset is deleted;
+    user scripts can redefine.
+
+
+    <h3>Parameters:</h3>
+    <ul>
+        <li><span class="parameter">filename</span>
+            <span class="types"><a class="type" href="../modules/paramset.html#ParamSet:string">string</a></span>
+        an absolute path to pset file, corresponds the local data folder by default if created via norns ui
+        </li>
+        <li><span class="parameter">name</span>
+            <span class="types"><a class="type" href="../modules/paramset.html#ParamSet:string">string</a></span>
+        the name of the pset, as entered in the norns pset menu, corresponding to the first line of [scriptname]-[number].pset in local data folder
+        </li>
+        <li><span class="parameter">pset_number</span>
+            <span class="types"><span class="type">number</span></span>
+        the number of the pset, as shown in the norns pset menu, corresponding to the [scriptname]-[number].pset in local data folder
         </li>
     </ul>
 

--- a/lua/core/menu/params.lua
+++ b/lua/core/menu/params.lua
@@ -280,7 +280,7 @@ m.key = function(n,z)
     if n==2 and z==1 then
       m.mode = mPSET
     elseif n==3 and z==1 then
-      os.execute("rm "..pset[m.ps_pos+1].file)
+      params:delete(pset[m.ps_pos+1].file,params.name,string.format("%02d",m.ps_pos+1))
       init_pset()
       m.mode = mPSET
     end

--- a/lua/core/menu/params.lua
+++ b/lua/core/menu/params.lua
@@ -280,7 +280,7 @@ m.key = function(n,z)
     if n==2 and z==1 then
       m.mode = mPSET
     elseif n==3 and z==1 then
-      params:delete(pset[m.ps_pos+1].file,params.name,string.format("%02d",m.ps_pos+1))
+      params:delete(pset[m.ps_pos+1].file,pset[m.ps_pos+1].name,string.format("%02d",m.ps_pos+1))
       init_pset()
       m.mode = mPSET
     end

--- a/lua/core/paramset.lua
+++ b/lua/core/paramset.lua
@@ -449,11 +449,7 @@ function ParamSet:write(filename, name)
     end
     io.close(fd)
     if self.action_write ~= nil then
-      if pset_number ~= nil then
-        self.action_write(filename,name,pset_number)
-      else
-        self.action_write(filename,name)
-      end
+      self.action_write(filename,name,pset_number)
     end
   else print("pset: BAD FILENAME") end
 end
@@ -499,11 +495,7 @@ function ParamSet:read(filename, silent)
       end
     end
     if self.action_read ~= nil then 
-      if pset_number ~= nil then
-        self.action_read(filename,silent,pset_number)
-      else
-        self.action_read(filename,silent)
-      end
+      self.action_read(filename,silent,pset_number)
     end
   else
     print("pset :: "..filename.." not read.")
@@ -522,11 +514,7 @@ function ParamSet:delete(filename, name, pset_number)
   print("pset >> delete: "..filename, name, pset_number)
   norns.system_cmd("rm "..filename)
   if self.action_delete ~= nil then
-    if pset_number ~= nil then
-      self.action_delete(filename, name, pset_number)
-    else
-      self.action_delete(filename, name)
-    end
+    self.action_delete(filename, name, pset_number)
   end
 end
 

--- a/lua/core/paramset.lua
+++ b/lua/core/paramset.lua
@@ -499,10 +499,10 @@ function ParamSet:read(filename, silent)
       end
     end
     if self.action_read ~= nil then 
-      if pset_number == nil then
-        self.action_read(filename,silent)
-      else
+      if pset_number ~= nil then
         self.action_read(filename,silent,pset_number)
+      else
+        self.action_read(filename,silent)
       end
     end
   else
@@ -522,7 +522,11 @@ function ParamSet:delete(filename, name, pset_number)
   print("pset >> delete: "..filename, name, pset_number)
   norns.system_cmd("rm "..filename)
   if self.action_delete ~= nil then
-    self.action_delete(filename, name, pset_number)
+    if pset_number ~= nil then
+      self.action_delete(filename, name, pset_number)
+    else
+      self.action_delete(filename, name)
+    end
   end
 end
 

--- a/lua/core/paramset.lua
+++ b/lua/core/paramset.lua
@@ -92,6 +92,7 @@ function ParamSet.new(id, name)
   ps.group = 0
   ps.action_write = nil
   ps.action_read = nil
+  ps.action_delete = nil
   ParamSet.sets[ps.id] = ps
   return ps
 end
@@ -429,10 +430,12 @@ end
 -- @tparam string name
 function ParamSet:write(filename, name)
   filename = filename or 1
+  local pset_number;
   if type(filename) == "number" then
     local n = filename
     filename = norns.state.data .. norns.state.shortname
-    filename = filename .. "-" .. string.format("%02d",n) .. ".pset"
+    pset_number = string.format("%02d",n)
+    filename = filename .. "-" .. pset_number .. ".pset"
   end
   print("pset >> write: "..filename)
   local fd = io.open(filename, "w+")
@@ -445,8 +448,12 @@ function ParamSet:write(filename, name)
       end
     end
     io.close(fd)
-    if self.action_write ~= nil then 
-      self.action_write(filename,name)
+    if self.action_write ~= nil then
+      if pset_number ~= nil then
+        self.action_write(filename,name,pset_number)
+      else
+        self.action_write(filename,name)
+      end
     end
   else print("pset: BAD FILENAME") end
 end
@@ -456,10 +463,12 @@ end
 -- @tparam boolean silent if true, do not trigger parameter actions
 function ParamSet:read(filename, silent)
   filename = filename or norns.state.pset_last
+  local pset_number;
   if type(filename) == "number" then
     local n = filename
     filename = norns.state.data .. norns.state.shortname
-    filename = filename .. "-" .. string.format("%02d",n) .. ".pset"
+    pset_number = string.format("%02d",n)
+    filename = filename .. "-" .. pset_number .. ".pset"
   end
   print("pset >> read: " .. filename)
   local fd = io.open(filename, "r")
@@ -490,10 +499,30 @@ function ParamSet:read(filename, silent)
       end
     end
     if self.action_read ~= nil then 
-      self.action_read(filename,silent)
+      if pset_number ~= nil then
+        self.action_read(filename,silent)
+      else
+        self.action_read(filename,silent,pset_number)
+      end
     end
   else
     print("pset :: "..filename.." not read.")
+  end
+end
+
+--- delete from disk.
+-- @param filename either an absolute path, a number (for [scriptname]-[number].pset in local data folder) or nil (for default [scriptname].pset in local data folder)
+-- @tparam string name
+function ParamSet:delete(filename, name, pset_number)
+  if type(filename) == "number" then
+    local n = filename
+    filename = norns.state.data .. norns.state.shortname
+    filename = filename .. "-" .. string.format("%02d",n) .. ".pset"
+  end
+  print("pset >> delete: "..filename, name, pset_number)
+  norns.system_cmd("rm "..filename)
+  if self.action_delete ~= nil then
+    self.action_delete(filename, name, pset_number)
   end
 end
 
@@ -519,6 +548,7 @@ function ParamSet:clear()
   self.count = 0
   self.action_read = nil 
   self.action_write = nil
+  self.action_delete = nil
   self.lookup = {}
 end
 

--- a/lua/core/paramset.lua
+++ b/lua/core/paramset.lua
@@ -499,7 +499,7 @@ function ParamSet:read(filename, silent)
       end
     end
     if self.action_read ~= nil then 
-      if pset_number ~= nil then
+      if pset_number == nil then
         self.action_read(filename,silent)
       else
         self.action_read(filename,silent,pset_number)

--- a/lua/core/paramset.lua
+++ b/lua/core/paramset.lua
@@ -499,7 +499,7 @@ function ParamSet:read(filename, silent)
       end
     end
     if self.action_read ~= nil then 
-      if pset_number == nil then
+      if pset_number ~= nil then
         self.action_read(filename,silent)
       else
         self.action_read(filename,silent,pset_number)


### PR DESCRIPTION
while writing up examples for saving table data with PSETs (building off of @schollz 's incredible work on this front), i realized that PSET index number is a helpful reporting callback -- since PSETs made via the PSET UI can share names, the index number is often the only differentiator. rather than force authors to extract this from the loaded filename, it made sense to add the PSET's index number (if available) to the actions.

i also realized that a PSET deletion action would be helpful for external data management, so i added that as well.

here's a quick example of usage:
```lua
MusicUtil = require 'musicutil' -- see https://monome.org/docs/norns/reference/lib/musicutil
s = require 'sequins' -- see https://monome.org/docs/norns/reference/lib/sequins

function init()
  base_note = math.random(30,50)
  my_seq = s{}
  notes_array = MusicUtil.generate_scale_of_length(base_note, "dorian", 16)
  note_data = {}
  for j = 1,64 do
    -- auto-generate 64 steps of notes:
    note_data[j] = MusicUtil.snap_note_to_array(math.random(base_note, base_note+28),notes_array)
  end
  my_seq:settable(note_data) -- send this table of notes to the sequins
  play = false
  
  -- here, we set our PSET callbacks:
  params.action_write = function(filename,name,number)
    print("finished writing '"..filename.."' as '"..name.."'", number)
    os.execute("mkdir -p "..norns.state.data.."/"..number.."/")
    tab.save(note_data,norns.state.data.."/"..number.."/note.data")
  end
  params.action_read = function(filename,silent,number)
    print("finished reading '"..filename.."'", number)
    note_data = tab.load(norns.state.data.."/"..number.."/note.data")
    my_seq:settable(note_data) -- send this restored table to the sequins
  end
  params.action_delete = function(filename,name,number)
    print("finished deleting '"..filename, number)
    norns.system_cmd("rm -r "..norns.state.data.."/"..number.."/")
  end
end
```

in the example:
- when a user saves a PSET, its index is passed to create a numeric directory in the script's data folder -- the note table is saved there as `note.data`
- when a user reads a PSET, its index is passed to load the note data into a sequins
- when a user deletes a PSET, its index is passed to delete the directory which holds the additional tables, etc

this is testing well on my side, but please lmk if there's anything i'm missing!