### PR TITLE
do not add separators to PSET file (and avoid historical collisions)

### DIFF
--- a/lua/core/paramset.lua
+++ b/lua/core/paramset.lua
@@ -472,7 +472,7 @@ function ParamSet:write(filename, name)
     io.output(fd)
     if name then io.write("-- "..name.."\n") end
     for _,param in ipairs(self.params) do
-      if param.id and param.save and param.t ~= self.tTRIGGER then
+      if param.id and param.save and param.t ~= self.tTRIGGER and param.t ~= self.tSEPARATOR then
         io.write(string.format("%s: %s\n", quote(param.id), param:get()))
       end
     end
@@ -499,6 +499,7 @@ function ParamSet:read(filename, silent)
   local fd = io.open(filename, "r")
   if fd then
     io.close(fd)
+    local param_already_set = {}
     for line in io.lines(filename) do
       if util.string_starts(line, "--") then
         params.name = string.sub(line, 4, -1)
@@ -509,7 +510,7 @@ function ParamSet:read(filename, silent)
           id = unquote(id)
           local index = self.lookup[id]
 
-          if index and self.params[index] then
+          if index and self.params[index] and not param_already_set[index] then
             if tonumber(value) ~= nil then
               self.params[index]:set(tonumber(value), silent)
             elseif value == "-inf" then
@@ -519,6 +520,7 @@ function ParamSet:read(filename, silent)
             elseif value then
               self.params[index]:set(value, silent)
             end
+            param_already_set[index] = true
           end
         end
       end


### PR DESCRIPTION
tonight, i realized that adding separators to the lookup table in #1584 means they get collected by the PSET writer. this is generally fine, since they don't have a `:set` action, but this syntax situation would result in an error if a PSET were saved and subsequently loaded for a script with conflicting parameter IDs:

```lua
function init()
  params:add_number('velocity', 'velocity', 0, 127)
  -- [...] some other params [...]
  -- assuming another section of the params wanted to use 'velocity' to demarcate a set of actions,
  --   but the author didn't provide a unique ID:  
  params:add_separator('velocity') 
end
```

the resulting PSET file would look like:

```bash
-- my_PSET
[...] SYSTEM PARAMS [...]
"velocity": 43
[...] some other params [...]
"velocity": 
```

and the PSET read would attempt to re-set the _number_-based `velocity` to `''` once it got to the second separator-based `velocity`, creating an error due to clamping a number with a string.

this PR corrects the inclusion of separators for new PSETs, as well as a mechanism to avoid reading values to parameters which have already been restored (to address PSETs which would have been made since `220802` was released). lmk if there's a more preferable way to address this and very sorry for not catching it before!