### PR TITLE
fix undefined `gamepad` when `script.clear` gets called

### DIFF
--- a/lua/core/startup.lua
+++ b/lua/core/startup.lua
@@ -20,6 +20,7 @@ clock = require "core/clock"
 midi = require 'core/midi'
 osc = require 'core/osc'
 keyboard = require 'core/keyboard'
+gamepad = require 'core/gamepad'
 poll = require 'core/poll'
 engine = tab.readonly{table = require 'core/engine', except = {'name'}}
 softcut = require 'core/softcut'


### PR DESCRIPTION
i discovered that https://github.com/monome/norns/pull/1439 introduced this error when `script.clear` gets called.

```
/home/we/norns/lua/core/script.lua:90: attempt to call a nil value (field 'clear')
stack traceback:
	/home/we/norns/lua/core/script.lua:90: in function 'core/script.clear'
	/home/we/norns/lua/core/script.lua:166: in function 'core/script.load'
	(...tail calls...)
```

[corresponding line](https://github.com/monome/norns/blob/487610b28b7d5a876c5df7f58890d58ed3b31605/lua/core/script.lua#L90):

```lua
keyboard.clear()
gamepad.clear()             -- <- culprit
```

the problem was that unlike `keyboard`, `gamepad` was not loaded in the global context.