### PR TITLE
fix `_menu.keychar` not getting called

### DIFF
--- a/lua/core/menu.lua
+++ b/lua/core/menu.lua
@@ -241,16 +241,18 @@ function _menu.keycode(c,value)
   end
 
   -- parameter change with +/-
-  if c=="MINUS" then 
-    _menu.penc(3,value*-1) 
-  elseif c=="EQUAL" then 
-    _menu.penc(3,value) 
+  if c=="MINUS" then
+    _menu.penc(3,value*-1)
+  elseif c=="EQUAL" then
+    _menu.penc(3,value)
   end
 
   if _menu.keyboardcode then _menu.keyboardcode(c,value) end
 end
 
-function _menu.keychar(c) end
+function _menu.keychar(c)
+  if _menu.keyboardchar then _menu.keyboardchar(c) end
+end
 
 function _menu.dpad(axis,value)
   if gamepad.down() then


### PR DESCRIPTION
a (sub-)menu can register `_menu.keycode` and `_menu.keychar` callbacks.

before this fix, `_menu.keychar` would never get called.

i discovered it while doing a user interface for a mod (which doesn't rely on the `script` i/o API but the `menu` one).