### PR TITLE
matron: embed lua-cjson module as `json` global

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,3 +13,6 @@
 [submodule "crone/lib/concurrentqueue"]
 	path = crone/lib/concurrentqueue
 	url = git@github.com:cameron314/concurrentqueue.git
+[submodule "third-party/lua-cjson"]
+	path = third-party/lua-cjson
+	url = https://github.com/mpx/lua-cjson.git

--- a/lua/core/script.lua
+++ b/lua/core/script.lua
@@ -27,6 +27,9 @@ Script.clear = function()
     package.loaded['asl'] = nil
   end
 
+  -- reset embedded modules
+  json = _json
+
   -- script local state
   local state = { }
 

--- a/lua/core/startup.lua
+++ b/lua/core/startup.lua
@@ -29,6 +29,9 @@ paramset = require 'core/paramset'
 params = paramset.new()
 norns.pmap = require 'core/pmap'
 
+-- embedded global modules
+json = _json
+
 -- load menu
 require 'core/menu'
 

--- a/matron/src/weaver.cc
+++ b/matron/src/weaver.cc
@@ -48,6 +48,12 @@
 #include "system_cmd.h"
 #include "weaver.h"
 
+extern "C" {
+#if HAVE_LUA_CJSON
+int luaopen_cjson(lua_State *l);
+#endif
+};
+
 // registered lua functions require the LVM state as a parameter.
 // but often we don't need it.
 // use pragma instead of casting to void as a workaround.
@@ -344,6 +350,14 @@ static void lua_register_norns_class(const char *class_name, const luaL_Reg *met
 }
 #endif
 
+static void lua_register_cjson() {
+#if HAVE_LUA_CJSON
+    luaopen_cjson(lvm);
+    lua_pushvalue(lvm, -1);
+    lua_setglobal(lvm, "_json");
+#endif
+}
+
 ////////////////////////////////
 //// extern function definitions
 
@@ -352,6 +366,9 @@ void w_init(void) {
     lvm = luaL_newstate();
     luaL_openlibs(lvm);
     lua_pcall(lvm, 0, 0, 0);
+
+   // initialize embedded third-party modules
+   lua_register_cjson();
 
     ////////////////////////
     // FIXME: document these in lua in some deliberate fashion

--- a/norns/wscript
+++ b/norns/wscript
@@ -97,6 +97,9 @@ def build(bld):
         matron_libs += ['stdc++']
         matron_use += ['LIBLINK_C']
 
+    if bld.env.ENABLE_LUA_CJSON:
+        matron_use.append('LUA_CJSON')
+
     if bld.env.PROFILE_MATRON:
         bld.env.append_unique('CXXFLAGS', ['-pg'])
         bld.env.append_unique('LDFLAGS', ['-pg'])

--- a/third-party/wscript
+++ b/third-party/wscript
@@ -21,6 +21,34 @@ def build_link(bld):
         ],
         name='LIBLINK_C')
 
+def build_cjson(bld):
+    bld.stlib(features='c cxx cxxstlib',
+        source=[
+            'lua-cjson/lua_cjson.c',
+            'lua-cjson/strbuf.c',
+            'lua-cjson/fpconv.c'
+        ],
+        target='lua-cjson',
+        includes=[
+            'lua-cjson',
+        ],
+        cflags=[
+            '-O3',
+            '-Wall',
+            '-Wimplicit-fallthrough=0', # NOTE: GCC7+ warns by default which results in Werror build failures
+            '-pedantic',
+        ],
+        defines=[
+            'NDEBUG'
+        ],
+        use=[
+            'LUA53'
+        ],
+        name='LUA_CJSON'
+    )
+
 def build(bld):
     if bld.env.ENABLE_ABLETON_LINK:
         build_link(bld)
+    if bld.env.ENABLE_LUA_CJSON:
+        build_cjson(bld)

--- a/wscript
+++ b/wscript
@@ -15,6 +15,7 @@ def options(opt):
     opt.add_option('--desktop', action='store_true', default=False)
     opt.add_option('--release', action='store_true', default=False)
     opt.add_option('--enable-ableton-link', action='store_true', default=True)
+    opt.add_option('--enable-lua-cjson', action='store_true', default=True)
     opt.add_option('--profile-matron', action='store_true', default=False)
 
     opt.recurse('maiden-repl')
@@ -65,6 +66,9 @@ def configure(conf):
 
     conf.env.ENABLE_ABLETON_LINK = conf.options.enable_ableton_link
     conf.define('HAVE_ABLETON_LINK', conf.options.enable_ableton_link)
+
+    conf.env.ENABLE_LUA_CJSON = conf.options.enable_lua_cjson
+    conf.define('HAVE_LUA_CJSON', conf.options.enable_lua_cjson)
 
     conf.recurse('maiden-repl')
 


### PR DESCRIPTION
this replaces #1543, rebased on the `norns-converged` branch and updated for the switch to using a c++ compiler.