### PR TITLE
replace nanomsg with nng

### DIFF
--- a/maiden-repl/src/pages.c
+++ b/maiden-repl/src/pages.c
@@ -49,11 +49,11 @@ void pages_deinit(void) {
   }
 }
 
-void page_append_selected(char *str) {
+void page_append_selected(const char *str) {
   page_print(page_cur, str);
 }
 
-void page_append(int i, char *str) {
+void page_append(int i, const char *str) {
   page_print(pages[i], str);
 }
 

--- a/maiden-repl/src/pages.h
+++ b/maiden-repl/src/pages.h
@@ -12,8 +12,8 @@ extern void pages_init(int nrows, int ncols);
 extern void pages_deinit(void);
 
 extern void page_select(int i);
-extern void page_append_selected(char *str);
-extern void page_append(int i, char *str);
+extern void page_append_selected(const char *str);
+extern void page_append(int i, const char *str);
 
 extern void pages_show_key(int k);
 // switch between pages

--- a/maiden-repl/src/ui.c
+++ b/maiden-repl/src/ui.c
@@ -137,22 +137,22 @@ void ui_deinit(void) {
   pthread_mutex_unlock(&exit_lock);
 }
 
-static void page_line(int i, char *str) {
+static void page_line(int i, const char *str) {
   pthread_mutex_lock(&exit_lock);
   if(!should_exit)  {
     page_append(i, str);
-    if( page_id() == i) { 
+    if( page_id() == i) {
       doupdate();
     }
   }
   pthread_mutex_unlock(&exit_lock);
 }
 
-void ui_crone_line(char *str) {
+void ui_crone_line(const char *str) {
   page_line(PAGE_CRONE, str);
 }
 
-void ui_matron_line(char *str) {
+void ui_matron_line(const char *str) {
   // FIXME: sloppy way to handle this
   if(strcmp(str, " <ok>\n") == 0) {
     mvwprintw(sep_win, 0, 0, "<ok>");
@@ -189,7 +189,10 @@ void forward_to_readline(char c)
 
 void handle_cmd(char *line)
 {
-  if(strlen(line) == 1) {
+  if (line == NULL) {
+    return;
+  }
+  if (strlen(line) == 1) {
     if (line[0] == 'q') {
       should_exit = true;
     }
@@ -198,7 +201,7 @@ void handle_cmd(char *line)
     if (*line != '\0') {
       add_history(line);
     }
-    switch( page_id() ) {
+    switch (page_id()) {
     case PAGE_MATRON:
       io_send_line(IO_MATRON, line);
       break;

--- a/maiden-repl/src/ui.h
+++ b/maiden-repl/src/ui.h
@@ -9,5 +9,5 @@ extern void ui_loop(void);
 
 // receive and display lines from child processes
 // lines should be null-terminated strings
-extern void ui_crone_line(char *str);
-extern void ui_matron_line(char *str);
+extern void ui_crone_line(const char *str);
+extern void ui_matron_line(const char *str);

--- a/maiden-repl/wscript
+++ b/maiden-repl/wscript
@@ -1,6 +1,5 @@
 top = '../..'
 
-
 def options(opt):
     opt.load('compiler_c compiler_cxx')
 
@@ -10,7 +9,14 @@ def configure(conf):
     # libraries with full pkg-config data
     conf.check_cfg(package='ncursesw', args=['--cflags', '--libs'])
     conf.check_cfg(package='panel', args=['--cflags', '--libs'])
-    conf.check_cfg(package='nanomsg', args=['--cflags', '--libs'])
+    conf.check_cfg(package='readline', args=['--cflags', '--libs'])
+
+    conf.check_cc(msg='Checking for nng',
+        define_name='HAVE_NNG',
+        mandatory=True,
+        lib='nng',
+        header_name='nng/nng.h',
+        uselib_store='NNG')
 
 def build(bld):
     maiden_repl_sources = [
@@ -28,18 +34,14 @@ def build(bld):
                 includes=[
                     'src',
                 ],
-
                 use=[
                     'NCURSESW',
+                    'NNG',
                     'PANEL',
-                    'NANOMSG'
+                    'READLINE'
                 ],
                 lib=[
                     'pthread',
-                    'readline',
-                    'ncursesw',
-                    'panel',
-                    'nanomsg'
                 ],
                 cxxflags=[
                     '-O2',

--- a/norns/wscript
+++ b/norns/wscript
@@ -82,6 +82,7 @@ def build(bld):
         'LUA53',
         'LIBLO',
         'LIBMONOME',
+        'NNG',
         'SNDFILE',
         'AVAHI-COMPAT-LIBDNS_SD',
         'JACK',
@@ -127,7 +128,6 @@ def build(bld):
     ]
 
     norns_libs = [
-        'nanomsg'
     ]
 
     norns_sources = norns_sources + matron_sources + crone_sources

--- a/ws-wrapper/wscript
+++ b/ws-wrapper/wscript
@@ -4,5 +4,5 @@ def build(bld):
     bld.program(features='c cprogram',
         source='src/main.c',
         target='ws-wrapper',
-        use=['NANOMSG'],
+        use=['NNG'],
         lib=['pthread'])

--- a/wscript
+++ b/wscript
@@ -56,6 +56,13 @@ def configure(conf):
         header_name='monome.h',
         uselib_store='LIBMONOME')
 
+    conf.check_cc(msg='Checking for nng',
+        define_name='HAVE_NNG',
+        mandatory=True,
+        lib='nng',
+        header_name='nng/nng.h',
+        uselib_store='NNG')
+
     if conf.options.desktop:
         conf.check_cfg(package='sdl2', args=['--cflags', '--libs'])
         conf.define('NORNS_DESKTOP', True)


### PR DESCRIPTION
the `nanomsg` library is in maintenance mode and has been superseded by  `nng`. additionally `nng` supports secure websockets which will be required in order to (eventually) add authentication to maiden.

_in order to build with this change the `libnng-dev` package must be installed._ 

while `nng` does offer compatibility headers for `nanomsg` the sidecar, maiden-repl, and ws-wrapper code has been updated to use current `nng` api in order to maintain consistency once authentication is implemented.

some minor touchups to maiden-repl are included as well (build cleanup and one crash fix)