### PR TITLE
Tweaks to the keyboard

### DIFF
--- a/lua/core/keyboard.lua
+++ b/lua/core/keyboard.lua
@@ -116,6 +116,10 @@ function keyboard.process(type,code,value)
   -- textentry keycode
   if te_kbd_cb.code then
     te_kbd_cb.code(c,value)
+    -- menu screen goto
+  elseif (c=="F1" or c=="F2" or c=="F3" or c=="F4") and value==1 then 
+    _menu.set_mode(true)
+    _menu.keycode(c,value)
     -- toggle menu with F5
   elseif (c=="F5" and value==1) then 
     _menu.set_mode(not _menu.mode)

--- a/lua/core/keyboard.lua
+++ b/lua/core/keyboard.lua
@@ -116,6 +116,9 @@ function keyboard.process(type,code,value)
   -- textentry keycode
   if te_kbd_cb.code then
     te_kbd_cb.code(c,value)
+    -- toggle menu with F5
+  elseif (c=="F5" and value==1) then 
+    _menu.set_mode(not _menu.mode)
     -- menu keycode
   elseif _menu.mode then _menu.keycode(c,value)
     -- script keycode

--- a/lua/core/menu.lua
+++ b/lua/core/menu.lua
@@ -216,7 +216,7 @@ function _menu.keycode(c,value)
   end
 
   -- E2 emu (scolling)
-  if value==1 then
+  if value>=1 then
     if c=="DOWN" then
       _menu.penc(2,1)
     elseif c=="UP" then

--- a/lua/core/menu.lua
+++ b/lua/core/menu.lua
@@ -237,6 +237,13 @@ function _menu.keycode(c,value)
     end
   end
 
+  -- parameter change with +/-
+  if c=="MINUS" then 
+    _menu.penc(3,value*-1) 
+  elseif c=="EQUAL" then 
+    _menu.penc(3,value) 
+  end
+
   if _menu.keyboardcode then _menu.keyboardcode(c,value) end
 end
 

--- a/lua/core/osc.lua
+++ b/lua/core/osc.lua
@@ -92,6 +92,8 @@ local function remote_handler(path, args)
     _norns.key(n, val)
   elseif cmd=="/remote/enc" then
     _norns.enc(n, val)
+  elseif cmd=="/remote/brd" then 
+    keyboard.process(1,n,val)
   end
 end
 				    


### PR DESCRIPTION
These are some keyboard tweaks I mentioned in https://github.com/monome/norns/discussions/1610

I created each as a individual commit if you'd like to cherry-pick ones to include.

Here is a virtual norns where they can be tested: https://play.norns.online/.

The main changes are: 

- F1-4 go straight to menu screens.
- F5 toggles on/off menu
- holding a key continues to adjust
- +/- keys adjust parameters
- osc handler can transmit keyboard (in the virtual norns the browser is sending keystrokes via osc)