### PR TITLE
Call the global Midi.remove function on removal

### DIFF
--- a/lua/core/midi.lua
+++ b/lua/core/midi.lua
@@ -406,7 +406,7 @@ _norns.midi.remove = function(id)
         port = Midi.devices[id].port
       }
       print(string.format("_norns.midi.remove: %d, %s, %s",dev.id,dev.name,dev.port))
-      Midi.devices[id].remove(dev)
+      Midi.remove(dev)
     end
   end
   Midi.devices[id] = nil


### PR DESCRIPTION
This change adjusts #1562 to align with what is understood to
be the original intent of the `Midi.add` and `Midi.remove` callbacks.