### PR TITLE
params: align 'add_separator' and 'add_group' flow with other paramtypes

### DIFF
--- a/lua/core/params/group.lua
+++ b/lua/core/params/group.lua
@@ -6,10 +6,11 @@ Group.__index = Group
 
 local tGROUP = 7
 
-function Group.new(name, n)
+function Group.new(id, name, n)
   local g = setmetatable({}, Group)
-  g.name = name or "group"
-  g.n = n or 1
+  g.name = type(name) ~= "number" and name or (id or "group")
+  g.id = id or g.name
+  g.n = type(name) == "number" and name or (n or 1)
   g.t = tGROUP
   g.action = function() end
   return g

--- a/lua/core/params/separator.lua
+++ b/lua/core/params/separator.lua
@@ -6,9 +6,10 @@ Separator.__index = Separator
 
 local tSEPARATOR = 0
 
-function Separator.new(name)
+function Separator.new(id,name)
   local s = setmetatable({}, Separator)
-  s.name = name or ""
+  s.name = name or (id or "separator")
+  s.id = id or s.name
   s.t = tSEPARATOR
   s.action = function() end
   return s

--- a/lua/core/paramset.lua
+++ b/lua/core/paramset.lua
@@ -142,7 +142,8 @@ function ParamSet:add(args)
     end
   end
 
-  if self.lookup[param.id] ~= nil and (param.id ~= "group" and param.id ~= "separator") then
+  local overwrite = true
+  if self.lookup[param.id] ~= nil and param.t ~= 0 and param.t ~= 7 then
     print("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
     print("!!!!! ERROR: parameter ID collision: ".. param.id)
     print("! please contact the script maintainer - this will cause a load failure in future updates")
@@ -152,6 +153,12 @@ function ParamSet:add(args)
     else
       print("! BEWARE! clobbering a script or mod param")
     end
+  elseif self.lookup[param.id] ~= nil and param.t == 0 and params:lookup_param(param.id).t ~= 0 then
+    print("! separator ID <"..param.id.."> collides with a non-separator parameter, will not overwrite")
+    overwrite = false
+  elseif self.lookup[param.id] ~= nil and param.t == 7 and params:lookup_param(param.id).t ~= 7 then
+    print("! group ID <"..param.id.."> collides with a non-group parameter, will not overwrite")
+    overwrite = false
   end
 
   param.save = true
@@ -159,8 +166,10 @@ function ParamSet:add(args)
   table.insert(self.params, param)
   self.count = self.count + 1
   self.group = self.group - 1
-  self.lookup[param.id] = self.count
-  self.hidden[self.count] = false
+  if overwrite == true then
+    self.lookup[param.id] = self.count
+    self.hidden[self.count] = false
+  end
   if args.action then
     param.action = args.action
   end

--- a/lua/core/paramset.lua
+++ b/lua/core/paramset.lua
@@ -110,6 +110,8 @@ function ParamSet:add_separator(name)
   self.hidden[self.count] = false
   if name ~= nil and self.lookup[name] == nil then
     self.lookup[name] = self.count
+  elseif name ~= nil and self.lookup[name] ~= nil then
+    print("!!!!! ERROR: separator ID collides with another parameter ID: ".. name)
   end
 end
 
@@ -127,6 +129,8 @@ function ParamSet:add_group(name,n)
     self.hidden[self.count] = false
     if name ~= nil and self.lookup[name] == nil then
       self.lookup[name] = self.count
+    elseif name ~= nil and self.lookup[name] ~= nil then
+      print("!!!!! ERROR: group ID collides with another parameter ID: ".. name)
     end
   else
     print("ERROR: paramset cannot nest GROUPs")

--- a/lua/core/paramset.lua
+++ b/lua/core/paramset.lua
@@ -178,8 +178,8 @@ function ParamSet:add(args)
   self.group = self.group - 1
   if overwrite == true then
     self.lookup[param.id] = self.count
-    self.hidden[self.count] = false
   end
+  self.hidden[self.count] = false
   if args.action then
     param.action = args.action
   end

--- a/lua/core/paramset.lua
+++ b/lua/core/paramset.lua
@@ -153,12 +153,22 @@ function ParamSet:add(args)
     else
       print("! BEWARE! clobbering a script or mod param")
     end
-  elseif self.lookup[param.id] ~= nil and param.t == 0 and params:lookup_param(param.id).t ~= 0 then
-    print("! separator ID <"..param.id.."> collides with a non-separator parameter, will not overwrite")
-    overwrite = false
-  elseif self.lookup[param.id] ~= nil and param.t == 7 and params:lookup_param(param.id).t ~= 7 then
-    print("! group ID <"..param.id.."> collides with a non-group parameter, will not overwrite")
-    overwrite = false
+  elseif self.lookup[param.id] ~= nil and param.t == 0 then
+    if params:lookup_param(param.id).t ~= 0 then
+      print("! separator ID <"..param.id.."> collides with a non-separator parameter, will not overwrite")
+      overwrite = false
+    elseif param.id ~= "separator" then
+      print("! stealing separator ID <"..param.id.."> from earlier separator")
+      overwrite = true
+    end
+  elseif self.lookup[param.id] ~= nil and param.t == 7 then
+    if params:lookup_param(param.id).t ~= 7 then
+      print("! group ID <"..param.id.."> collides with a non-group parameter, will not overwrite")
+      overwrite = false
+    elseif param.id ~= "group" then
+      print("! stealing group ID <"..param.id.."> from earlier group")
+      overwrite = true
+    end
   end
 
   param.save = true

--- a/lua/core/paramset.lua
+++ b/lua/core/paramset.lua
@@ -125,7 +125,9 @@ function ParamSet:add_group(name,n)
     self.count = self.count + 1
     self.group = n
     self.hidden[self.count] = false
-    self.lookup[name] = self.count
+    if name ~= nil and self.lookup[name] == nil then
+      self.lookup[name] = self.count
+    end
   else
     print("ERROR: paramset cannot nest GROUPs")
   end

--- a/lua/core/paramset.lua
+++ b/lua/core/paramset.lua
@@ -108,7 +108,7 @@ function ParamSet:add_separator(name)
   self.count = self.count + 1
   self.group = self.group - 1
   self.hidden[self.count] = false
-  if name ~= nil then
+  if name ~= nil and self.lookup[name] == nil then
     self.lookup[name] = self.count
   end
 end

--- a/lua/core/paramset.lua
+++ b/lua/core/paramset.lua
@@ -97,46 +97,6 @@ function ParamSet.new(id, name)
   return ps
 end
 
---- add separator.
--- name is optional.
--- separators have their own parameter index and
--- can be hidden or added to a parameter group.
--- @tparam string name
-function ParamSet:add_separator(name)
-  local param = separator.new(name)
-  table.insert(self.params, param)
-  self.count = self.count + 1
-  self.group = self.group - 1
-  self.hidden[self.count] = false
-  if name ~= nil and self.lookup[name] == nil then
-    self.lookup[name] = self.count
-  elseif name ~= nil and self.lookup[name] ~= nil then
-    print("!!!!! ERROR: separator ID collides with another parameter ID: ".. name)
-  end
-end
-
---- add parameter group.
--- groups cannot be nested,
--- i.e. a group cannot be made within a group.
--- @tparam string name
--- @tparam int n
-function ParamSet:add_group(name,n)
-  if self.group < 1 then
-    local param = group.new(name,n)
-    table.insert(self.params, param)
-    self.count = self.count + 1
-    self.group = n
-    self.hidden[self.count] = false
-    if name ~= nil and self.lookup[name] == nil then
-      self.lookup[name] = self.count
-    elseif name ~= nil and self.lookup[name] ~= nil then
-      print("!!!!! ERROR: group ID collides with another parameter ID: ".. name)
-    end
-  else
-    print("ERROR: paramset cannot nest GROUPs")
-  end
-end
-
 --- add generic parameter.
 -- helper function to add param to paramset
 -- two uses:
@@ -172,13 +132,17 @@ function ParamSet:add(args)
       param = binary.new(id, name, args.behavior, args.default, args.allow_pmap)
     elseif args.type == "text" then
       param = text.new(id, name, args.text)
+    elseif args.type == "separator" then
+      param = separator.new(id, name)
+    elseif args.type == "group" then
+      param = group.new(id, name, args.n)
     else
       print("paramset.add() error: unknown type")
       return nil
     end
   end
 
-  if self.lookup[param.id] ~= nil then
+  if self.lookup[param.id] ~= nil and (param.id ~= "group" and param.id ~= "separator") then
     print("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
     print("!!!!! ERROR: parameter ID collision: ".. param.id)
     print("! please contact the script maintainer - this will cause a load failure in future updates")
@@ -215,8 +179,8 @@ function ParamSet:add_number(id, name, min, max, default, formatter, wrap)
 end
 
 --- add option.
--- @tparam string id
--- @tparam string name
+-- @tparam string id (no spaces)
+-- @tparam string name (can contain spaces)
 -- @param options
 -- @param default
 function ParamSet:add_option(id, name, options, default)
@@ -224,8 +188,8 @@ function ParamSet:add_option(id, name, options, default)
 end
 
 --- add control.
--- @tparam string id
--- @tparam string name
+-- @tparam string id (no spaces)
+-- @tparam string name (can contain spaces)
 -- @tparam controlspec controlspec
 -- @param formatter
 function ParamSet:add_control(id, name, controlspec, formatter)
@@ -233,8 +197,8 @@ function ParamSet:add_control(id, name, controlspec, formatter)
 end
 
 --- add file.
--- @tparam string id
--- @tparam string name
+-- @tparam string id (no spaces)
+-- @tparam string name (can contain spaces)
 -- @tparam string path
 function ParamSet:add_file(id, name, path)
   self:add { param=file.new(id, name, path) }
@@ -246,8 +210,8 @@ function ParamSet:add_text(id, name, txt)
 end
 
 --- add taper.
--- @tparam string id
--- @tparam string name
+-- @tparam string id (no spaces)
+-- @tparam string name (can contain spaces)
 -- @tparam number min
 -- @tparam number max
 -- @param default
@@ -258,19 +222,55 @@ function ParamSet:add_taper(id, name, min, max, default, k, units)
 end
 
 --- add trigger.
--- @tparam string id
--- @tparam string name
+-- @tparam string id (no spaces)
+-- @tparam string name (can contain spaces)
 function ParamSet:add_trigger(id, name)
   self:add { param=trigger.new(id, name) }
 end
 
 --- add binary
--- @tparam string id
--- @tparam string name
+-- @tparam string id (no spaces)
+-- @tparam string name (can contain spaces)
 -- @tparam string behavior
 -- @tparam number default
 function ParamSet:add_binary(id, name, behavior, default)
   self:add { param=binary.new(id, name, behavior, default) }
+end
+
+--- add separator.
+-- id and name are optional.
+-- if neither id or name are provided,
+-- separator will be named 'separator'
+-- and will not have a unique parameter index.
+-- separators which have their own parameter index
+-- can be hidden / shown.
+-- @tparam string id (no spaces)
+-- @tparam string name (can contain spaces)
+function ParamSet:add_separator(id, name)
+  self:add { param=separator.new(id, name) }
+end
+
+--- add parameter group.
+-- groups cannot be nested,
+-- i.e. a group cannot be made within a group.
+-- id and name are optional.
+-- if neither id or name are provided,
+-- group will be named 'group'
+-- and will not have a unique parameter index.
+-- groups which have their own parameter index
+-- can be hidden / shown.
+-- @tparam string id (no spaces)
+-- @tparam string name (can contain spaces)
+-- @tparam int n
+function ParamSet:add_group(id, name, n)
+  if id == nil then id = "group" end
+  n = type(name) == "number" and name or (n or 1)
+  if self.group < 1 then
+    self:add { param=group.new(id, name, n) }
+    self.group = type(name) == "number" and name or n
+  else
+    print("ERROR: paramset cannot nest GROUPs")
+  end
 end
 
 --- print.


### PR DESCRIPTION
while scripting tonight, i realized https://github.com/monome/norns/pull/1539 did not anticipate situations where an author might do the following:

```lua
params:add_number('my var', 'my var', 1, 127)
[...]
params:add_separator('my var')
```

though it's convention to use underscores within parameter ID's, the system supports ID instantiation with spaces, so there's a chance someone will accidentally clobber their useful parameter with a separator or group name. since separators and groups do not have ID's, only names, this seems like a good guardrail.