### PR TITLE
Allow chaining of actions

### DIFF
--- a/lua/core/paramset.lua
+++ b/lua/core/paramset.lua
@@ -352,15 +352,27 @@ function ParamSet:set_action(index, func)
   param.action = func
 end
 
---- set additional action
+--- run an action after the existing action
 -- @param index
--- @tparam function new_action set an additional action for this index
+-- @tparam function new_action the new action to run
 -- Chain a new action onto a paramset (even if one isn't already set)
-function ParamSet:chain_action(index, new_action)
+function ParamSet:append_action(index, new_action)
   local current_action = self:lookup_param(index).action or function() end
   self:set_action(index, function()
     current_action()
     new_action()
+  end)
+end
+
+--- run an action before the existing action
+-- @param index
+-- @tparam function new_action the new action to run
+-- Chain a new action onto a paramset (even if one isn't already set)
+function ParamSet:prepend_action(index, new_action)
+  local current_action = self:lookup_param(index).action or function() end
+  self:set_action(index, function()
+    new_action()
+    current_action()
   end)
 end
 

--- a/lua/core/paramset.lua
+++ b/lua/core/paramset.lua
@@ -352,6 +352,18 @@ function ParamSet:set_action(index, func)
   param.action = func
 end
 
+--- set additional action
+-- @param index
+-- @tparam function new_action set an additional action for this index
+-- Chain a new action onto a paramset (even if one isn't already set)
+function ParamSet:chain_action(index, new_action)
+  local current_action = self:lookup_param(index).action or function() end
+  self:set_action(index, function()
+    current_action()
+    new_action()
+  end)
+end
+
 --- set save state.
 -- @param index
 -- @param state set the save state for this index

--- a/lua/core/paramset.lua
+++ b/lua/core/paramset.lua
@@ -358,9 +358,9 @@ end
 -- Chain a new action onto a paramset (even if one isn't already set)
 function ParamSet:append_action(index, new_action)
   local current_action = self:lookup_param(index).action or function() end
-  self:set_action(index, function()
-    current_action()
-    new_action()
+  self:set_action(index, function(...)
+    current_action(...)
+    new_action(...)
   end)
 end
 
@@ -370,9 +370,9 @@ end
 -- Chain a new action onto a paramset (even if one isn't already set)
 function ParamSet:prepend_action(index, new_action)
   local current_action = self:lookup_param(index).action or function() end
-  self:set_action(index, function()
-    new_action()
-    current_action()
+  self:set_action(index, function(...)
+    new_action(...)
+    current_action(...)
   end)
 end
 


### PR DESCRIPTION
This saves the existing action and when invoked calls the old one and the new one.

This came up as a discussion on the norns study group discord. It is not extensively tested. At all. But here for consideration!