### PR TITLE
execute global Midi.remove callback

### DIFF
--- a/lua/core/midi.lua
+++ b/lua/core/midi.lua
@@ -399,6 +399,7 @@ end
 -- remove a device.
 _norns.midi.remove = function(id)
   if Midi.devices[id] then
+    Midi.remove(Midi.devices[id])
     if Midi.devices[id].remove then
       local dev = {
         id = Midi.devices[id].id,


### PR DESCRIPTION
this executes the global, customizable midi device removal callback when a device is unplugged (if the device is registered by the norns midi system), in addition to and without affecting the per-device removal callback (if defined.)

alternative to PR #1562, addressing issue #1557