### PR TITLE
clean up device callbacks

### DIFF
--- a/lua/core/arc.lua
+++ b/lua/core/arc.lua
@@ -157,6 +157,12 @@ function Arc.cleanup()
     dev.delta = nil
     dev.key = nil
   end
+
+  Arc.add = function(dev)
+    print("arc added:", dev.id, dev.name, dev.serial)
+  end
+
+  Arc.remove = function(dev) end
 end
 
 -- @static

--- a/lua/core/grid.lua
+++ b/lua/core/grid.lua
@@ -144,6 +144,12 @@ function Grid.cleanup()
     dev.key = nil
     dev.tilt = nil
   end
+
+  Grid.add = function(dev)
+    print("grid added:", dev.id, dev.name, dev.serial)
+  end
+
+  Grid.remove = function(dev) end
 end
 
 -- update devices.

--- a/lua/core/hid.lua
+++ b/lua/core/hid.lua
@@ -87,7 +87,6 @@ function Hid.add(dev)
   if dev.is_ascii_keyboard then print("this appears to be an ASCII keyboard!") end
   if dev.is_mouse then print("this appears to be a mouse!") end
   if dev.is_gamepad then print("this appears to be a gamepad!") end
-
 end
 
 --- static callback when any hid device is removed;
@@ -95,7 +94,6 @@ end
 -- @static
 -- @param dev : a Hid table
 function Hid.remove(dev) end
-
 
 --- create device, returns object with handler and send
 -- @static
@@ -115,6 +113,15 @@ function Hid.cleanup()
   for _, dev in pairs(Hid.devices) do
     dev.event = nil
   end
+
+  Hid.add = function(dev)
+    print("HID device was added:", dev.id, dev.name)
+    if dev.is_ascii_keyboard then print("this appears to be an ASCII keyboard!") end
+    if dev.is_mouse then print("this appears to be a mouse!") end
+    if dev.is_gamepad then print("this appears to be a gamepad!") end
+  end
+
+  Hid.remove = function(dev) end
 end
 
 function Hid.update_devices()

--- a/lua/core/midi.lua
+++ b/lua/core/midi.lua
@@ -191,6 +191,9 @@ function Midi.cleanup()
   for _, dev in pairs(Midi.devices) do
     dev.event = nil
   end
+
+  Midi.add = function(dev) end
+  Midi.remove = function(dev) end
 end
 
 -- utility


### PR DESCRIPTION
related to https://github.com/monome/norns/pull/1643, i noticed that script-defined grid, arc, MIDI and HID add/remove callbacks were persisting past script life.

<details>
<summary>test scripts</summary>

```lua
-- all the device add/remove callbacks!
-- each persists into a new script load

function midi.add(dev)
  print('custom midi add callback!')
end

function midi.remove(dev)
  print('custom midi remove callback!')
end

function grid.add(dev)
  print('custom grid add callback!')
end

function grid.remove(dev)
  print('custom grid remove callback!')
end

function arc.add(dev)
  print('custom arc add callback!')
end

function arc.remove(dev)
  print('custom arc remove callback!')
end

function hid.add(dev)
  print('custom HID add callback!')
end

function hid.remove(dev)
  print('custom HID remove callback!')
end
```

then run a new script, eg.
```
function init()
  print('new script, shouldn't remember callbacks')
end
```
</details>

with these changes, each device add/remove resets to the initial state with each new `script.lua` invocation.