### PR TITLE
Place downbeats correctly.

### DIFF
--- a/lua/lib/lattice.lua
+++ b/lua/lib/lattice.lua
@@ -103,7 +103,7 @@ function Lattice:pulse()
         pattern.phase = pattern.phase + 1
         local swing_val = (2*pattern.swing/100)
         if not pattern.downbeat then 
-          swing_val = (2*(100-pattern.swing)/100)
+          swing_val = 1
         end
         if pattern.phase > (pattern.division * ppm)*swing_val then
           pattern.phase = pattern.phase - (pattern.division * ppm)


### PR DESCRIPTION
Without this change, a swing of 66 will shift some events early and some events late from where they would otherwise be. With this change, a swing of 66 leaves some beats alone, and shifts other beats late from where they would otherwise be. 

Example to evaluate change, run as a norns script:

```
engine.name = "PolyPerc"
local lattice = require("lattice")

function init()
    l = lattice:new()
    p1 = l:new_pattern{
        enabled = true,
        division = 1/4,
        action = function(t)
            print("q", t)
            engine.hz(440) 
        end,
    }
    p2 = l:new_pattern{
        enabled = true,
        division = 1/8,
        swing = 66,
        action = function(t)
            print("e", t)
            engine.hz(660)
        end,
    }
    l:start()
end
```

In this example, the expected behavior is that two events (440 and 660) fall on the "down" beat, and then one (660) falls on the "up" beat, but with a "triplet feel". Without the change we get the "eighth notes" falling before and after the quarter note, but not on it.