### PR TITLE
add version error

### DIFF
--- a/lua/core/menu.lua
+++ b/lua/core/menu.lua
@@ -79,6 +79,9 @@ norns.scripterror = function(msg)
   print("### SCRIPT ERROR: "..msg)
   if util.string_starts(msg,"missing") then
     print("### try 'SYSTEM > RESTART'")
+  elseif util.string_starts(msg,"version") then
+    print("### try 'SYSTEM > UPDATE'")
+    print("### or check for new disk image")
   end
   _menu.errormsg = msg
   _menu.scripterror = true

--- a/lua/core/menu/home.lua
+++ b/lua/core/menu/home.lua
@@ -105,6 +105,10 @@ m.redraw = function()
         screen.level(8)
         screen.move(0,25)
         screen.text("try 'SYSTEM > RESTART'")
+      elseif util.string_starts(_menu.errormsg,"version") then
+        screen.level(8)
+        screen.move(0,25)
+        screen.text("try 'SYSTEM > UPDATE'")
       end
     end
     screen.level(15)

--- a/lua/core/norns.lua
+++ b/lua/core/norns.lua
@@ -174,15 +174,6 @@ else
   norns.version.update = "000000"
 end
 
-norns.version.required = function(version)
-  -- probably throwing away silly input is fine
-  if tonumber(version) then
-    if tonumber(version) > tonumber(norns.version.update) then
-      norns.scripterror("version " .. version .. " required")
-    end
-  end
-end
-
 --- shutdown
 norns.shutdown = function()
   hook.system_pre_shutdown()

--- a/lua/core/norns.lua
+++ b/lua/core/norns.lua
@@ -174,6 +174,15 @@ else
   norns.version.update = "000000"
 end
 
+norns.version.required = function(version)
+  -- probably throwing away silly input is fine
+  if tonumber(version) then
+    if tonumber(version) > tonumber(norns.version.update) then
+      norns.scripterror("version " .. version .. " required")
+    end
+  end
+end
+
 --- shutdown
 norns.shutdown = function()
   hook.system_pre_shutdown()

--- a/lua/core/script.lua
+++ b/lua/core/script.lua
@@ -96,6 +96,7 @@ Script.clear = function()
   norns.state.path = _path["dust"]
   norns.state.data = _path.data
   norns.state.lib = norns.state.path
+  norns.version.required = nil
 
   -- clear params
   params:clear()
@@ -210,6 +211,11 @@ end
 
 --- load engine, execute script-specified init (if present).
 Script.run = function()
+  if tonumber(norns.version.required) and tonumber(norns.version.required) > tonumber(norns.version.update) then
+    norns.scripterror("version " .. norns.version.required .. " required")
+    Script.clear()
+    return
+  end
   -- allow mods to do initialization
   hook.script_pre_init()
 

--- a/lua/lib/fileselect.lua
+++ b/lua/lib/fileselect.lua
@@ -142,11 +142,13 @@ fs.enc = function(n,d)
   elseif n==3 and d > 0 then
     fs.file = fs.list[fs.pos+1]
     if fs.lengths[fs.pos+1] then
-      fs.previewing = fs.pos
-      audio.tape_play_stop()
-      audio.tape_play_open(fs.path .. fs.file)
-      audio.tape_play_start()
-      fs.redraw()
+      if fs.previewing ~= fs.pos then
+        fs.previewing = fs.pos
+        audio.tape_play_stop()
+        audio.tape_play_open(fs.getdir() .. fs.file)
+        audio.tape_play_start()
+        fs.redraw()
+      end
     end
   elseif n == 3 and d < 0 then
     if fs.pos == fs.previewing then
@@ -177,7 +179,7 @@ fs.redraw = function()
           screen.level(4)
         end
         local text = fs.display_list[list_index]
-        if i == fs.previewing then
+        if list_index-1 == fs.previewing then
             text = '* ' .. util.trim_string_to_width(text, 95)
         end
         screen.text(text)

--- a/lua/lib/fileselect.lua
+++ b/lua/lib/fileselect.lua
@@ -106,8 +106,20 @@ fs.key = function(n,z)
   -- back
   if n==2 and z==1 then
     fs.done = true
+    if fs.previewing then
+      -- stop previewing
+      audio.tape_play_stop()
+      fs.previewing = nil
+      fs.redraw()
+    end
   -- select
   elseif n==3 and z==1 then
+    if fs.previewing then
+      -- stop previewing
+      audio.tape_play_stop()
+      fs.previewing = nil
+      fs.redraw()
+    end
     if #fs.list > 0 then
       fs.file = fs.list[fs.pos+1]
       if fs.file == "../" then
@@ -151,7 +163,8 @@ fs.enc = function(n,d)
       end
     end
   elseif n == 3 and d < 0 then
-    if fs.pos == fs.previewing then
+    -- always stop with left scroll
+    if fs.previewing then
       audio.tape_play_stop()
       fs.previewing = nil
       fs.redraw()
@@ -180,7 +193,7 @@ fs.redraw = function()
         end
         local text = fs.display_list[list_index]
         if list_index-1 == fs.previewing then
-            text = '* ' .. util.trim_string_to_width(text, 95)
+            text = util.trim_string_to_width('* ' .. text, 97)
         end
         screen.text(text)
         if fs.lengths[list_index] then

--- a/lua/lib/fileselect.lua
+++ b/lua/lib/fileselect.lua
@@ -139,6 +139,21 @@ fs.enc = function(n,d)
   if n==2 then
     fs.pos = util.clamp(fs.pos + d, 0, fs.len - 1)
     fs.redraw()
+  elseif n==3 and d > 0 then
+    fs.file = fs.list[fs.pos+1]
+    if fs.lengths[fs.pos+1] then
+      fs.previewing = fs.pos
+      audio.tape_play_stop()
+      audio.tape_play_open(fs.path .. fs.file)
+      audio.tape_play_start()
+      fs.redraw()
+    end
+  elseif n == 3 and d < 0 then
+    if fs.pos == fs.previewing then
+      audio.tape_play_stop()
+      fs.previewing = nil
+      fs.redraw()
+    end
   end
 end
 
@@ -161,7 +176,11 @@ fs.redraw = function()
         else
           screen.level(4)
         end
-        screen.text(fs.display_list[list_index])
+        local text = fs.display_list[list_index]
+        if i == fs.previewing then
+            text = '* ' .. util.trim_string_to_width(text, 95)
+        end
+        screen.text(text)
         if fs.lengths[list_index] then
           screen.move(128,10*i)
           screen.text_right(fs.lengths[list_index])


### PR DESCRIPTION
Adds an error on script load if the script writer sets the value of `norns.version.required` to a number (or string) representing a date newer than `norns.version.update`. This variable should be set outside of `init`, since the check happens before even the `pre_init` hook is called.