### PR TITLE
fix lattice transport value getting increased in steps of 5

### DIFF
--- a/lua/lib/lattice.lua
+++ b/lua/lib/lattice.lua
@@ -118,9 +118,9 @@ function Lattice:pulse()
           flagged = true
         end
       end
-      if flagged then
-         self:order_sprockets()
-      end
+    end
+    if flagged then
+      self:order_sprockets()
     end
     self.transport = self.transport + 1
   end

--- a/lua/lib/lattice.lua
+++ b/lua/lib/lattice.lua
@@ -121,8 +121,8 @@ function Lattice:pulse()
       if flagged then
          self:order_sprockets()
       end
-      self.transport = self.transport + 1
     end
+    self.transport = self.transport + 1
   end
 end
 


### PR DESCRIPTION
Here's the corresponding issue: #1637

Lattice transport values should be increased outside the for-loop. 
In the current state, the transport values are increased in steps of 5, due to the sprocket ordering logic.