### PR TITLE
sidecar: serialize command invocation requests

### DIFF
--- a/lua/core/norns.lua
+++ b/lua/core/norns.lua
@@ -200,33 +200,13 @@ norns.is_norns = norns.platform == 2
 --- true if we are running on norns shield (PI3)
 norns.is_shield = norns.platform == 3
 
--- Util (system_cmd)
-local system_cmd_q = {}
-local system_cmd_busy = false
-
---- add cmd to queue
+--- run an external command
 -- @tparam string cmd shell command to execute
 -- @tparam ?func callback the callback will be called with the output of the
 -- command after it completes. if the callback is nil, then print the output
 -- instead.
 norns.system_cmd = function(cmd, callback)
-  table.insert(system_cmd_q, {cmd=cmd, callback=callback})
-  if system_cmd_busy == false then
-    system_cmd_busy = true
-    _norns.system_cmd(cmd)
-  end
-end
-
--- callback management from c
-_norns.system_cmd_capture = function(cap)
-  if system_cmd_q[1].callback == nil then print(cap)
-  else system_cmd_q[1].callback(cap) end
-  table.remove(system_cmd_q,1)
-  if #system_cmd_q > 0 then
-    _norns.system_cmd(system_cmd_q[1].cmd)
-  else
-    system_cmd_busy = false
-  end
+  return _norns.system_cmd(cmd, callback or print)
 end
 
 --- find pathnames matching a pattern

--- a/matron/src/clocks/clock_internal.cc
+++ b/matron/src/clocks/clock_internal.cc
@@ -83,6 +83,7 @@ static void clock_internal_start() {
 
     pthread_attr_init(&attr);
     pthread_create(&clock_internal_thread, &attr, &clock_internal_thread_run, NULL);
+    pthread_setname_np(clock_internal_thread, "clock_internal");
     pthread_attr_destroy(&attr);
 }
 

--- a/matron/src/clocks/clock_link.cc
+++ b/matron/src/clocks/clock_link.cc
@@ -105,6 +105,7 @@ void clock_link_start() {
     clock_link_shared_data.enabled = false;
 
     pthread_create(&clock_link_thread, &attr, &clock_link_run, NULL);
+    pthread_setname_np(clock_link_thread, "clock_link");
 }
 
 void clock_link_join_session() {

--- a/matron/src/clocks/clock_scheduler.cc
+++ b/matron/src/clocks/clock_scheduler.cc
@@ -129,6 +129,7 @@ void clock_scheduler_start() {
 
     pthread_attr_init(&attr);
     pthread_create(&clock_scheduler_tick_thread, &attr, &clock_scheduler_tick_thread_run, NULL);
+    pthread_setname_np(clock_scheduler_tick_thread, "clock_sched_tick");
     pthread_attr_destroy(&attr);
 }
 

--- a/matron/src/device/device.cc
+++ b/matron/src/device/device.cc
@@ -114,6 +114,8 @@ int dev_start(union dev *d) {
         fprintf(stderr, "m_init(): error creating thread\n");
         return -1;
     }
+    pthread_setname_np(d->base.tid, "device_loop");
+
     return 0;
 }
 

--- a/matron/src/device/device_monitor.cc
+++ b/matron/src/device/device_monitor.cc
@@ -113,6 +113,7 @@ void dev_monitor_init(void) {
     if (s) {
         fprintf(stderr, "error creating thread\n");
     }
+    pthread_setname_np(watch_tid, "watch_loop");
     pthread_attr_destroy(&attr);
 }
 

--- a/matron/src/event_types.h
+++ b/matron/src/event_types.h
@@ -312,6 +312,7 @@ struct event_crow_event {
 struct event_system_cmd {
     struct event_common common;
     char *capture;
+    int cb_ref;
 };
 
 struct event_softcut_render {

--- a/matron/src/events.cc
+++ b/matron/src/events.cc
@@ -288,7 +288,7 @@ static void handle_event(union event_data *ev) {
         w_handle_startup_ready_timeout();
         break;
     case EVENT_SYSTEM_CMD:
-        w_handle_system_cmd(ev->system_cmd.capture);
+        w_handle_system_cmd(ev->system_cmd.capture, ev->system_cmd.cb_ref);
         break;
     case EVENT_RESET_LVM:
         w_reset_lvm();

--- a/matron/src/hardware/battery.cc
+++ b/matron/src/hardware/battery.cc
@@ -37,6 +37,7 @@ void battery_init() {
         if (pthread_create(&p, NULL, battery_check, 0)) {
             fprintf(stderr, "BATTERY: Error creating thread\n");
         }
+        pthread_setname_np(p, "battery_check");
     } else {
         fprintf(stderr, "BATTERY: FAIL.\n");
     }

--- a/matron/src/hardware/input.cc
+++ b/matron/src/hardware/input.cc
@@ -27,6 +27,7 @@ int input_setup(matron_io_t *io) {
         fprintf(stderr, "ERROR (input %s) pthread error\n", io->ops->name);
         return err;
     }
+    pthread_setname_np(input->poll_thread, "input_poll");
 
     return 0;
 }

--- a/matron/src/hardware/stat.cc
+++ b/matron/src/hardware/stat.cc
@@ -33,6 +33,7 @@ void stat_init() {
     if (pthread_create(&p, NULL, stat_check, 0)) {
         fprintf(stderr, "STAT: Error creating thread\n");
     }
+    pthread_setname_np(p, "stat_check");
 }
 
 void stat_deinit() {

--- a/matron/src/input.cc
+++ b/matron/src/input.cc
@@ -71,5 +71,6 @@ void input_init(void) {
     if (s != 0) {
         fprintf(stderr, "input_init(): error in pthread_create(): %d\n", s);
     }
+    pthread_setname_np(pid, "input_run");
     pthread_attr_destroy(&attr);
 }

--- a/matron/src/metro.cc
+++ b/matron/src/metro.cc
@@ -154,6 +154,7 @@ void metro_init(struct metro *t, uint64_t nsec, int count) {
         metro_handle_error(res, "pthread_create");
         return;
     } else {
+        pthread_setname_np(t->tid, "metro_loop");
         t->status = METRO_STATUS_RUNNING;
         if (res != 0) {
             metro_handle_error(res, "pthread_setschedparam");

--- a/matron/src/system_cmd.h
+++ b/matron/src/system_cmd.h
@@ -2,4 +2,4 @@
 
 #include <stdint.h>
 
-extern void system_cmd(char *);
+extern bool system_cmd(const char *cmd, int ref);

--- a/matron/src/weaver.h
+++ b/matron/src/weaver.h
@@ -95,7 +95,7 @@ extern void w_handle_startup_ready_ok();
 extern void w_handle_startup_ready_timeout();
 
 // util callbacks
-extern void w_handle_system_cmd(char* capture);
+extern void w_handle_system_cmd(char* capture, int cb_ref);
 
 // custom events
 extern void w_handle_custom_weave(struct event_custom *ev);

--- a/norns/sidecar.cpp
+++ b/norns/sidecar.cpp
@@ -1,7 +1,10 @@
+#include <assert.h>
+#include <search.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+#include <pthread.h>
 
 #include <nng/nng.h>
 #include <nng/protocol/reqrep0/rep.h>
@@ -20,28 +23,155 @@ static void sidecar_nng_error(const char *func, int rv) {
 }
 
 //---------------------------------
+//--- request queue
+
+typedef enum {
+    REQUEST_FIRST_REQUEST = 0,
+    REQUEST_RUN_CMD,
+} request_type;
+
+struct request_common {
+    request_type type;
+};
+
+struct request_run_cmd {
+    struct request_common common;
+    char *cmd;
+    void *ctx;
+    client_cmd_completion_t completion_handler;
+};
+
+union request {
+    request_type type;
+    struct request_run_cmd run_cmd;
+};
+
+struct req_node {
+    struct req_node *next;
+    struct req_node *prreq;
+    union request *req;
+};
+
+struct req_q {
+    struct req_node *head;
+    struct req_node *tail;
+    ssize_t size;
+    pthread_cond_t nonempty;
+    pthread_mutex_t lock;
+};
+
+static struct req_q requests;
+
+static void requests_push(union request *req) {
+    struct req_node *node = (struct req_node*)calloc(1, sizeof(struct req_node));
+    node->req = req;
+    if (requests.size == 0) {
+        insque(node, NULL);
+        requests.head = node;
+    } else {
+        insque(node, requests.tail);
+    }
+    requests.tail = node;
+    requests.size += 1;
+}
+
+static union request *requests_pop() {
+    struct req_node *node = requests.head;
+    if (node == NULL) {
+        return NULL;
+    }
+    union request *req = node->req;
+    requests.head = node->next;
+    if (node == requests.tail) {
+        assert(requests.size == 1);
+        requests.tail = NULL;
+    }
+    remque(node);
+    free(node);
+    requests.size -= 1;
+    return req;
+}
+
+static void requests_init(void) {
+    requests.size = 0;
+    requests.head = NULL;
+    requests.tail = NULL;
+    pthread_cond_init(&requests.nonempty, NULL);
+}
+
+static union request *request_new(request_type type) {
+    // FIXME: better not to allocate here, use object pool
+    union request *req = (request*)calloc(1, sizeof(union request));
+    req->type = type;
+    return req;
+}
+
+static void request_post(union request *req) {
+    assert(req != NULL);
+    pthread_mutex_lock(&requests.lock);
+    if (requests.size == 0) {
+        // signal handler thread to wake up...
+        pthread_cond_signal(&requests.nonempty);
+    }
+    requests_push(req);
+    // ...handler actually wakes up once we release the lock
+    pthread_mutex_unlock(&requests.lock);
+
+}
+
+
+//---------------------------------
 //--- server
 
-const size_t CMD_CAPTURE_BYTES = 8192 * 8;
+const size_t MAX_CAPTURE_BYTES = 1024 * 1000;  // 10MB maximum
+const size_t READ_BUFFER_BYTES = 8192;
+static char read_buffer[READ_BUFFER_BYTES];
 
-// allocates and returns a string buffer
-static int sidecar_server_run_cmd(char **result, const char *cmd, size_t *sz) {
+static nng_msg *sidecar_server_run_cmd(const char *cmd) {
   FILE *f = popen((char *)cmd, "r");
   if (f == NULL) {
     fprintf(stderr, "popen() failed\n");
-    return -1;
+    return NULL;
   }
-  // FIXME: would be more efficient to allocate incrementally in chunks
-  // instead of getting a huge blob up front and resizing down
-  char *buf = (char *)malloc(CMD_CAPTURE_BYTES);
-  buf[0] = '\0';
-  size_t nb = fread(buf, 1, CMD_CAPTURE_BYTES - 1, f);
-  buf[nb] = '\0';
-  buf = (char *)realloc(buf, nb);
-  *result = buf;
-  *sz = nb;
+
+  int status;
+  nng_msg *msg = NULL;
+  size_t capture_bytes = 0;
+  size_t read_bytes = 0;
+
+  // NOTE: initial allocation is 0 because nng_msg_append* place values at the
+  // end of the msg, allocating more space as needed. allocating space up front
+  // does not behave like a capacity reservation.
+  status = nng_msg_alloc(&msg, 0);
+  if (status != 0) {
+    fprintf(stderr, "nng_msg_alloc() failed\n");
+    return NULL;
+  }
+
+  while ((read_bytes = fread(read_buffer, 1, READ_BUFFER_BYTES, f)) > 0) {
+    status = nng_msg_append(msg, read_buffer, read_bytes);
+    if (status != 0) {
+      pclose(f);
+      nng_msg_free(msg);
+      fprintf(stderr, "nng_msg_append() failed\n");
+      return NULL;
+    }
+
+    capture_bytes += read_bytes;
+
+    if (capture_bytes > MAX_CAPTURE_BYTES) {
+      pclose(f);
+      nng_msg_free(msg);
+      fprintf(stderr, "sidecar: command output too large, %d bytes maxiumum\n", MAX_CAPTURE_BYTES);
+      return NULL;
+    }
+  }
+
+  // append a null byte to the end of the buffer
+  nng_msg_append_u16(msg, 0);
+
   pclose(f);
-  return 0;
+  return msg;
 }
 
 int sidecar_server_main() {
@@ -64,23 +194,24 @@ int sidecar_server_main() {
 
   for (;;) {
     char *cmd = NULL;
-    char *result = NULL;
     size_t cmd_sz = 0;
-    size_t result_sz = 0;
 
     if ((rv = nng_recv(sock, &cmd, &cmd_sz, NNG_FLAG_ALLOC)) != 0) {
       sidecar_nng_error("recv error", rv);
       continue;
     }
 
-    sidecar_server_run_cmd(&result, cmd, &result_sz);
-
-    if ((rv = nng_send(sock, result, result_sz, 0)) != 0) {
-      sidecar_nng_error("send error", rv);
+    nng_msg *response = sidecar_server_run_cmd(cmd);
+    if (response != NULL) {
+      if ((rv = nng_sendmsg(sock, response, 0)) != 0) {
+        nng_msg_free(response);
+        sidecar_nng_error("send error", rv);
+      }
     }
 
-    if (result) { free(result); }
-    if (cmd) { nng_free(cmd, cmd_sz); }
+    if (cmd != NULL) {
+      nng_free(cmd, cmd_sz);
+    }
   }
 
   return 0;
@@ -89,13 +220,88 @@ int sidecar_server_main() {
 //---------------------------------
 //--- client
 
+
 struct client_state {
   nng_socket sock;
   nng_dialer dialer;
   bool initialized;
 };
 
+static pthread_t client_thread;
 static struct client_state cs;
+static pthread_mutex_t run_cmd_lock;
+
+static void handle_run_cmd(const char *cmd, void *ctx, client_cmd_completion_t completion) {
+  static char empty_result[1] = { '\0' };
+
+  int rv;
+  char *result = NULL;
+  size_t result_sz = 0;
+  char *recv_buf = NULL;
+  size_t recv_sz = 0;
+
+  // serialize interaction with the sidecar so sync and async command invocation
+  // is not interlieved
+  pthread_mutex_lock(&run_cmd_lock);
+
+  if ((rv = nng_send(cs.sock, (void *)cmd, strlen(cmd) + 1, 0)) != 0) {
+    sidecar_nng_error("sidecar: send error", rv);
+    goto complete;
+  }
+
+  // TODO: investigate using a pre-allocated receive buffer
+  if ((rv = nng_recv(cs.sock, &recv_buf, &recv_sz, NNG_FLAG_ALLOC)) != 0) {
+    sidecar_nng_error("sidecar: recv error", rv);
+    goto complete;
+  }
+
+  if (recv_sz > 0) {
+    result = recv_buf;
+    result_sz = recv_sz;
+  } else {
+    result = empty_result;
+    result_sz = 1;
+  }
+
+complete:
+  pthread_mutex_unlock(&run_cmd_lock);
+  completion(cmd, ctx, result, result_sz);
+  nng_free(recv_buf, recv_sz);
+}
+
+static void handle_request(union request *req) {
+  switch (req->type) {
+  case REQUEST_RUN_CMD:
+    handle_run_cmd(req->run_cmd.cmd, req->run_cmd.ctx, req->run_cmd.completion_handler);
+    free(req->run_cmd.cmd);
+    break;
+  default:
+    fprintf(stderr, "sidecar: unhandled event type; %d\n", req->type);
+    break;
+  }
+}
+
+static void *sidecar_client_loop(void *) {
+  union request *req = NULL;
+
+  for (;;) {
+    pthread_mutex_lock(&requests.lock);
+    while (requests.size == 0) {
+      pthread_cond_wait(&requests.nonempty, &requests.lock);
+    }
+    req = requests_pop();
+    pthread_mutex_unlock(&requests.lock);
+    if (req != NULL) {
+      handle_request(req);
+    }
+  }
+
+  return NULL;
+}
+
+//
+// external
+//
 
 int sidecar_client_init() {
   int rv;
@@ -124,36 +330,53 @@ int sidecar_client_init() {
     cs.initialized = true;
   }
 
+  requests_init();
+
+  if (pthread_create(&client_thread, NULL, sidecar_client_loop, NULL)) {
+    fprintf(stderr, "sidecar: unable to create client thread\n");
+    return -1;
+  }
+  pthread_setname_np(client_thread, "client_loop");
+  pthread_detach(client_thread);
+
   return 0;
 }
 
-void sidecar_client_cmd(char **result, size_t *size, const char *cmd) {
-  int rv;
-  char *recv_buf = NULL;
-  size_t recv_sz = 0;
+void sidecar_client_cleanup() {
+  // TODO: terminate the request loop and join the thread
+}
 
-  if (!cs.initialized) {
-    fprintf(stderr, "sidecar: client not initialized\n");
-    return;
-  }
+bool sidecar_client_cmd_async(const char *cmd, void *ctx, client_cmd_completion_t cb) {
+  union request *req = request_new(REQUEST_RUN_CMD);
+  req->run_cmd.cmd = strdup(cmd);
+  req->run_cmd.ctx = ctx;
+  req->run_cmd.completion_handler = cb;
+  request_post(req);
+  return true;
+}
 
-  if ((rv = nng_send(cs.sock, (void *)cmd, strlen(cmd) + 1, 0)) != 0) {
-    sidecar_nng_error("sidecar: send error", rv);
-    return;
-  }
+bool sidecar_client_cmd(const char *cmd, void *ctx, client_cmd_completion_t cb) {
+  handle_run_cmd(cmd, ctx, cb);
+  return true;
+}
 
-  if ((rv = nng_recv(cs.sock, &recv_buf, &recv_sz, NNG_FLAG_ALLOC)) != 0) {
-    sidecar_nng_error("sidecar: recv error", rv);
-    return;
-  }
+typedef struct {
+  char **result;
+  size_t *result_size;
+} buffer_fill_ctx;
 
-  if (recv_sz > 0) {
-    *result = (char *)malloc(recv_sz);
-    *size = recv_sz;
-    memcpy(*result, recv_buf, recv_sz);
+static void _buffer_fill_completion(const char *cmd, void *ctx, const char *buf, size_t size) {
+  buffer_fill_ctx *output = (buffer_fill_ctx *)ctx;
+  *(output->result_size) = size;
+  if (size != 0) {
+    *(output->result) = (char *)malloc(size);
+    memcpy(*(output->result), buf, size);
   } else {
-    *size = 1;
-    *result = (char *)malloc(*size);
-    *result[0] = '\0';
+    *(output->result) = NULL;
   }
+}
+
+void sidecar_client_cmd(const char *cmd, char **dst, size_t *dst_size) {
+  buffer_fill_ctx ctx = { dst, dst_size };
+  handle_run_cmd(cmd, &ctx, _buffer_fill_completion);
 }

--- a/norns/sidecar.h
+++ b/norns/sidecar.h
@@ -4,16 +4,30 @@
 
 #include <stdlib.h>
 
+typedef void (*client_cmd_completion_t)(const char *cmd, void *ctx, const char *buff, size_t size);
+
 // main loop of sidecar server process
 // (FIXME: never exits! at all!)
 int sidecar_server_main();
 
 // intialize sidecar client IPC connections
 int sidecar_client_init();
+void sidecar_client_cleanup();
 
-// request a command to be executed by the sidecar server
-// blocks until completion and response
-// result is a null-terminated string stored in `*result`
-void sidecar_client_cmd(char **result, size_t *size, const char *cmd);
+// request a command to be executed asynchronously by the sidecar server
+// returns immediately after enqueing command
+// calls completion function from a background thread with the command output
+bool sidecar_client_cmd_async(const char *cmd, void *ctx, client_cmd_completion_t cb);
+
+// request a command be executed synchronously by the sidecar server
+// calls completion function for the invoking thread
+bool sidecar_client_cmd(const char *cmd, void *ctx, client_cmd_completion_t cb);
+
+// request a command be executed synchronously by the sidecar server and returns
+// the command output in result and size. if the command did not return any
+// output size will be 0 and result will be NULL.
+//
+// the caller is responsible for free()ing result
+void sidecar_client_cmd(const char *cmd, char **result, size_t *size);
 
 #endif


### PR DESCRIPTION
- fix capture buffer termination (issue #1569)
- moves async command capture logic from lua to c
- ensures sidecar requests from `_norns.execute` and `_norns.system_cmd`
  are not interleaved when called from different threads
- adds progressive capture buffer allocation in server up to
  maximum of 10MB

additionally this change adds a sidecar client side "request queue" which is derived from the core event queue. while overkill for this particular fix the intension is to lay part of the infrastructure for moving the `stat.cc` logic out of the main norns process and into the sidecar which will reduce the overhead of gathering stats.