### PR TITLE
norns: only fork sidecar

### DIFF
--- a/norns/main.cpp
+++ b/norns/main.cpp
@@ -1,35 +1,47 @@
-#include <thread>
 #include <unistd.h>
+#include <stdio.h>
+#include <string.h>
+#include <signal.h>
+#include <sys/prctl.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <fcntl.h>
 
 #include "crone_main.h"
 #include "matron_main.h"
 
 #include "sidecar.h"
 
-#include "OscInterface.h"
-
 int main(int argc, char **argv) {
-  if (fork() == 0) {
-    // parent process
-    if (fork() != 0) {
-      // second fork
-      sidecar_client_init();
-      
-      crone_main();
-      matron_main(argc, argv);
+  int exec_name_size = strlen(argv[0]);
 
-      matron_cleanup();
-      crone_cleanup();
-    } else {
-      // parent
-      // nothing to do..
-      while (1) {
-        std::this_thread::sleep_for(std::chrono::seconds(1));
-      }
+  if (fork() == 0) {
+    strncpy(argv[0], "sidecar [norns]", exec_name_size);
+
+    // child, set the thread name to sidecar for added clarity in gdb
+    if (prctl(PR_SET_NAME, (unsigned long)"sidecar") < 0) {
+      perror("prctl(PR_SET_NAME)");
     }
-  } else {
-    // first fork
+
+    // arrange to receive SIGHUP when the thread which forked the child exits
+    if (prctl(PR_SET_PDEATHSIG, SIGHUP) < 0) {
+      perror("prctl(PR_SET_PDEATHSIG)");
+    }
+
+    // detach this processes stdin from parent
+    int fd = open("/dev/null", O_RDONLY);
+    dup2(fd, 0);
+
     sidecar_server_main();
+  } else {
+    // parent
+    sidecar_client_init();
+
+    crone_main();
+    matron_main(argc, argv);
+
+    matron_cleanup();
+    crone_cleanup();
   }
   return 0;
 }


### PR DESCRIPTION
performs a single fork for the sidecar process along with:
- set the child process name for visibiliy in ps
- set the thread name in child process for visibility in gdb
- send child a SIGHUP if parent dies
- disconnect child from parent stdin

the primary motivation for this change is simplicity and
to allow easier debugging. the parent process remains the
one running crone/matron.


with this modification the output of `ps` looks something like:
```
...
we         618     1  0 22:23 ?        00:00:00 /home/we/norns/build/ws-wrapper/ws-wrapper ws://*:5555 /home/we/norns/build/norns/norns
we         619   618 15 22:23 ?        00:00:07 /home/we/norns/build/norns/norns
we         623   619  0 22:23 ?        00:00:00 sidecar [norns]
...
```