### PR TITLE
Make maiden-repl compile on macOS 13.1 Ventura

### DIFF
--- a/maiden-repl/CMakeLists.txt
+++ b/maiden-repl/CMakeLists.txt
@@ -15,22 +15,22 @@ add_executable(maiden-repl ${SRC})
 
 if(UNIX)
     if(APPLE)
-        find_library(pthread libpthread.dylib REQUIRED)
         find_library(readline libreadline.dylib
             NO_DEFAULT_PATH
             HINTS
-                /usr/local/opt/readline/lib
+                /opt/homebrew/opt/readline/lib
             REQUIRED)
-        find_library(nanomsg libnanomsg.dylib REQUIRED)
-        find_library(ncurses libcurses.dylib REQUIRED)
-        find_library(panel libpanel.dylib REQUIRED)
+        find_library(nanomsg libnanomsg.dylib
+        NO_DEFAULT_PATH
+            HINTS
+        /opt/homebrew/opt/nanomsg/lib
+            REQUIRED)
         target_link_libraries(maiden-repl
-            ${pthread}
             ${readline}
-            ${ncurses}
-            ${panel}
+            ncurses
+            panel
             ${nanomsg})
-        include_directories(/usr/local/include /usr/local/opt/readline/include)
+        include_directories(/usr/local/include /opt/homebrew/opt/nanomsg/include /opt/homebrew/opt/readline/include)
     else()
         set(CURSES_NEED_NCURSES TRUE)
         set(CURSES_NEED_WIDE TRUE) # Required for unicode

--- a/maiden-repl/README.md
+++ b/maiden-repl/README.md
@@ -31,7 +31,7 @@ building
 `maiden-repl` is known to build on:
 * monome norns, norns shield os images
 * linux (debian buster)
-* macOS (10.14 Mojave)
+* macOS (13.1 Ventura)
 
 when building directly on a norns device `maiden-repl` should be built by
 default as part of the `waf` based build system for the full norns software


### PR DESCRIPTION
I've updated the cmake build settings to work with latest macOS (and homebrew paths).
