### PR TITLE
Ugen install

### DIFF
--- a/lua/core/engine.lua
+++ b/lua/core/engine.lua
@@ -11,6 +11,8 @@ local Engine = {}
 Engine.names = {}
 -- currently loaded name
 Engine.name = nil
+-- ugens to be installed on first script load
+Engine.ugens = {}
 -- current command table
 Engine.commands = {}
 -- flag if there is a load request pending

--- a/lua/core/menu/home.lua
+++ b/lua/core/menu/home.lua
@@ -101,7 +101,7 @@ m.redraw = function()
     local line = string.upper(norns.state.name)
     if(_menu.scripterror and _menu.errormsg ~= 'NO SCRIPT') then
       line = "error: " .. _menu.errormsg
-      if util.string_starts(_menu.errormsg,"missing") then
+      if util.string_starts(_menu.errormsg,"missing") or util.string_starts(_menu.errormsg,"installed") then
         screen.level(8)
         screen.move(0,25)
         screen.text("try 'SYSTEM > RESTART'")

--- a/lua/core/script.lua
+++ b/lua/core/script.lua
@@ -220,7 +220,12 @@ Script.run = function()
   -- allow mods to do initialization
   hook.script_pre_init()
   -- attempt to install missing ugens
-  Script.ugen_helper()
+  local restart_flag = Script.ugen_helper()
+  if restart_flag then
+    norns.scripterror("installed new UGens")
+    Script.clear()
+    return
+  end
   print("# script run")
   if engine.name ~= nil then
     print("loading engine: " .. engine.name)
@@ -291,11 +296,7 @@ Script.ugen_helper = function()
       end
     end
   end
-  if flag then
-    norns.scripterror("installed new UGens")
-    Script.clear()
-    return
-  end
+  return flag
 end
 
 return Script

--- a/lua/core/script.lua
+++ b/lua/core/script.lua
@@ -261,6 +261,9 @@ end
 -- Looks in `/ignore` and `/lib/ignore` for UGens not found in
 -- `~/.local/share/SuperCollider/Extensions/UgenName`
 Script.ugen_helper = function()
+  if type(engine.ugens) == "string" then
+    engine.ugens = {engine.ugens}
+  end
   local extensions = _path.home .. "/.local/share/SuperCollider/Extensions/"
   local suffixes = {".sc", "_scsynth.so"}
   local flag = false

--- a/lua/core/script.lua
+++ b/lua/core/script.lua
@@ -271,11 +271,13 @@ Script.ugen_helper = function()
     for _,suffix in pairs(suffixes) do
       if not util.file_exists(extensions .. name .. "/" .. name .. suffix) then
         if util.file_exists(norns.state.path .. "/ignore/" .. name .. suffix) then
+          util.os_capture("mkdir " .. extensions .. name)
           util.os_capture("cp " .. norns.state.path .. "/ignore/" .. name .. suffix .. " " .. extensions .. name .. "/" .. name .. suffix)
           print("installing UGen file: " .. name .. suffix)
           print("to location: " .. extensions .. name .. "/")
           flag = true
         elseif util.file_exists(norns.state.lib .. "/ignore/" .. name .. suffix) then
+          util.os_capture("mkdir " .. extensions .. name)
           util.os_capture("cp " .. norns.state.lib .. "/ignore/" .. name .. suffix .. " " .. extensions .. name .. "/" .. name .. suffix)
           print("installing UGen file: " .. name . suffix)
           print("to location: " .. extensions .. name .. "/")

--- a/lua/core/startup.lua
+++ b/lua/core/startup.lua
@@ -21,7 +21,7 @@ midi = require 'core/midi'
 osc = require 'core/osc'
 keyboard = require 'core/keyboard'
 poll = require 'core/poll'
-engine = tab.readonly{table = require 'core/engine', except = {'name'}}
+engine = tab.readonly{table = require 'core/engine', except = {'name', 'ugens'}}
 softcut = require 'core/softcut'
 wifi = require 'core/wifi'
 controlspec = require 'core/controlspec'


### PR DESCRIPTION
Adds a `Script.ugen_helper()` function that iterates over the table of strings `engine.ugens`, checking for each whether a file of the form `name.sc` and `name_scsynth.so` is present at `~/.local/share/SuperCollider/Extensions/name/` and if not, attempts to copy from `/ignore` or `/lib/ignore`. If files are successfully copied, script load is blocked and an error message encouraging a `system > restart` is displayed.

Potential gotcha: if a "UGen" is just an `.sc` file without a corresponding `.so` file, using this method will prevent script load.  I don't know how frequently these "pseudo-UGens" get used qua UGens as opposed to bespoke script components, but it's something to be aware of.

I figured `Script` was a better place for this than `Engine`, but I'm happy to refactor if we don't agree.