### PR TITLE
fix registration for screen_display_image_region

### DIFF
--- a/matron/src/weaver.cc
+++ b/matron/src/weaver.cc
@@ -520,7 +520,7 @@ void w_init(void) {
         {"screen_load_png", _screen_load_png},
         {"screen_create_image", _screen_create_image},
         {"screen_display_image", _screen_display_image},
-        {"screen_display_iamge", _screen_display_image_region},
+        {"screen_display_image_region", _screen_display_image_region},
         {NULL, NULL}
     };
     // clang-format on


### PR DESCRIPTION
corrects a bad typo which must have been introduced when cleaning up the PR originally