### PR TITLE
add TAPE previewing to fileselect

### DIFF
--- a/lua/lib/fileselect.lua
+++ b/lua/lib/fileselect.lua
@@ -142,11 +142,13 @@ fs.enc = function(n,d)
   elseif n==3 and d > 0 then
     fs.file = fs.list[fs.pos+1]
     if fs.lengths[fs.pos+1] then
-      fs.previewing = fs.pos
-      audio.tape_play_stop()
-      audio.tape_play_open(fs.path .. fs.file)
-      audio.tape_play_start()
-      fs.redraw()
+      if fs.previewing ~= fs.pos then
+        fs.previewing = fs.pos
+        audio.tape_play_stop()
+        audio.tape_play_open(fs.getdir() .. fs.file)
+        audio.tape_play_start()
+        fs.redraw()
+      end
     end
   elseif n == 3 and d < 0 then
     if fs.pos == fs.previewing then
@@ -177,7 +179,7 @@ fs.redraw = function()
           screen.level(4)
         end
         local text = fs.display_list[list_index]
-        if i == fs.previewing then
+        if list_index-1 == fs.previewing then
             text = '* ' .. util.trim_string_to_width(text, 95)
         end
         screen.text(text)

--- a/lua/lib/fileselect.lua
+++ b/lua/lib/fileselect.lua
@@ -106,8 +106,20 @@ fs.key = function(n,z)
   -- back
   if n==2 and z==1 then
     fs.done = true
+    if fs.previewing then
+      -- stop previewing
+      audio.tape_play_stop()
+      fs.previewing = nil
+      fs.redraw()
+    end
   -- select
   elseif n==3 and z==1 then
+    if fs.previewing then
+      -- stop previewing
+      audio.tape_play_stop()
+      fs.previewing = nil
+      fs.redraw()
+    end
     if #fs.list > 0 then
       fs.file = fs.list[fs.pos+1]
       if fs.file == "../" then
@@ -151,7 +163,8 @@ fs.enc = function(n,d)
       end
     end
   elseif n == 3 and d < 0 then
-    if fs.pos == fs.previewing then
+    -- always stop with left scroll
+    if fs.previewing then
       audio.tape_play_stop()
       fs.previewing = nil
       fs.redraw()
@@ -180,7 +193,7 @@ fs.redraw = function()
         end
         local text = fs.display_list[list_index]
         if list_index-1 == fs.previewing then
-            text = '* ' .. util.trim_string_to_width(text, 95)
+            text = util.trim_string_to_width('* ' .. text, 97)
         end
         screen.text(text)
         if fs.lengths[list_index] then

--- a/lua/lib/fileselect.lua
+++ b/lua/lib/fileselect.lua
@@ -139,6 +139,21 @@ fs.enc = function(n,d)
   if n==2 then
     fs.pos = util.clamp(fs.pos + d, 0, fs.len - 1)
     fs.redraw()
+  elseif n==3 and d > 0 then
+    fs.file = fs.list[fs.pos+1]
+    if fs.lengths[fs.pos+1] then
+      fs.previewing = fs.pos
+      audio.tape_play_stop()
+      audio.tape_play_open(fs.path .. fs.file)
+      audio.tape_play_start()
+      fs.redraw()
+    end
+  elseif n == 3 and d < 0 then
+    if fs.pos == fs.previewing then
+      audio.tape_play_stop()
+      fs.previewing = nil
+      fs.redraw()
+    end
   end
 end
 
@@ -161,7 +176,11 @@ fs.redraw = function()
         else
           screen.level(4)
         end
-        screen.text(fs.display_list[list_index])
+        local text = fs.display_list[list_index]
+        if i == fs.previewing then
+            text = '* ' .. util.trim_string_to_width(text, 95)
+        end
+        screen.text(text)
         if fs.lengths[list_index] then
           screen.move(128,10*i)
           screen.text_right(fs.lengths[list_index])


### PR DESCRIPTION
This would close #1581

The operation is basically as proposed: E3 will turn on and off previewing, which hijacks TAPE.

Currently it's very bare-bones; so for instance if TAPE is muted, no sound will be heard.

Thoughts / suggestions / comments welcome :)