### PR TITLE
allow sending midi clock to all devices simultaneously

### DIFF
--- a/lua/core/clock.lua
+++ b/lua/core/clock.lua
@@ -248,10 +248,10 @@ function clock.add_params()
       norns.state.clock.link_start_stop_sync = x
     end)
   params:set_save("link_start_stop_sync", false)
-  local clock_table = {"off"}
+  local clock_table = {"off","all"}
   for i = 1,16 do
     local short_name = string.len(midi.vports[i].name) < 12 and midi.vports[i].name or util.acronym(midi.vports[i].name)
-    clock_table[i+1] = "port "..(i)..""..(midi.vports[i].name ~= "none" and (": "..short_name) or "")
+    clock_table[i+2] = "port "..(i)..""..(midi.vports[i].name ~= "none" and (": "..short_name) or "")
   end
   params:add_option("clock_midi_out", "midi out",
       clock_table, norns.state.clock.midi_out)
@@ -301,10 +301,17 @@ function clock.add_params()
   clock.run(function()
     while true do
       clock.sync(1/24)
-      local midi_out = params:get("clock_midi_out")-1
-      if midi_out > 0 then
-        if midi.vports[midi_out].name ~= "none" then
-          midi.vports[midi_out]:clock()
+			local midi_out = params:get("clock_midi_out")
+			if midi_out == 2 then -- "all"
+				for i=1,16 do
+					if midi.vports[i].name ~= "none" then
+						midi.vports[i]:clock()
+						-- print('sending clock to port'..i)
+					end
+				end
+			elseif midi_out > 2 then  
+        if midi.vports[midi_out-2].name ~= "none" then
+          midi.vports[midi_out-2]:clock()	
         end
       end
     end

--- a/lua/core/clock.lua
+++ b/lua/core/clock.lua
@@ -253,8 +253,8 @@ function clock.add_params()
   params:set_save("link_start_stop_sync", false)
   params:add_separator("midi_clock_out", "midi clock out")
   for i = 1,16 do
-    local short_name = string.len(midi.vports[i].name) < 12 and midi.vports[i].name or util.acronym(midi.vports[i].name)
-    params:add_binary("clock_midi_out_"..i, "port "..i..": "..short_name, "toggle", norns.state.clock.midi_out[i])
+    local short_name = string.len(midi.vports[i].name) <= 20 and midi.vports[i].name or util.acronym(midi.vports[i].name)
+    params:add_binary("clock_midi_out_"..i, i..". "..short_name, "toggle", norns.state.clock.midi_out[i])
     params:set_action("clock_midi_out_"..i,
       function(x)
         if x == 1 then

--- a/lua/core/clock.lua
+++ b/lua/core/clock.lua
@@ -12,6 +12,8 @@ local function new_id()
   return id
 end
 
+local send_midi_clock = {}
+
 --- create and start a coroutine using the norns clock scheduler.
 -- @tparam function f coroutine body function
 -- @param[opt] ... any extra arguments will be passed to the body function
@@ -200,7 +202,7 @@ end
 
 
 function clock.add_params()
-  params:add_group("CLOCK", 9)
+  params:add_group("CLOCK", 27)
 
   params:add_option("clock_source", "source", {"internal", "midi", "link", "crow"},
     norns.state.clock.source)
@@ -234,6 +236,7 @@ function clock.add_params()
       if source == "internal" then clock.internal.start()
       elseif source == "link" then print("link reset not supported") end
     end)
+  params:add_separator("link_separator", "link")
   params:add_number("link_quantum", "link quantum", 1, 32, norns.state.clock.link_quantum)
   params:set_action("link_quantum",
     function(x)
@@ -248,15 +251,31 @@ function clock.add_params()
       norns.state.clock.link_start_stop_sync = x
     end)
   params:set_save("link_start_stop_sync", false)
-  local clock_table = {"off","all"}
+  params:add_separator("midi_clock_out", "midi clock out")
   for i = 1,16 do
     local short_name = string.len(midi.vports[i].name) < 12 and midi.vports[i].name or util.acronym(midi.vports[i].name)
-    clock_table[i+2] = "port "..(i)..""..(midi.vports[i].name ~= "none" and (": "..short_name) or "")
+    params:add_binary("clock_midi_out_"..i, "port "..i..": "..short_name, "toggle", norns.state.clock.midi_out[i])
+    params:set_action("clock_midi_out_"..i,
+      function(x)
+        if x == 1 then
+          table.insert(send_midi_clock,i)
+        else
+          if tab.contains(send_midi_clock,i) then
+            table.remove(send_midi_clock,tab.key(send_midi_clock, i))
+          end
+        end
+        norns.state.clock.midi_out[i] = x
+      end
+    )
+    if short_name ~= "none" and midi.vports[i].connected then
+      params:show("clock_midi_out_"..i)
+    else
+      params:hide("clock_midi_out_"..i)
+    end
+    params:set_save("clock_midi_out_"..i, false)
   end
-  params:add_option("clock_midi_out", "midi out",
-      clock_table, norns.state.clock.midi_out)
-  params:set_action("clock_midi_out", function(x) norns.state.clock.midi_out = x end)
-  params:set_save("clock_midi_out", false)
+  _menu.rebuild_params()
+  params:add_separator("crow_clock_out", "crow clock out")
   params:add_option("clock_crow_out", "crow out",
       {"off", "output 1", "output 2", "output 3", "output 4"}, norns.state.clock.crow_out)
   params:set_action("clock_crow_out", function(x)
@@ -301,18 +320,9 @@ function clock.add_params()
   clock.run(function()
     while true do
       clock.sync(1/24)
-			local midi_out = params:get("clock_midi_out")
-			if midi_out == 2 then -- "all"
-				for i=1,16 do
-					if midi.vports[i].name ~= "none" then
-						midi.vports[i]:clock()
-						-- print('sending clock to port'..i)
-					end
-				end
-			elseif midi_out > 2 then  
-        if midi.vports[midi_out-2].name ~= "none" then
-          midi.vports[midi_out-2]:clock()	
-        end
+      for i = 1,#send_midi_clock do
+        local port = send_midi_clock[i]
+        midi.vports[port]:clock()
       end
     end
   end)

--- a/lua/core/midi.lua
+++ b/lua/core/midi.lua
@@ -385,8 +385,8 @@ function Midi.update_connected_state()
       Midi.vports[i].connected = false 
     end
     if params.lookup["clock_midi_out_"..i] ~= nil then
-      local short_name = string.len(midi.vports[i].name) < 12 and midi.vports[i].name or util.acronym(midi.vports[i].name)
-      params:lookup_param("clock_midi_out_"..i).name = "port "..i..": "..short_name
+      local short_name = string.len(midi.vports[i].name) <= 20 and midi.vports[i].name or util.acronym(midi.vports[i].name)
+      params:lookup_param("clock_midi_out_"..i).name = i..". "..short_name
       if short_name ~= "none" and midi.vports[i].connected then
         params:show("clock_midi_out_"..i)
       else

--- a/lua/core/midi.lua
+++ b/lua/core/midi.lua
@@ -384,7 +384,18 @@ function Midi.update_connected_state()
     else
       Midi.vports[i].connected = false 
     end
+    if params.lookup["clock_midi_out_"..i] ~= nil then
+      local short_name = string.len(midi.vports[i].name) < 12 and midi.vports[i].name or util.acronym(midi.vports[i].name)
+      params:lookup_param("clock_midi_out_"..i).name = "port "..i..": "..short_name
+      if short_name ~= "none" and midi.vports[i].connected then
+        params:show("clock_midi_out_"..i)
+      else
+        params:set("clock_midi_out_"..i,0)
+        params:hide("clock_midi_out_"..i)
+      end
+    end
   end
+  _menu.rebuild_params()
 end
 
 -- add a device.

--- a/lua/core/state.lua
+++ b/lua/core/state.lua
@@ -48,7 +48,7 @@ state.clock.source = 1
 state.clock.tempo = 90
 state.clock.link_quantum = 4
 state.clock.link_start_stop_sync = 1
-state.clock.midi_out = 1
+state.clock.midi_out = {}
 state.clock.crow_out = 1
 state.clock.crow_out_div = 4
 state.clock.crow_in_div = 4
@@ -60,6 +60,12 @@ state.resume = function()
   if f ~= nil then
     io.close(f)
     dofile(_path.data..'system.state')
+  end
+
+  -- if previously-saved state.clock.midi_out is a number,
+  -- make it a table
+  if type(state.clock.midi_out) == 'number' then
+    state.clock.midi_out = {}
   end
 
   -- update vports
@@ -139,7 +145,9 @@ state.save_state = function()
   io.write("norns.state.clock.tempo = " .. norns.state.clock.tempo .. "\n")
   io.write("norns.state.clock.link_quantum = " .. norns.state.clock.link_quantum .. "\n")
   io.write("norns.state.clock.link_start_stop_sync = " .. norns.state.clock.link_start_stop_sync .. "\n")
-  io.write("norns.state.clock.midi_out = " .. norns.state.clock.midi_out .. "\n")
+  for i = 1,16 do
+    io.write("norns.state.clock.midi_out["..i.."] = " .. norns.state.clock.midi_out[i] .. "\n")
+  end
   io.write("norns.state.clock.crow_out = " .. norns.state.clock.crow_out .. "\n")
   io.write("norns.state.clock.crow_out_div = " .. norns.state.clock.crow_out_div .. "\n")
   io.write("norns.state.clock.crow_in_div = " .. norns.state.clock.crow_in_div .. "\n")


### PR DESCRIPTION
Added an option to the "midi clock" param under `clock.lua`, "all", which sends clock to every device whose name isn't "none".