### PR TITLE
lua NRT processing function

### DIFF
--- a/crone/src/BufDiskWorker.cpp
+++ b/crone/src/BufDiskWorker.cpp
@@ -142,7 +142,7 @@ void BufDiskWorker::workLoop() {
                 render(bufs[job.bufIdx[0]], job.startSrc, job.dur, (size_t)job.samples, job.renderCallback);
                 break;
             case JobType::Process:
-                process(bufs[job.bufIdx[0]], job.startSrc, job.dur, job.renderCallback, job.processFunc, job.fadeTime, job.preserve, job.mix);
+                process(bufs[job.bufIdx[0]], job.startSrc, job.dur, job.processFunc, job.doneCallback, job.preserve, job.mix);
                 break;
         }
 #if 0 // debug, timing
@@ -635,5 +635,5 @@ void BufDiskWorker::process(BufDesc &buf, float start, float dur,
         buf.data[frStart] = buf.data[frStart] * preserve + processFunc(i, buf.data[frStart]) * mix;
         frStart++;
     }
-    doneCallback();
+    doneCallback(0);
 }

--- a/crone/src/BufDiskWorker.h
+++ b/crone/src/BufDiskWorker.h
@@ -28,13 +28,15 @@ namespace crone {
     class BufDiskWorker {
     public:
         typedef std::function<void(float secPerSample, float start, size_t count, float* samples)> RenderCallback;
+        typedef std::function<float(int sampleIndex, float inputSample)> ProcessFunc;
+        typedef std::function<void()> DoneCallback;
 
     private:
         enum class JobType {
             Clear, ClearWithFade, Copy,
             ReadMono, ReadStereo,
             WriteMono, WriteStereo,
-            Render,
+            Render, Process,
         };
         struct Job {
             JobType type;
@@ -50,6 +52,8 @@ namespace crone {
             bool reverse;
             int samples;
             RenderCallback renderCallback;
+            ProcessFunc processFunc;
+            DoneCallback doneCallback;
         };
         struct BufDesc {
             float *data;
@@ -115,6 +119,10 @@ namespace crone {
 
         static void requestRender(size_t idx, float start, float dur, int count, RenderCallback callback);
 
+        // process portion of buffer using custom function
+        static void requestProcess(size_t idx, float start, float dur, 
+                                   float preserve, float mix, ProcessFunc process, DoneCallback doneCallback);
+
     private:
         static void workLoop();
 
@@ -141,6 +149,10 @@ namespace crone {
                                       float start = 0, float dur = -1) noexcept;
 
         static void render(BufDesc &buf, float start, float dur, size_t samples, RenderCallback callback);
+
+        static void process(BufDesc &buf, float start, float dur, 
+                            ProcessFunc processFunc, DoneCallback doneCallback, 
+                            float preserve = 0, float mix = 1);
     };
 
 }

--- a/crone/src/BufDiskWorker.h
+++ b/crone/src/BufDiskWorker.h
@@ -29,7 +29,7 @@ namespace crone {
     public:
         typedef std::function<void(float secPerSample, float start, size_t count, float* samples)> RenderCallback;
         typedef std::function<float(int sampleIndex, float inputSample)> ProcessFunc;
-        typedef std::function<void()> DoneCallback;
+        typedef std::function<void(int jobType)> DoneCallback;
 
     private:
         enum class JobType {

--- a/crone/src/BufDiskWorker.h
+++ b/crone/src/BufDiskWorker.h
@@ -28,7 +28,7 @@ namespace crone {
     class BufDiskWorker {
     public:
         typedef std::function<void(float secPerSample, float start, size_t count, float* samples)> RenderCallback;
-        typedef std::function<float(int sampleIndex, float inputSample)> ProcessFunc;
+        typedef std::function<float(size_t sampleIndex, float inputSample)> ProcessFunc;
         typedef std::function<void(int jobType)> DoneCallback;
 
     private:

--- a/crone/src/OscInterface.cpp
+++ b/crone/src/OscInterface.cpp
@@ -798,6 +798,22 @@ void OscInterface::addServerMethods() {
                                      });
     });
 
+    addServerMethod("/softcut/buffer/process", "iffbff", [](lo_arg **argv, int argc) {
+        if (argc < 4) return;
+        int ch = argv[0]->i;
+        float preserve = 0;
+        float mix = 1;
+        float (*process)(size_t, float) = (float (*)(size_t, float))lo_blob_dataptr(argv[3]);
+        if (argc > 4) { preserve = argv[4]->f; }
+        if (argc > 5) { mix = argv[5]->f; } 
+        softCutClient->processBuffer(ch, argv[1]->f, argv[2]->f, preserve, mix,
+                                     [=](size_t sampleIndex, float inputSample){
+                                        return (*process)(sampleIndex, inputSample);
+                                     }, [=](int jobType){
+                                        lo_send(matronAddress, "/softcut/buffer/done_callback", "ii", ch, jobType);
+                                     });
+    });
+
     addServerMethod("/softcut/query/position", "i", [](lo_arg **argv, int argc) {
       if(argc < 1) return;
       int idx = argv[0]->i;

--- a/crone/src/SoftcutClient.h
+++ b/crone/src/SoftcutClient.h
@@ -108,6 +108,12 @@ namespace crone {
             if (chan < 0 || chan > 1 || count < 1) { return; }
             BufDiskWorker::requestRender(bufIdx[chan], start, dur, count, callback);
         }
+        
+        void processBuffer(int chan, float start, float dur, float  preserve, float mix, 
+                           BufDiskWorker::ProcessFunc processFunc, BufDiskWorker::DoneCallback doneCallback) {
+            if (chan < 0 || chan > 1) { return; }
+            BufDiskWorker::requestProcess(chan, start, dur, preserve, mix, processFunc, doneCallback);
+        }
 
         // check if quantized phase has changed for a given voice
         bool checkVoiceQuantPhase(int i) {

--- a/lua/core/norns.lua
+++ b/lua/core/norns.lua
@@ -88,6 +88,8 @@ _norns.vu = function(in1, in2, out1, out2) end
 _norns.softcut_phase = function(id, value) end
 
 _norns.softcut_render = function(ch, start, sec_per_sample, samples) end
+_norns.softcut_process = function(sample_index, current_value) return 0 end
+_norns.softcut_done = function(ch, job_type) end
 _norns.softcut_position = function(i,pos) end
 
 -- default readings for battery

--- a/matron/src/event_types.h
+++ b/matron/src/event_types.h
@@ -92,6 +92,8 @@ typedef enum {
     EVENT_CUSTOM,
     // monome grid tilt
     EVENT_GRID_TILT,
+    // softcut done callback
+    EVENT_SOFTCUT_CALLBACK,
 } event_t;
 
 // a packed data structure for four volume levels
@@ -323,6 +325,12 @@ struct event_softcut_render {
     float* data;
 };
 
+struct event_softcut_callback {
+    struct event_common common;
+    int idx;
+    int job_type;
+};
+
 struct event_softcut_position {
     struct event_common common;
     int idx;
@@ -374,6 +382,7 @@ union event_data {
     struct event_crow_event crow_event;
     struct event_system_cmd system_cmd;
     struct event_softcut_render softcut_render;
+    struct event_softcut_callback softcut_callback;
     struct event_softcut_position softcut_position;
     struct event_custom custom;
 };

--- a/matron/src/events.c
+++ b/matron/src/events.c
@@ -308,6 +308,9 @@ static void handle_event(union event_data *ev) {
     case EVENT_SOFTCUT_RENDER:
         w_handle_softcut_render(ev->softcut_render.idx, ev->softcut_render.sec_per_sample, ev->softcut_render.start, ev->softcut_render.size, ev->softcut_render.data);
         break;
+    case EVENT_SOFTCUT_CALLBACK:
+        w_handle_softcut_done_callback(ev->softcut_callback.idx, ev->softcut_callback.job_type);
+        break;
     case EVENT_SOFTCUT_POSITION:
         w_handle_softcut_position(ev->softcut_position.idx, ev->softcut_position.pos);
         break;

--- a/matron/src/oracle.c
+++ b/matron/src/oracle.c
@@ -852,7 +852,7 @@ int handle_softcut_callback(const char *path, const char *types, lo_arg **argv, 
     assert(argc > 1);
     union event_data *ev = event_data_new(EVENT_SOFTCUT_CALLBACK);
     ev->softcut_callback.idx = argv[0]->i;
-    ev->softcut_callback.jobType = argv[1]->i;
+    ev->softcut_callback.job_type = argv[1]->i;
     event_post(ev);
     return  0;
 }

--- a/matron/src/oracle.c
+++ b/matron/src/oracle.c
@@ -10,12 +10,14 @@
  */
 
 #include <assert.h>
+#include <lo/lo.h>
+#include <lo/lo_serverthread.h>
+#include <lo/lo_types.h>
 #include <pthread.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
-#include <lo/lo.h>
 
 #include "args.h"
 #include "events.h"
@@ -113,6 +115,9 @@ static int handle_poll_softcut_phase(const char *path, const char *types, lo_arg
 static int handle_softcut_render(const char *path, const char *types, lo_arg **argv, int argc,
 				 lo_message data, void *user_data);
 
+static int handle_softcut_callback(const char *path, const char *types, lo_arg **argv, int argc,
+         lo_message data, void *user_data);
+
 static int handle_softcut_position(const char *path, const char *types, lo_arg **argv, int argc,
 				 lo_message data, void *user_data);
 
@@ -185,6 +190,7 @@ void o_init(void) {
 
     // softcut buffer content
     lo_server_thread_add_method(st, "/softcut/buffer/render_callback", "iffb", handle_softcut_render, NULL);
+    lo_server_thread_add_method(st, "/softcut/buffer/done_callback", "ii", handle_softcut_callback, NULL);
     lo_server_thread_add_method(st, "/poll/softcut/position", "if", handle_softcut_position, NULL);
 
     lo_server_thread_start(st);
@@ -606,6 +612,12 @@ void o_cut_buffer_render(int ch, float start, float dur, int samples) {
     lo_send(crone_addr, "/softcut/buffer/render", "iffi", ch, start, dur, samples);
 }
 
+void o_cut_buffer_process(int ch, float start, float dur, float (*process)(size_t, float), float preserve, float mix) {
+    // FIXME: there's no way that this is that easy.
+    lo_blob processfunc = lo_blob_new(sizeof(process), process);
+    lo_send(crone_addr, "/softcut/buffer/process", "iffbff", ch, start, dur, processfunc, preserve, mix);
+}
+
 void o_cut_query_position(int i) {
     lo_send(crone_addr, "/softcut/query/position", "i", i);
 }
@@ -833,6 +845,16 @@ int handle_softcut_render(const char *path, const char *types, lo_arg **argv, in
     memcpy(ev->softcut_render.data, samples, sz);
     event_post(ev);
     return 0;
+}
+
+int handle_softcut_callback(const char *path, const char *types, lo_arg **argv, int argc,
+        lo_message data, void *user_data) {
+    assert(argc > 1);
+    union event_data *ev = event_data_new(EVENT_SOFTCUT_CALLBACK);
+    ev->softcut_callback.idx = argv[0]->i;
+    ev->softcut_callback.jobType = argv[1]->i;
+    event_post(ev);
+    return  0;
 }
 
 int handle_softcut_position(const char *path, const char *types, lo_arg **argv, int argc,

--- a/matron/src/oracle.h
+++ b/matron/src/oracle.h
@@ -144,6 +144,7 @@ extern void o_cut_buffer_read_stereo(char *file, float start_src, float start_ds
 extern void o_cut_buffer_write_mono(char *file, float start, float dur, int ch);
 extern void o_cut_buffer_write_stereo(char *file, float start, float dur);
 extern void o_cut_buffer_render(int ch, float start, float dur, int samples);
+extern void o_cut_buffer_process(int ch, float start, float dur, float (*process)(size_t, float), float preserve, float mix);
 extern void o_cut_query_position(int i);
 extern void o_cut_reset();
 // most softcut parameter changs take single voice index...

--- a/matron/src/weaver.c
+++ b/matron/src/weaver.c
@@ -227,6 +227,7 @@ static int _cut_buffer_read_stereo(lua_State *l);
 static int _cut_buffer_write_mono(lua_State *l);
 static int _cut_buffer_write_stereo(lua_State *l);
 static int _cut_buffer_render(lua_State *l);
+static int _cut_buffer_process(lua_State *l);
 static int _cut_query_position(lua_State *l);
 static int _cut_reset(lua_State *l);
 static int _set_cut_param(lua_State *l);
@@ -409,6 +410,7 @@ void w_init(void) {
     lua_register_norns("cut_buffer_write_mono", &_cut_buffer_write_mono);
     lua_register_norns("cut_buffer_write_stereo", &_cut_buffer_write_stereo);
     lua_register_norns("cut_buffer_render", &_cut_buffer_render);
+    lua_register_norns("cut_buffer_process", &_cut_buffer_process);
     lua_register_norns("cut_query_position", &_cut_query_position);
     lua_register_norns("cut_reset", &_cut_reset);
     lua_register_norns("cut_param", &_set_cut_param);
@@ -2434,6 +2436,13 @@ void w_handle_softcut_render(int idx, float sec_per_sample, float start, size_t 
     l_report(lvm, l_docall(lvm, 4, 0));
 }
 
+void w_handle_softcut_done_callback(int idx) {
+  lua_getglobal(lvm, "_norns");
+  lua_getfield(lvm, -1, "softcut_done_callback");
+  lua_remove(lvm, -2);
+  l_report(lvm, l_docall(lvm, 0, 0));
+}
+
 void w_handle_softcut_position(int idx, float pos) {
     lua_getglobal(lvm, "_norns");
     lua_getfield(lvm, -1, "softcut_position");
@@ -2789,6 +2798,14 @@ int _cut_buffer_render(lua_State *l) {
     int samples = (int)luaL_checknumber(l, 4);
     o_cut_buffer_render(ch, start, dur, samples);
     return 0;
+}
+
+int _cut_buffer_process(lua_State *l) {
+    lua_check_num_args(7);
+    int ch = (int)luaL_checkinteger(l, 1) - 1;
+    float start = (float)luaL_checknumber(l, 2);
+    float dur = (float)luaL_checknumber(l, 3);
+    float (process*)(int, float) = 
 }
 
 int _cut_query_position(lua_State *l) {

--- a/matron/src/weaver.c
+++ b/matron/src/weaver.c
@@ -2436,11 +2436,27 @@ void w_handle_softcut_render(int idx, float sec_per_sample, float start, size_t 
     l_report(lvm, l_docall(lvm, 4, 0));
 }
 
-void w_handle_softcut_done_callback(int idx) {
-  lua_getglobal(lvm, "_norns");
-  lua_getfield(lvm, -1, "softcut_done_callback");
-  lua_remove(lvm, -2);
-  l_report(lvm, l_docall(lvm, 0, 0));
+void w_handle_softcut_done_callback(int idx, int type) {
+    lua_getglobal(lvm, "_norns");
+    lua_getfield(lvm, -1, "softcut_done_callback");
+    lua_remove(lvm, -2);
+    switch (type) {
+        case 0 : 
+            lua_pushstring(lvm, "process");
+            break;
+        default :
+            luaL_error(lvm, "invalid job type");
+    }
+    l_report(lvm, l_docall(lvm, 1, 0));
+}
+
+float w_handle_softcut_process(size_t sample, float datum) {
+    lua_getglobal(lvm, "_norns");
+    lua_getfield(lvm, -1, "softcut_process");
+    lua_remove(lvm, -2);
+    lua_pushnumber(lvm, sample);
+    lua_pushnumber(lvm, datum);
+    return l_docall(lvm, 2, 0);
 }
 
 void w_handle_softcut_position(int idx, float pos) {
@@ -2805,7 +2821,6 @@ int _cut_buffer_process(lua_State *l) {
     int ch = (int)luaL_checkinteger(l, 1) - 1;
     float start = (float)luaL_checknumber(l, 2);
     float dur = (float)luaL_checknumber(l, 3);
-    float (process*)(int, float) = 
 }
 
 int _cut_query_position(lua_State *l) {

--- a/matron/src/weaver.h
+++ b/matron/src/weaver.h
@@ -86,7 +86,8 @@ extern void w_handle_poll_wave(int idx, uint8_t *data);
 extern void w_handle_poll_io_levels(uint8_t *levels);
 extern void w_handle_poll_softcut_phase(int idx, float val);
 extern void w_handle_softcut_render(int idx, float sec_per_sample, float start, size_t size, float* data);
-extern void w_handle_softcut_done_callback(int idx);
+extern void w_handle_softcut_done_callback(int idx, int type);
+extern float w_handle_softcut_process(size_t sample, float datum);
 extern void w_handle_softcut_position(int idx, float pos);
 
 extern void w_handle_engine_loaded();

--- a/matron/src/weaver.h
+++ b/matron/src/weaver.h
@@ -86,6 +86,7 @@ extern void w_handle_poll_wave(int idx, uint8_t *data);
 extern void w_handle_poll_io_levels(uint8_t *levels);
 extern void w_handle_poll_softcut_phase(int idx, float val);
 extern void w_handle_softcut_render(int idx, float sec_per_sample, float start, size_t size, float* data);
+extern void w_handle_softcut_done_callback(int idx);
 extern void w_handle_softcut_position(int idx, float pos);
 
 extern void w_handle_engine_loaded();


### PR DESCRIPTION
This springs from #1623. The idea is to add a new softcut function `process_buffer` that requests `BufDiskWorker` to process a section of a buffer with a lua-defined processing function, and executes a callback when finished.

The challenging part appears to be correctly passing a pointer to `w_handle_softcut_process` across OSC to `BufDiskWorker`. Currently it appears as though `w_handle_softcut_process` is never called, but no error is raised when I check the logs, and the callback never fires.