### PR TITLE
add password length failsafes for WPA-PSK

### DIFF
--- a/lua/core/menu/system.lua
+++ b/lua/core/menu/system.lua
@@ -11,7 +11,7 @@ m.key = function(n,z)
     _menu.set_page("HOME")
   elseif n==3 and z==1 then
     if m.pages[m.pos]=="PASSWORD" then
-      textentry.enter(m.passdone, "", "new password:")
+      textentry.enter(m.passdone, "", "new password:", m.passcheck)
     else
       _menu.set_page(m.pages[m.pos])
     end
@@ -45,21 +45,39 @@ end
 m.init = norns.none
 m.deinit = norns.none
 
+m.passcheck = function(txt)
+  if txt ~= nil then
+    if string.len(txt) < 8 then
+      return ("remaining: "..8 - string.len(txt))
+    elseif string.len(txt) > 63 then
+      return ("too long")
+    end
+  end
+end
+
 m.passdone = function(txt)
   if txt ~= nil then
-    local chpasswd_status = os.execute("echo 'we:"..txt.."' | sudo chpasswd")
-    local smbpasswd_status = os.execute("printf '"..txt.."\n"..txt.."\n' | sudo smbpasswd -a we")
-    local hotspotpasswd_status;
-    local fd = io.open("home/we/norns/.system.hotspot_password", "w+")
-    if fd then
-      io.output(fd)
-      io.write(txt)
-      io.close(fd)
-      hotspotpasswd_status = true
+    if string.len(txt) >= 8 and string.len(txt) < 64 then
+      local chpasswd_status = os.execute("echo 'we:"..txt.."' | sudo chpasswd")
+      local smbpasswd_status = os.execute("printf '"..txt.."\n"..txt.."\n' | sudo smbpasswd -a we")
+      local hotspotpasswd_status;
+      local fd = io.open("home/we/norns/.system.hotspot_password", "w+")
+      if fd then
+        io.output(fd)
+        io.write(txt)
+        io.close(fd)
+        hotspotpasswd_status = true
+      end
+      if chpasswd_status then print("ssh password changed") end
+      if smbpasswd_status then print("samba password changed") end
+      if hotspotpasswd_status then print("hotspot password changed, toggle WIFI off/on to take effect") end
+    elseif string.len(txt) <= 8 then
+      print("!! password must be at least 8 characters !!")
+      print("!! password has not been changed !!")
+    elseif string.len(txt) > 64 then
+      print("!! password cannot be longer than 63 characters !!")
+      print("!! password has not been changed !!")
     end
-    if chpasswd_status then print("ssh password changed") end
-    if smbpasswd_status then print("samba password changed") end
-    if hotspotpasswd_status then print("hotspot password changed, toggle WIFI off/on to take effect") end
   end
   _menu.set_page("SYSTEM")
 end


### PR DESCRIPTION
WPA-PSK requires a sequence between 8 and 63 ASCII characters, so if a user uses this prompt to change their password to something shorter, then they won't be able to access hotspot (due to the conveniences added by https://github.com/monome/norns/pull/1570).

to help guardrail, this commit adds:
- an on-screen `textentry` check which shows a countdown to 8 characters and a warning if the password goes beyond 63
- a character count check to `m.passdone`, which will only change all passwords if the string length is >= 8 and < 64, otherwise it prints warnings to maiden that the password has not been changed

(built after a super helpful troubleshooting support ticket from raja!)