### PR TITLE
add 'lfo'

### DIFF
--- a/lua/core/script.lua
+++ b/lua/core/script.lua
@@ -27,6 +27,11 @@ Script.clear = function()
     package.loaded['asl'] = nil
   end
 
+  if norns.lfo ~= nil then
+    norns.lfo.lattice:destroy()
+    norns.lfo.lattice = nil
+  end
+
   -- script local state
   local state = { }
 

--- a/lua/core/script.lua
+++ b/lua/core/script.lua
@@ -29,7 +29,7 @@ Script.clear = function()
 
   if norns.lfo ~= nil then
     norns.lfo.lattice:destroy()
-    norns.lfo.lattice = nil
+    norns.lfo = nil
   end
 
   -- script local state

--- a/lua/lib/lfo.lua
+++ b/lua/lib/lfo.lua
@@ -62,6 +62,15 @@ function LFO.new(shape, min, max, depth, mode, period, action)
   return i
 end
 
+--- construct an LFO via table arguments
+-- eg. my_lfo:add{shape = 'sine', min = 200, max = 12000}
+-- @tparam[opt] string shape The shape for this LFO (options: 'sine','saw','square','random'; default: 'sine')
+-- @tparam[opt] number min The minimum bound for this LFO (default: 0)
+-- @tparam[opt] number max The maximum bound for this LFO (default: 1)
+-- @tparam[opt] number depth The depth of modulation between min/max (range: 0.0 to 1.0; default: 0.0)
+-- @tparam[opt] string mode How to advance the LFO (options: 'clocked', 'free'; default: 'clocked')
+-- @tparam[opt] number period The timing of this LFO's advancement. If mode is 'clocked', argument is in beats. If mode is 'free', argument is in seconds.
+-- @tparam[opt] function action A callback function to perform as the LFO advances. This library passes both the scaled and the raw value to the callback function.
 function LFO:add(args)
   local shape = args.shape == nil and 'sine' or args.shape
   local min = args.min == nil and 0 or args.min

--- a/lua/lib/lfo.lua
+++ b/lua/lib/lfo.lua
@@ -25,7 +25,6 @@ function LFO.init()
 end
 
 --- construct an LFO
--- consumes one clock per LFO (norns has 100 clocks available for scripting)
 -- @tparam[opt] string shape The shape for this LFO (options: 'sine','saw','square','random'; default: 'sine')
 -- @tparam[opt] number min The minimum bound for this LFO (default: 0)
 -- @tparam[opt] number max The maximum bound for this LFO (default: 1)

--- a/lua/lib/lfo.lua
+++ b/lua/lib/lfo.lua
@@ -19,7 +19,9 @@ local percentage;
 local scaled_min, scaled_max, mid, centroid_mid;
 
 function LFO.init()
-  norns.lfo = {lattice = lattice:new()}
+  if norns.lfo == nil then
+    norns.lfo = {lattice = lattice:new()}
+  end
 end
 
 --- construct an LFO

--- a/lua/lib/lfospec.lua
+++ b/lua/lib/lfospec.lua
@@ -16,6 +16,7 @@ local lfos_all_loaded = false
 local rand_values;
 
 --- construct an LFO
+-- consumes one clock per LFO (norns has 100 clocks available for scripting)
 -- @tparam[opt] string shape The shape for this LFO (options: 'sine','saw','square','random'; default: 'sine')
 -- @tparam[opt] number min The minimum bound for this LFO (default: 0)
 -- @tparam[opt] number max The maximum bound for this LFO (default: 1)
@@ -319,8 +320,10 @@ function LFO:add_params(id,sep,group)
           lfo_params_visibility("hide", id)
           params:set("lfo_scaled_"..id,"")
           params:set("lfo_raw_"..id,"")
+          self:stop()
         elseif x == 2 then
           lfo_params_visibility("show", id)
+          self:start()
         end
         self:set('enabled',x-1)
         lfo_bang(id)

--- a/lua/lib/lfospec.lua
+++ b/lua/lib/lfospec.lua
@@ -1,7 +1,7 @@
 -- LFOs for general-purpose scripting
 -- @module lib.lfospec
 -- inspired by contributions from @markwheeler (changes), @justmat (hnds), and @sixolet (toolkit)
--- added by @dndrks
+-- added by @dndrks + @sixolet
 
 local lattice = require 'lattice'
 local hook = require 'core/hook'
@@ -12,9 +12,7 @@ LFO.__index = LFO
 local lfo_rates = {1/16,1/8,1/4,5/16,1/3,3/8,1/2,3/4,1,1.5,2,3,4,6,8,16,32,64,128,256,512,1024}
 local lfo_rates_as_strings = {"1/16","1/8","1/4","5/16","1/3","3/8","1/2","3/4","1","1.5","2","3","4","6","8","16","32","64","128","256","512","1024"}
 
-local update_freq = 96
 local params_per_entry = 14
-local lfos_all_loaded = false
 
 local rand_values;
 
@@ -52,7 +50,6 @@ function LFO.new(shape, min, max, depth, mode, period, fn)
     wrap = false,
     formatter = nil
   }
-  i.counter = nil
   i.action = fn == nil and (function(scaled, raw) end) or fn
   return i
 end
@@ -283,7 +280,7 @@ function LFO:set(var, arg)
 end
 
 --- get LFO variable state
--- @tparam string var The variable to query (options: 'shape', 'min', 'max', 'depth', 'offset', 'mode', 'period', 'reset_target', 'baseline', 'action', 'enabled', 'controlspec', 'counter')
+-- @tparam string var The variable to query (options: 'shape', 'min', 'max', 'depth', 'offset', 'mode', 'period', 'reset_target', 'baseline', 'action', 'enabled', 'controlspec')
 function LFO:get(var)
   if var == nil then
     error('scripted LFO variable required')

--- a/lua/lib/lfospec.lua
+++ b/lua/lib/lfospec.lua
@@ -1,0 +1,410 @@
+-- LFOs for general-purpose scripting
+-- @module lib.lfospec
+
+local LFO = {}
+LFO.__index = LFO
+
+local lfo_rates = {1/16,1/8,1/4,5/16,1/3,3/8,1/2,3/4,1,1.5,2,3,4,6,8,16,32,64,128,256,512,1024}
+local lfo_rates_as_strings = {"1/16","1/8","1/4","5/16","1/3","3/8","1/2","3/4","1","1.5","2","3","4","6","8","16","32","64","128","256","512","1024"}
+
+local update_freq = 96
+local params_per_entry = 13
+local lfos_all_loaded = false
+
+local rand_values;
+
+--- construct an LFO
+-- @tparam[opt] string shape The shape for this LFO (options: 'sine','ramp','square','random'; default: 'sine')
+-- @tparam[opt] number min The minimum bound for this LFO (default: 0)
+-- @tparam[opt] number max The maximum bound for this LFO (default: 1)
+-- @tparam[opt] number depth The depth of modulation between min/max (range: 0.0 to 1.0; default: 0.0)
+-- @tparam[opt] string mode How to advance the LFO (options: 'clocked', 'free'; default: 'clocked')
+-- @tparam[opt] number period The timing of this LFO's advancement. If mode is 'clocked', argument is in beats. If mode is 'free', argument is in Hz.
+-- @tparam[opt] function fn A callback function to perform as the LFO advances. This library passes both the scaled and the raw value to the callback function.
+function LFO.new(shape, min, max, depth, mode, period, fn)
+  local i = {}
+  setmetatable(i, LFO)
+  i.scaled = 0
+  i.raw = 0
+  i.phase_counter = 0
+  i.shape = shape == nil and 'sine' or shape
+  i.min = min == nil and 0 or min
+  i.max = max == nil and 1 or max
+  i.depth = depth == nil and 1 or depth
+  i.enabled = 0
+  i.mode = mode == nil and 'clocked' or mode
+  i.period = period == nil and 4 or period
+  i.reset_target = 'floor'
+  i.baseline = 'min'
+  i.offset = 0
+  i.controlspec = {
+    warp = 'linear',
+    step = 0.01,
+    units = '',
+    quantum = 0.01,
+    wrap = false,
+    formatter = nil
+  }
+  i.counter = nil
+  i.action = fn == nil and (function(scaled, raw) end) or fn
+
+  return i
+end
+
+-- PARAMETERS UI /
+local function lfo_params_visibility(state, i)
+  params[state](params, "lfo_baseline_"..i)
+  params[state](params, "lfo_offset_"..i)
+  params[state](params, "lfo_depth_"..i)
+  params[state](params, "lfo_scaled_"..i)
+  params[state](params, "lfo_raw_"..i)
+  params[state](params, "lfo_mode_"..i)
+  if state == "show" then
+    if params:get("lfo_mode_"..i) == 1 then
+      params:hide("lfo_free_"..i)
+      params:show("lfo_clocked_"..i)
+    elseif params:get("lfo_mode_"..i) == 2 then
+      params:hide("lfo_clocked_"..i)
+      params:show("lfo_free_"..i)
+    end
+  else
+    params:hide("lfo_clocked_"..i)
+    params:hide("lfo_free_"..i)
+  end
+  params[state](params, "lfo_shape_"..i)
+  params[state](params, "lfo_min_"..i)
+  params[state](params, "lfo_max_"..i)
+  params[state](params, "lfo_reset_"..i)
+  params[state](params, "lfo_reset_target_"..i)
+  _menu.rebuild_params()
+end
+
+local function build_lfo_spec(lfo,i,bound)
+  params:add{
+    type = 'control',
+    id = 'lfo_'..bound..'_'..i,
+    name = 'lfo '..bound,
+    controlspec = controlspec.new(
+      lfo.min,
+      lfo.max,
+      lfo.controlspec.warp,
+      lfo.controlspec.step,
+      bound == 'min' and lfo.min or lfo.max,
+      lfo.controlspec.units,
+      lfo.controlspec.quantum,
+      lfo.controlspec.wrap
+    ),
+    formatter = lfo.controlspec.formatter
+  }
+  params:set_action('lfo_'..bound..'_'..i, function(x)
+    lfo:set(bound,x)
+  end)
+end
+
+local function lfo_bang(i)
+  local function lb(prm)
+    params:lookup_param("lfo_"..prm.."_"..i):bang()
+  end
+  lb('depth')
+  lb('min')
+  lb('max')
+  lb('baseline')
+  lb('offset')
+  lb('mode')
+  lb('clocked')
+  lb('free')
+  lb('shape')
+  lb('reset')
+  lb('reset_target')
+end
+
+-- / PARAMETERS UI
+
+-- SCRIPTING /
+
+local function process_lfo(id)
+  while true do
+    clock.sync(1/update_freq)
+
+    local _lfo = id
+    local phase
+
+    _lfo.phase_counter = _lfo.phase_counter + (1/update_freq)
+    if _lfo.mode == "clocked" then
+      phase = _lfo.phase_counter / _lfo.period
+    else
+      phase = _lfo.phase_counter * clock.get_beat_sec() / (1/_lfo.period)
+    end
+    phase = phase % 1
+
+    if _lfo.enabled == 1 then
+
+      local current_val = (math.sin(2*math.pi*phase) + 1)/2
+      if _lfo.shape == "saw" then
+        current_val = phase < 0.5 and phase/0.5 or 1-(phase-0.5)/(0.5)
+      end
+    
+      local min = _lfo.min
+      local max = _lfo.max
+
+      if min > max then
+        local old_min = min
+        local old_max = max
+        min = old_max
+        max = old_min
+      end
+
+      if min == -inf or max == -inf then
+        min = min == -inf and -2^1023.999999999 or min
+        max = max == inf and 2^1023.999999999 or max
+      end
+
+      local percentage = math.abs(min-max) * _lfo.depth
+      if _lfo.shape ~= 'random' then
+        _lfo.raw = current_val
+      end
+      current_val = current_val + _lfo.offset
+      local value = util.linlin(0,1,min,min + percentage,current_val)
+
+      if _lfo.depth > 0 then
+        local mid;
+        local scaled_min;
+        local scaled_max;
+        local raw_value;
+
+        if _lfo.baseline == 'min' then
+          scaled_min = min
+          scaled_max = min + percentage
+          mid = util.linlin(min,max,scaled_min,scaled_max,(min+max)/2)
+        elseif _lfo.baseline == 'center' then
+          mid = (min+max)/2
+          local centroid_mid = math.abs(min-max) * ((_lfo.depth)/2)
+          scaled_min = util.clamp(mid - centroid_mid,min,max)
+          scaled_max = util.clamp(mid + centroid_mid,min,max)
+          value = util.linlin(0,1,scaled_min,scaled_max,current_val)
+        elseif _lfo.baseline == 'max' then
+          mid = (min+max)/2
+          value = max - value
+          scaled_min = max * (1-(_lfo.depth))
+          scaled_max = max
+          mid = math.abs(util.linlin(min,max,scaled_min,scaled_max,mid))
+          value = util.linlin(0,1,scaled_max,scaled_min,current_val)
+        end
+
+        raw_value = util.linlin(min,max,0,1,value)
+
+        if _lfo.shape == "sine" then
+          value = util.clamp(value,min,max)
+          _lfo.scaled = value
+        elseif _lfo.shape == "saw" then
+          value = util.clamp(value,min,max)
+          _lfo.scaled = value
+        elseif _lfo.shape == "square" then
+          local square_value = value >= mid and max or min
+          square_value = util.linlin(min,max,scaled_min,scaled_max,square_value)
+          square_value = util.clamp(square_value,scaled_min,scaled_max)
+          _lfo.scaled = square_value
+          _lfo.raw = util.linlin(scaled_min,scaled_max,0,1,square_value)
+        elseif _lfo.shape == "random" then
+          local prev_value = rand_values
+          rand_values = value >= mid and max or min
+          local rand_value;
+          if prev_value ~= rand_values then
+            rand_value = util.linlin(min,max,scaled_min,scaled_max,math.random(math.floor(min*100),math.floor(max*100))/100)
+            rand_value = util.clamp(rand_value,min,max)
+            _lfo.scaled = rand_value
+            _lfo.raw = util.linlin(scaled_min,scaled_max,0,1,rand_value)
+          end
+        end
+        _lfo.action(_lfo.scaled, _lfo.raw)
+        if _lfo.parameter_id ~= nil then
+          params:set("lfo_scaled_".._lfo.parameter_id,util.round(_lfo.scaled,0.01))
+          params:set("lfo_raw_".._lfo.parameter_id,util.round(_lfo.raw,0.01))
+        end
+      end
+    end
+  end
+end
+
+--- start LFO
+function LFO:start()
+  if self.counter == nil then
+    self:reset_phase()
+    self.counter = clock.run(function() process_lfo(self) end)
+    self.enabled = 1
+  end
+end
+
+--- stop LFO
+function LFO:stop()
+  if self.counter ~= nil then
+    clock.cancel(self.counter)
+    self.counter = nil
+    self.enabled = 0
+  end
+end
+
+--- set LFO variable state
+-- @tparam string var The variable to target (options: 'shape', 'min', 'max', 'depth', 'offset', 'mode', 'period', 'reset_target', 'baseline', 'action')
+-- @tparam various arg The argument to pass to the target (often numbers + strings, but 'action' expects a function)
+function LFO:set(var, arg)
+  if var == nil then
+    error('scripted LFO variable required')
+  elseif arg == nil then
+    error('scripted LFO argument required')
+  elseif not self[var] then
+    error("scripted LFO variable '"..var.."' not valid")
+  else
+    self[var] = arg
+  end
+end
+
+--- get LFO variable state
+-- @tparam string var The variable to query (options: 'shape', 'min', 'max', 'depth', 'offset', 'mode', 'period', 'reset_target', 'baseline', 'action', 'enabled', 'controlspec', 'counter')
+function LFO:get(var)
+  if var == nil then
+    error('scripted LFO variable required')
+  elseif not self[var] then
+    error("scripted LFO variable '"..var.."' not valid")
+  else
+    return self[var]
+  end
+end
+
+--- reset the LFO's phase
+function LFO:reset_phase()
+  if self.mode == "free" then
+    local baseline = 1/(clock.get_beat_sec() / (1/self.period))
+    if self.reset_target == "floor" then
+      self.phase_counter = (baseline/4) + (baseline/2)
+    else
+      self.phase_counter = (baseline/4)
+    end
+  else
+    if self.reset_target == "floor" then
+      self.phase_counter = 0.75 * (self.period)
+    else
+      self.phase_counter = 0.25 * (self.period)
+    end
+  end
+end
+
+-- / SCRIPT LFOS
+
+--- Build parameter menu UI for an already-constructed LFO.
+-- @tparam string id The parameter ID to use for this LFO.
+-- @tparam[opt] string separator A separator name for the LFO parameters.
+-- @tparam[opt] string group A group name for the LFO parameters.
+function LFO:add_params(id,sep,group)
+  if params.lookup["lfo_"..id] == nil then
+
+    if group then
+      if sep ~= nil then
+        params:add_group("lfo_group_"..id,group,params_per_entry+1)
+      else
+        params:add_group("lfo_group_"..id,group,params_per_entry)
+      end
+    end
+
+    if sep then
+      params:add_separator("lfo_sep_"..sep,sep)
+    end
+
+    params:add_option("lfo_"..id,"lfo state",{"off","on"},1)
+    params:set_action("lfo_"..id,function(x)
+      if x == 1 then
+        lfo_params_visibility("hide", id)
+        params:set("lfo_scaled_"..id,"")
+        params:set("lfo_raw_"..id,"")
+      elseif x == 2 then
+        lfo_params_visibility("show", id)
+      end
+      self:set('enabled',x-1)
+      lfo_bang(id)
+    end)
+
+    params:add_option("lfo_shape_"..id, "lfo shape", {"sine","saw","square","random"},1)
+    params:set_action("lfo_shape_"..id, function(x) self:set('shape', params:lookup_param("lfo_shape_"..id).options[x]) end)
+
+    params:add_number("lfo_depth_"..id,"lfo depth",0,100,0,function(param) return (param:get().."%") end)
+    params:set_action("lfo_depth_"..id, function(x)
+      if x == 0 then
+        params:set("lfo_scaled_"..id,"")
+        params:set("lfo_raw_"..id,"")
+      end
+      self:set('depth',x/100)
+    end)
+
+    params:add_number('lfo_offset_'..id, 'lfo offset', -100, 100, 0, function(param) return (param:get().."%") end)
+    params:set_action("lfo_offset_"..id, function(x)
+      self:set('offset',x/100)
+    end)
+
+    params:add_text("lfo_scaled_"..id,"  scaled value","")
+    params:add_text("lfo_raw_"..id,"  raw value","")
+
+    build_lfo_spec(self,id,"min")
+    build_lfo_spec(self,id,"max")
+
+    local baseline_options;
+    baseline_options = {"from min", "from center", "from max"}
+    params:add_option("lfo_baseline_"..id, "lfo baseline", baseline_options, 1)
+    params:set_action("lfo_baseline_"..id, function(x)
+      self:set('baseline',string.gsub(params:lookup_param("lfo_baseline_"..id).options[x],"from ",""))
+      _menu.rebuild_params()
+    end)
+
+    params:add_option("lfo_mode_"..id, "lfo mode", {"clocked","free"},1)
+    params:set_action("lfo_mode_"..id,
+      function(x)
+        if x == 1 and params:string("lfo_"..id) == "on" then
+          params:hide("lfo_free_"..id)
+          params:show("lfo_clocked_"..id)
+        elseif x == 2 and params:string("lfo_"..id) == "on" then
+          params:hide("lfo_clocked_"..id)
+          params:show("lfo_free_"..id)
+        end
+        _menu.rebuild_params()
+        self:set('mode',params:lookup_param("lfo_mode_"..id).options[x])
+      end
+      )
+
+    params:add_option("lfo_clocked_"..id, "lfo rate", lfo_rates_as_strings, 9)
+    params:set_action("lfo_clocked_"..id,
+      function(x)
+        if params:string("lfo_mode_"..id) == "clocked" then
+          self:set('period',lfo_rates[x] * 4)
+        end
+      end
+    )
+
+    params:add{
+      type='control',
+      id="lfo_free_"..id,
+      name="lfo rate",
+      controlspec=controlspec.new(0.001,4,'exp',0.001,0.05,'hz',0.001)
+    }
+    params:set_action("lfo_free_"..id, function(x)
+      if params:string("lfo_mode_"..id) == "free" then
+        self:set('period', x)
+      end
+    end)
+
+    params:add_trigger("lfo_reset_"..id, "reset lfo")
+    params:set_action("lfo_reset_"..id, function(x) self:reset_phase() end)
+
+    params:add_option("lfo_reset_target_"..id, "reset lfo to", {"floor","ceiling"}, 1)
+    params:set_action("lfo_reset_target_"..id, function(x)
+      self:set('reset_target', params:lookup_param("lfo_reset_target_"..id).options[x])
+    end)
+    
+    params:hide("lfo_free_"..id)
+
+    params:lookup_param("lfo_"..id):bang()
+    self.parameter_id = id
+  else
+    print('! params for LFO '..id..' already added !')
+  end
+end
+
+return LFO

--- a/lua/lib/lfospec.lua
+++ b/lua/lib/lfospec.lua
@@ -10,7 +10,7 @@ local lfo_rates = {1/16,1/8,1/4,5/16,1/3,3/8,1/2,3/4,1,1.5,2,3,4,6,8,16,32,64,12
 local lfo_rates_as_strings = {"1/16","1/8","1/4","5/16","1/3","3/8","1/2","3/4","1","1.5","2","3","4","6","8","16","32","64","128","256","512","1024"}
 
 local update_freq = 96
-local params_per_entry = 13
+local params_per_entry = 14
 local lfos_all_loaded = false
 
 local rand_values;

--- a/lua/lib/lfospec.lua
+++ b/lua/lib/lfospec.lua
@@ -1,5 +1,7 @@
 -- LFOs for general-purpose scripting
 -- @module lib.lfospec
+-- inspired by contributions from @markwheeler (changes), @justmat (hnds), and @sixolet (toolkit)
+-- added by @dndrks
 
 local LFO = {}
 LFO.__index = LFO


### PR DESCRIPTION
`lfo` is a general-purpose scripting library for establishing LFOs, with optional parameter UI control.
it was inspired by the fantastic contributions over the years from @markwheeler , @justmat + @sixolet.

@sixolet brought the lib into a lattice structure, which means it only consumes one system clock to instantiate as many LFOs as you want, with settable `ppqn` per LFO to manage processing.

### basic use in a script

instantiating `lfo` and building LFOs should feel pretty similar to scripting with any of the current libraries:

```lua
_lfos = require 'lfo' -- assign the library to a general variable
engine.name = 'PolyPerc'
s = require 'sequins'

function init()
  hz_vals = s{400,600,200,350}
  sync_vals = s{1,1/3,1/2,1/6,2}
  clock.run(iter)
  
  -- establish an LFO variable for a specific purpose:
  cutoff_lfo = _lfos.new(
    'saw', -- shape
    200, -- min
    1300, -- max
    1, -- depth (0 to 1)
    'clocked', -- mode
    6, -- period (in 'clocked' mode, represents beats)
    -- pass our 'scaled' value (bounded by min/max and depth) to the engine:
    function(scaled, raw) engine.cutoff(scaled) end -- action, always passes scaled and raw values
  )
  
  cutoff_lfo:start() -- start our LFO, complements ':stop()'
end

function iter()
  while true do
    clock.sync(sync_vals())
    hertz = hz_vals()
    engine.hz(hertz)
  end
end
```

### advanced use in a script

to go further, there are additional `:set` and `:get` methods, which connect to the individual LFO's current state.

`:set` and `:get` options:
- 'enabled': 1 or 0
- 'shape': 'sine', 'saw', 'square', 'random'
- 'min': number
- 'max': number
- 'depth': number 0.0 to 1.0
- 'offset': number -1.0 to 1.0
- 'mode': 'clocked' or 'free'
- 'period': number (in 'clocked', beats; in 'free', hz)
- 'baseline': 'from min', 'from center', 'from max'
- 'reset_target': 'floor' or 'ceiling' (essentially should the reset start at min or max?)
- `ppqn`: the resolution of the LFO, defaults to 96 but can be brought down (ideally in equal divisions of 96) to reduce consumption
- 'action': the callback function, which receives both the scaled (to min/max * depth) and raw value (0 to 1)

special `:get` options:
- 'scaled': returns the scaled value of the LFO (scaled to min and max, adjusted by depth and offset)
- 'raw': returns the 0 to 1 raw value of the LFO, without considering the other adjustments

```lua
_lfos = require 'lfo' -- assign the library to a general variable
engine.name = 'PolyPerc'
s = require 'sequins'

function init()
  hz_vals = s{400,600,200,350}
  sync_vals = s{1,1/3,1/2,1/6,2}
  clock.run(iter)
  
  screen_dirty = true
  
  -- establish an LFO variable for a specific purpose:
  cutoff_lfo = _lfos.new()
  cutoff_lfo:set('shape', 'sine')
  cutoff_lfo:set('min', 200)
  cutoff_lfo:set('max', 5000)
  cutoff_lfo:set('depth', 0.3)
  cutoff_lfo:set('mode', 'free')
  cutoff_lfo:set('period', 2)
  cutoff_lfo:set('action', function(scaled,raw) engine.cutoff(scaled) screen_dirty = true end)
  
  redraw_screen = metro.init(check_dirty,1/15,-1)
  redraw_screen:start()
end

function iter()
  while true do
    clock.sync(sync_vals())
    hertz = hz_vals()
    engine.hz(hertz)
    cutoff_lfo:set('depth', math.random())
  end
end

function check_dirty()
  if screen_dirty then
    redraw()
    screen_dirty = false
  end
end

function redraw()
   screen.clear()
   screen.level(15)
   screen.move(64,40)
   screen.font_size(20)
   screen.text_center(util.round(cutoff_lfo:get('scaled'),0.01)..'hz')
   screen.update()
end

-- press K3 to start/stop:
function key(n,z)
  if n == 3 and z == 1 then
    if cutoff_lfo:get('enabled') == 1 then
      cutoff_lfo:stop()
    else
      cutoff_lfo:start()
    end
  end
end

-- turn E3 to adjust cutoff when LFO is inactive:
function enc(n,d)
  if n == 3 and cutoff_lfo:get('enabled') == 0 then
    local current = cutoff_lfo:get('scaled')
    local change = util.clamp(current + d*100, cutoff_lfo:get('min'), cutoff_lfo:get('max'))
    cutoff_lfo:set('scaled', change)
    engine.cutoff(cutoff_lfo:get('scaled'))
    screen_dirty = true
  end
end
```

## parameter UI

to simplify the process of changing variables during play, you can also just instantiate a parameter menu entry for any of the LFOs you construct. in order for the parameter menu to scale appropriately, it simply needs the `min` and `max` bounds for the LFO set ahead of executing `:add_params`:

```lua
_lfos = require 'lfo' -- assign the library to a general variable
engine.name = 'PolyPerc'
s = require 'sequins'

function init()
  hz_vals = s{400,600,200,350}
  sync_vals = s{1,1/3,1/2,1/6,2}
  clock.run(iter)
  
  screen_dirty = true
  
  -- establish an LFO variable for a specific purpose:
  cutoff_lfo = _lfos.new()
  -- IMPORTANT! set your LFO's 'min' and 'max' *before* adding params, so they can scale appropriately:
  cutoff_lfo:set('min', 200)
  cutoff_lfo:set('max', 5000)
  -- now we can add params:
  cutoff_lfo:add_params('cutoff_lfo', 'cutoff', 'LFOs')
  
  cutoff_lfo:set('action', function(scaled, raw) engine.cutoff(scaled) end)
  
  redraw_screen = metro.init(check_dirty,1/15,-1)
  redraw_screen:start()
end

function iter()
  while true do
    clock.sync(sync_vals())
    hertz = hz_vals()
    engine.hz(hertz)
  end
end

function check_dirty()
  if screen_dirty then
    redraw()
    screen_dirty = false
  end
end

function redraw()
   screen.clear()
   screen.move(64,40)
   screen.font_size(20)
   screen.text_center(util.round(cutoff_lfo:get('scaled'),0.01)..'hz')
   screen.update()
end
```