### PR TITLE
provide the ability to manipulate audio routing

### DIFF
--- a/lua/core/hook.lua
+++ b/lua/core/hook.lua
@@ -33,6 +33,7 @@ end
 local hooks = {
   script_pre_init = Hook.new(),
   script_post_cleanup = Hook.new(),
+  audio_post_restore_default_routing = Hook.new(),
   system_post_startup = Hook.new(),
   system_pre_shutdown = Hook.new(),
 }

--- a/lua/core/script.lua
+++ b/lua/core/script.lua
@@ -77,6 +77,12 @@ Script.clear = function()
   -- clear softcut
   softcut.reset()
 
+  -- restore default audio routing
+  if audio.routing_is_altered() then
+    print("# restoring default audio routing")
+    audio.routing_default()
+  end
+
   -- clear init
   init = norns.none
 

--- a/lua/core/startup.lua
+++ b/lua/core/startup.lua
@@ -91,12 +91,10 @@ end
 -- initial screen state
 _norns.screen_save()
 
--- reverse stereo for norns shield
-audio.system_connect()
 -- ensure supercollider connections on restart
-audio.supercollider_connect()
--- clear dirty routing flag potentially set by the above operation
-audio._default_routing_altered = false
+audio.with_change_tracking_disabled(function()
+  audio.supercollider_connect()
+end)
 
 print("start_audio(): ")
 -- start the process of syncing with crone boot

--- a/lua/core/startup.lua
+++ b/lua/core/startup.lua
@@ -92,17 +92,11 @@ end
 _norns.screen_save()
 
 -- reverse stereo for norns shield
-if util.file_exists(_path.home .. "/reverse.txt") then
-  print("NORNS SHIELD: REVERSING STEREO")
-  _norns.execute("jack_disconnect 'crone:output_1' 'system:playback_1'")
-  _norns.execute("jack_disconnect 'crone:output_2' 'system:playback_2'")
-  _norns.execute("jack_connect 'crone:output_1' 'system:playback_2'")
-  _norns.execute("jack_connect 'crone:output_2' 'system:playback_1'")
-  _norns.execute("jack_disconnect 'system:capture_1' 'crone:input_1'")
-  _norns.execute("jack_disconnect 'system:capture_2' 'crone:input_2'")
-  _norns.execute("jack_connect 'system:capture_1' 'crone:input_2'")
-  _norns.execute("jack_connect 'system:capture_2' 'crone:input_1'")
-end
+audio.system_connect()
+-- ensure supercollider connections on restart
+audio.supercollider_connect()
+-- clear dirty routing flag potentially set by the above operation
+audio._default_routing_altered = false
 
 print("start_audio(): ")
 -- start the process of syncing with crone boot

--- a/matron/src/jack_client.cpp
+++ b/matron/src/jack_client.cpp
@@ -52,3 +52,31 @@ uint32_t jack_client_get_xrun_count() {
 double jack_client_get_current_time() {
   return (double)jack_frame_time(jack_client) / jack_sample_rate;
 }
+
+const char** jack_client_get_input_ports() {
+  return jack_get_ports(jack_client, NULL, NULL, JackPortIsInput);
+}
+
+const char** jack_client_get_output_ports() {
+  return jack_get_ports(jack_client, NULL, NULL, JackPortIsOutput);
+}
+
+const char** jack_client_get_port_connections(const char *port_name) {
+  const jack_port_t *port = jack_port_by_name(jack_client, port_name);
+  if (port != NULL) {
+    return jack_port_get_all_connections(jack_client, port);
+  }
+  return NULL;
+}
+
+bool jack_client_connect(const char *source_name, const char *destination_name) {
+  return jack_connect(jack_client, source_name, destination_name) == 0;
+}
+
+bool jack_client_disconnect(const char *source_name, const char *destination_name) {
+  return jack_disconnect(jack_client, source_name, destination_name) == 0;
+}
+
+void jack_client_free_port_list(const char **list) {
+  jack_free(list);
+}

--- a/matron/src/jack_client.h
+++ b/matron/src/jack_client.h
@@ -10,7 +10,7 @@ extern int jack_client_init();
 
 extern void jack_client_deinit();
 
-// return the running estimate of audio CPU load reported by jack 
+// return the running estimate of audio CPU load reported by jack
 // returns ratio in [0,1]
 extern float jack_client_get_cpu_load();
 
@@ -19,3 +19,10 @@ extern uint32_t jack_client_get_xrun_count();
 
 // get JACks current system time estimate in seconds (computed from sample frames)
 extern double jack_client_get_current_time();
+
+extern const char** jack_client_get_input_ports();
+extern const char** jack_client_get_output_ports();
+extern const char** jack_client_get_port_connections(const char *port_name);
+extern void jack_client_free_port_list(const char **list);
+extern bool jack_client_connect(const char *source_name, const char *destination_name);
+extern bool jack_client_disconnect(const char *source_name, const char *destination_name);

--- a/matron/src/weaver.cc
+++ b/matron/src/weaver.cc
@@ -301,6 +301,12 @@ static int _clock_get_tempo(lua_State *l);
 static int _audio_get_cpu_load(lua_State *l);
 static int _audio_get_xrun_count(lua_State *l);
 
+static int _audio_get_input_ports(lua_State *l);
+static int _audio_get_output_ports(lua_State *l);
+static int _audio_get_port_connections(lua_State *l);
+static int _audio_connect(lua_State *l);
+static int _audio_disconnect(lua_State *l);
+
 // platform detection (CM3 vs PI3 vs OTHER)
 static int _platform(lua_State *l);
 
@@ -592,6 +598,12 @@ void w_init(void) {
 
     lua_register_norns("audio_get_cpu_load", &_audio_get_cpu_load);
     lua_register_norns("audio_get_xrun_count", &_audio_get_xrun_count);
+
+    lua_register_norns("audio_get_input_ports", &_audio_get_input_ports);
+    lua_register_norns("audio_get_output_ports", &_audio_get_output_ports);
+    lua_register_norns("audio_get_port_connections", &_audio_get_port_connections);
+    lua_register_norns("audio_connect", &_audio_connect);
+    lua_register_norns("audio_disconnect", &_audio_disconnect);
 
     // platform
     lua_register_norns("platform", &_platform);
@@ -1983,6 +1995,57 @@ int _audio_get_xrun_count(lua_State *l) {
     lua_pushnumber(l, jack_client_get_xrun_count());
     return 1;
 }
+
+
+static int _push_port_list(lua_State *l, const char **names) {
+    const char **element = names;
+    int index = 1;
+
+    lua_newtable(l);
+
+    if (element != NULL) {
+        while (*element != NULL) {
+            lua_pushstring(l, *element);
+            lua_rawseti(l, -2, index);
+            ++index;
+            ++element;
+        }
+    }
+
+    jack_client_free_port_list(names);
+    return 1;
+}
+
+int _audio_get_input_ports(lua_State *l) {
+    return _push_port_list(l, jack_client_get_input_ports());
+}
+
+int _audio_get_output_ports(lua_State *l) {
+    return _push_port_list(l, jack_client_get_output_ports());
+}
+
+int _audio_get_port_connections(lua_State *l) {
+    lua_check_num_args(1);
+    const char *port = lua_tostring(l, 1);
+    return _push_port_list(l, jack_client_get_port_connections(port));
+}
+
+int _audio_connect(lua_State *l) {
+    lua_check_num_args(2);
+    const char *source = lua_tostring(l, 1);
+    const char *destination = lua_tostring(l, 2);
+    lua_pushboolean(l, jack_client_connect(source, destination));
+    return 1;
+}
+
+int _audio_disconnect(lua_State *l) {
+    lua_check_num_args(2);
+    const char *source = lua_tostring(l, 1);
+    const char *destination = lua_tostring(l, 2);
+    lua_pushboolean(l, jack_client_disconnect(source, destination));
+    return 1;
+}
+
 
 //--------------------------------------------------
 //--- define lua handlers for system callbacks


### PR DESCRIPTION
- adds low level wrappers for various `jack` functions to introspect and manipulate ports
- adds high level api to alter audio routing by port, by tables of ports, or by component
- adds a hook for tweaking audio routing in mods
- ensures supercollider is connected on restart
- removes all system calls out to `jack_*` commands