### PR TITLE
clean up script-defined `osc.event` callbacks between scripts

### DIFF
--- a/lua/core/osc.lua
+++ b/lua/core/osc.lua
@@ -42,6 +42,11 @@ function OSC.send_crone(path, args)
   end
 end
 
+--- clear handlers.
+function OSC.cleanup()
+  OSC.event = nil
+end
+
 local function param_handler(path, args)
   local address_parts = {}
   local osc_pset_id = ""

--- a/lua/core/script.lua
+++ b/lua/core/script.lua
@@ -63,6 +63,7 @@ Script.clear = function()
   arc.cleanup()
   midi.cleanup()
   hid.cleanup()
+  osc.cleanup()
 
   -- stop all timers
   metro.free_all()


### PR DESCRIPTION
currently, if a script defines an [`osc.event` callback](https://github.com/monome/norns/blob/main/lua/core/osc.lua#L11-L20), this persists past the script's lifecycle.

<details>
<summary>issue reported from @jaseknighter via discord + confirmed with the following snippet</summary>

```lua
-- test 1
function osc.event(path,args,from)
  print("hello from osc")
end
```

sending `/param/clock_tempo 90` from Max prints the following to matron:
```bash
hello from osc
setting parameter /clock_tempo to 90
```

loading a new script does not clear the custom print, eg:
```lua
-- test 2
function init()
  print('this is a new script, i should not remember to say hello!')
end
```

prints _both_ of the same messages as the previous snippet when it receives `/param/clock_tempo 90` from Max .
</details>

this PR makes the scripting process work as expected, where script-scope `osc.event` definitions do not persist past the script's life.