### PR TITLE
work on lattice v2

### DIFF
--- a/lua/lib/lattice.lua
+++ b/lua/lib/lattice.lua
@@ -1,29 +1,27 @@
---- module for creating a lattice of patterns based on a single fast "superclock"
+--- module for creating a lattice of sprockets based on a single fast "superclock"
 --
 -- @module Lattice
--- @release v1.2.1
--- @author tyleretters & ezra & zack
+-- @release v2.0
+-- @author tyleretters & ezra & zack & rylee
 
-local Lattice, Pattern = {}, {}
+local Lattice, Sprocket = {}, {}
 
 --- instantiate a new lattice
 -- @tparam[opt] table args optional named attributes are:
 -- - "auto" (boolean) turn off "auto" pulses from the norns clock, defaults to true
--- - "meter" (number) of quarter notes per measure, defaults to 4
--- - "ppqn" (number) the number of pulses per quarter note of this superclock, defaults to 96
+-- - "ppq" (number) the number of pulses per quarter cycle of this superclock, defaults to 96
 -- @treturn table a new lattice
 function Lattice:new(args)
   local l = setmetatable({}, { __index = Lattice })
-  local args = args == nil and {} or args
+  args = args == nil and {} or args
   l.auto = args.auto == nil and true or args.auto
-  l.meter = args.meter == nil and 4 or args.meter
-  l.ppqn = args.ppqn == nil and 96 or args.ppqn
+  l.ppq = args.ppq == nil and args.ppqn == nil and 96 or args.ppq == nil and args.ppqn or args.ppq
   l.enabled = false
   l.transport = 0
   l.superclock_id = nil
-  l.pattern_id_counter = 100
-  l.patterns = {}
-  l.pattern_ordering={}
+  l.sprocket_id_counter = 100
+  l.sprockets = {}
+  l.sprocket_ordering={{}, {}, {}, {}, {}}
   return l
 end
 
@@ -37,15 +35,16 @@ end
 
 --- reset the norns clock without restarting lattice
 function Lattice:reset()
-  -- destroy clock, but not the patterns
+  -- destroy clock, but not the sprockets
   self:stop()
-  if self.superclock_id ~= nil then 
+  if self.superclock_id ~= nil then
     clock.cancel(self.superclock_id)
-    self.superclock_id = nil 
+    self.superclock_id = nil
   end
-  for i, pattern in pairs(self.patterns) do
-    pattern.phase = pattern.division * self.ppqn * self.meter * (1-pattern.delay)
-    pattern.downbeat = false
+  for i, sprocket in pairs(self.sprockets) do
+    sprocket.phase = sprocket.division * self.ppq * 4 * (1 - sprocket.delay)
+    -- "4" because ppq is per quarter cycle
+    sprocket.downbeat = false
   end
   self.transport = 0
   params:set("clock_reset",1)
@@ -73,14 +72,12 @@ function Lattice:destroy()
   if self.superclock_id ~= nil then
     clock.cancel(self.superclock_id)
   end
-  self.patterns = {}
-  self.pattern_ordering={}
+  self.sprockets = {}
+  self.sprocket_ordering = {}
 end
 
---- set the meter of the lattice
--- @tparam number meter the meter the lattice counts
-function Lattice:set_meter(meter)
-  self.meter = meter
+function Lattice:set_meter(_)
+  print("meter is deprecated")
 end
 
 --- use the norns clock to pulse
@@ -88,84 +85,92 @@ end
 function Lattice.auto_pulse(s)
   while true do
     s:pulse()
-    clock.sync(1/s.ppqn)
-  end
-end 
-
---- advance all patterns in this lattice a single by pulse, call this manually if lattice.auto = false
-function Lattice:pulse()
-  if self.enabled then
-    local ppm = self.ppqn * self.meter
-    local flagged=false
-    for _, id in ipairs(self.pattern_ordering) do
-      local pattern=self.patterns[id]
-      if pattern.enabled then
-        pattern.phase = pattern.phase + 1
-        local swing_val = (2*pattern.swing/100)
-        if not pattern.downbeat then 
-          swing_val = 1
-        end
-        if pattern.phase > (pattern.division * ppm)*swing_val then
-          pattern.phase = pattern.phase - (pattern.division * ppm)
-          if pattern.delay_new ~= nil then
-            pattern.phase = pattern.phase - (pattern.division*ppm)*(1-(pattern.delay-pattern.delay_new))
-            pattern.delay = pattern.delay_new
-            pattern.delay_new = nil
-          end
-          pattern.action(self.transport)
-          pattern.downbeat = not pattern.downbeat
-        end
-      elseif pattern.flag then
-        self.patterns[pattern.id] = nil
-	flagged=true
-      end
-    end
-    if flagged then
-       self:order_patterns()
-    end
-    self.transport = self.transport + 1
+    clock.sync(1/s.ppq)
   end
 end
 
---- factory method to add a new pattern to this lattice
+--- advance all sprockets in this lattice a single by pulse, call this manually if lattice.auto = false
+function Lattice:pulse()
+  if self.enabled then
+    local ppc = self.ppq * 4
+    -- prefer "cycle" to "meter"; ppq is a quarter cycle
+    local flagged=false
+    for i = 1, 5 do
+      for _, id in ipairs(self.sprocket_ordering[i]) do
+        local sprocket=self.sprockets[id]
+        if sprocket.enabled then
+          sprocket.phase = sprocket.phase + 1
+          local swing_val = 2 * sprocket.swing / 100
+          if not sprocket.downbeat then
+            swing_val = 1
+          end
+          if sprocket.phase > sprocket.division * ppc * swing_val then
+            sprocket.phase = sprocket.phase - (sprocket.division * ppc)
+            if sprocket.delay_new ~= nil then
+              sprocket.phase = sprocket.phase - (sprocket.division * ppc) * (1 - (sprocket.delay - sprocket.delay_new))
+              sprocket.delay = sprocket.delay_new
+              sprocket.delay_new = nil
+            end
+            sprocket.action(self.transport)
+            sprocket.downbeat = not sprocket.downbeat
+          end
+        elseif sprocket.flag then
+          self.sprockets[sprocket.id] = nil
+          flagged=true
+        end
+      end
+      if flagged then
+         self:order_sprockets()
+      end
+      self.transport = self.transport + 1
+    end
+  end
+end
+
+--- factory method to add a new sprocket to this lattice
 -- @tparam[opt] table args optional named attributes are:
 -- - "action" (function) called on each step of this division (lattice.transport is passed as the argument), defaults to a no-op
--- - "division" (number) the division of the pattern, defaults to 1/4
--- - "enabled" (boolean) is this pattern enabled, defaults to true
+-- - "division" (number) the division of the sprocket, defaults to 1/4
+-- - "enabled" (boolean) is this sprocket enabled, defaults to true
 -- - "swing" (number) is the percentage of swing (0 - 100%), defaults to 50
 -- - "delay" (number) specifies amount of delay, as fraction of division (0.0 - 1.0), defaults to 0
--- @treturn table a new pattern
-function Lattice:new_pattern(args)
-  self.pattern_id_counter = self.pattern_id_counter + 1
-  local args = args == nil and {} or args
-  args.id = self.pattern_id_counter
+-- @treturn table a new sprocket
+function Lattice:new_sprocket(args)
+  self.sprocket_id_counter = self.sprocket_id_counter + 1
+  args = args == nil and {} or args
+  args.id = self.sprocket_id_counter
+  args.priority = args.priority == nil and 3 or util.clamp(args.priority, 1, 5)
   args.action = args.action == nil and function(t) return end or args.action
   args.division = args.division == nil and 1/4 or args.division
   args.enabled = args.enabled == nil and true or args.enabled
-  args.phase = args.division * self.ppqn * self.meter
-  args.swing = args.swing == nil and 50 or args.swing
-  args.delay = args.delay == nil and 0 or args.delay
-  local pattern = Pattern:new(args)
-  self.patterns[self.pattern_id_counter] = pattern
-  self:order_patterns()
-  return pattern
+  args.phase = args.division * self.ppq * 4
+  -- "4" because there are 4 quarters per cycle
+  args.swing = args.swing == nil and 50 or util.clamp(args.swing,0,100)
+  args.delay = args.delay == nil and 0 or util.clamp(args.delay,0,1)
+  local sprocket = Sprocket:new(args)
+  self.sprockets[self.sprocket_id_counter] = sprocket
+  self:order_sprockets()
+  return sprocket
 end
 
--- "private" method to keep numerical order of the pattern ids
+-- "private" method to keep numerical order of the sprocket ids
 -- for use when pulsing
-function Lattice:order_patterns()
-  self.pattern_ordering={}
-  for id, pattern in pairs(self.patterns) do
-	table.insert(self.pattern_ordering,id)
+function Lattice:order_sprockets()
+  self.sprocket_ordering = {{}, {}, {}, {}, {}}
+  for id, sprocket in pairs(self.sprockets) do
+    table.insert(self.sprocket_ordering[sprocket.priority],id)
   end
-  table.sort(self.pattern_ordering)
+  for i = 1, 5 do
+    table.sort(self.sprocket_ordering[i])
+  end
 end
 
---- "private" method to instantiate a new pattern, only called by Lattice:new_pattern()
--- @treturn table a new pattern
-function Pattern:new(args)
-  local p = setmetatable({}, { __index = Pattern })
+--- "private" method to instantiate a new sprocket, only called by Lattice:new_sprocket()
+-- @treturn table a new sprocket
+function Sprocket:new(args)
+  local p = setmetatable({}, { __index = Sprocket })
   p.id = args.id
+  p.priority = args.priority
   p.division = args.division
   p.action = args.action
   p.enabled = args.enabled
@@ -177,48 +182,48 @@ function Pattern:new(args)
   return p
 end
 
---- start the pattern
-function Pattern:start()
+--- start the sprocket
+function Sprocket:start()
   self.enabled = true
 end
 
---- stop the pattern
-function Pattern:stop()
+--- stop the sprocket
+function Sprocket:stop()
   self.enabled = false
 end
 
---- toggle the pattern
-function Pattern:toggle()
+--- toggle the sprocket
+function Sprocket:toggle()
   self.enabled = not self.enabled
 end
 
---- flag the pattern to be destroyed
-function Pattern:destroy()
+--- flag the sprocket to be destroyed
+function Sprocket:destroy()
   self.enabled = false
   self.flag = true
 end
 
---- set the division of the pattern
--- @tparam number n the division of the pattern
-function Pattern:set_division(n)
+--- set the division of the sprocket
+-- @tparam number n the division of the sprocket
+function Sprocket:set_division(n)
    self.division = n
 end
 
---- set the action for this pattern
+--- set the action for this sprocket
 -- @tparam function the action
-function Pattern:set_action(fn)
+function Sprocket:set_action(fn)
   self.action = fn
 end
 
---- set the swing of the pattern
+--- set the swing of the sprocket
 -- @tparam number the swing value 0-100%
-function Pattern:set_swing(swing)
-  self.swing=util.clamp(swing,0,100)
+function Sprocket:set_swing(swing)
+  self.swing = util.clamp(swing,0,100)
 end
 
--- set the delay for this pattern
+-- set the delay for this sprocket
 -- @tparam fraction of the time between beats to delay (0-1)
-function Pattern:set_delay(delay)
+function Sprocket:set_delay(delay)
   self.delay_new = util.clamp(delay,0,1)
 end
 

--- a/lua/lib/lattice.lua
+++ b/lua/lib/lattice.lua
@@ -153,6 +153,11 @@ function Lattice:new_sprocket(args)
   return sprocket
 end
 
+function Lattice:new_pattern(args)
+  print("'new_pattern' is deprecated; use 'new_sprocket' instead.")
+  self:new_sprocket(args)
+end
+
 -- "private" method to keep numerical order of the sprocket ids
 -- for use when pulsing
 function Lattice:order_sprockets()

--- a/lua/lib/lattice.lua
+++ b/lua/lib/lattice.lua
@@ -21,7 +21,7 @@ function Lattice:new(args)
   l.superclock_id = nil
   l.sprocket_id_counter = 100
   l.sprockets = {}
-  l.sprocket_ordering={{}, {}, {}, {}, {}}
+  l.sprocket_ordering = {{}, {}, {}, {}, {}}
   return l
 end
 
@@ -93,11 +93,11 @@ end
 function Lattice:pulse()
   if self.enabled then
     local ppc = self.ppqn * 4
-    -- prefer "cycle" to "meter"; "4" because a "quarter note" is "1/4"
+    -- pulses per cycle; "4" because a "quarter note" is "1/4"
     local flagged=false
     for i = 1, 5 do
       for _, id in ipairs(self.sprocket_ordering[i]) do
-        local sprocket=self.sprockets[id]
+        local sprocket = self.sprockets[id]
         if sprocket.enabled then
           sprocket.phase = sprocket.phase + 1
           local swing_val = 2 * sprocket.swing / 100
@@ -116,7 +116,7 @@ function Lattice:pulse()
           end
         elseif sprocket.flag then
           self.sprockets[sprocket.id] = nil
-          flagged=true
+          flagged = true
         end
       end
       if flagged then
@@ -144,7 +144,7 @@ function Lattice:new_sprocket(args)
   args.division = args.division == nil and 1/4 or args.division
   args.enabled = args.enabled == nil and true or args.enabled
   args.phase = args.division * self.ppqn * 4
-  -- "4" because a quarter note is "1/4"
+  -- "4" because a "quarter note" is "1/4"
   args.swing = args.swing == nil and 50 or util.clamp(args.swing,0,100)
   args.delay = args.delay == nil and 0 or util.clamp(args.delay,0,1)
   local sprocket = Sprocket:new(args)


### PR DESCRIPTION
### Pattern -> Sprocket
In talking with @tyleretters, we felt it would be good to move away from "pattern,"
which implies maybe a bit more structure than something like "sprocket".
A sprocket performs a simple function repeatedly;
more whimsical than "cam" or "cog," which are maybe more accurate.

### Priority
Added an optional "priority" parameter for sprocket creation.
There are 5 levels of priority, with 1 being the highest.
All higher priority sprockets will be triggered in order of creation before lower priority sprockets trigger.

### Remove meter
The inclusion of "meter" seems to add needless complication;
for example I noticed the docs are not correct.
Musically, a "quarter note" is the same speed regardless of whether the meter is divided in four or in five,
but changing the meter parameter on Lattice resulted in different meanings of `division = 1/4`.
For this reason I'd like to enforce `meter = 4` and instead explain in the docs that to achieve,
say, a whole note in 5/4, just do `division = 5/4`.

### Misc style changes
This was the other thing I wanted to accomplish with the PR. Let me know if I'm off-book.