### PR TITLE
send external source tempo to clock.tempo_change_handler

### DIFF
--- a/lua/core/clock.lua
+++ b/lua/core/clock.lua
@@ -315,7 +315,11 @@ function clock.add_params()
     while true do
       if params:get("clock_source") ~= 1 then
         local external_tempo = math.floor(clock.get_tempo() + 0.5)
+        local previous_val = params:get("clock_tempo")
         params:set("clock_tempo", external_tempo, true)
+        if clock.tempo_change_handler ~= nil and previous_val ~= external_tempo then
+          clock.tempo_change_handler(external_tempo)
+        end
       end
 
       clock.sleep(1)


### PR DESCRIPTION
addresses issue #1612

adds a call to the script-defined `clock.tempo_change_handler` function whenever the `clock_tempo` parameter is changed in the parameters from an external source. tested with the snippet included in the issue.