### PR TITLE
Remove error from unknown key press

### DIFF
--- a/lua/core/keyboard.lua
+++ b/lua/core/keyboard.lua
@@ -113,6 +113,9 @@ function keyboard.meta()
 
 function keyboard.process(type,code,value)
   local c = keyboard.codes[code]
+  if c == nil then
+    return
+  end
 
   -- textentry keycode
   if te_kbd_cb.code then


### PR DESCRIPTION
This fixes a problem in which a (typing) keyboard can generate an unrecognised code, resulting in a Lua error in the norns libraries, and possibly in a user script, too.

I recently reported - wrongly - an error with the zxcvbn script. You can [see the details here](https://github.com/schollz/zxcvbn/issues/25). The core of the problem is that I have a keyboard which generates errors when some function keys are pressed, as seen here in maiden:

```
lua: 
/home/we/norns/lua/core/keyboard.lua:132: table index is nil
stack traceback:
	/home/we/norns/lua/core/keyboard.lua:132: in function 'core/keyboard.process'
	/home/we/norns/lua/core/hid.lua:177: in function </home/we/norns/lua/core/hid.lua:162>
```

This is because when some keys are pressed they generate unlisted [codes](https://github.com/monome/norns/blob/main/lua/core/keyboard.lua#L155). As a result variable `c` is unexpectedly nil and there is [an error here](https://github.com/monome/norns/blob/main/lua/core/keyboard.lua#L155).

Additionally, anyone overriding [`keyboard.code()`](https://github.com/monome/norns/blob/main/lua/core/keyboard.lua#L93) may unexpectedly receive a nil value as the first argument and not handle that. That is the case for zxcvbn.

The proposed change seems to fix this. I've only got one keyboard to check against ([this one](https://www.keychron.uk/products/keychron-k8-wireless-mechanical-keyboard-uk-iso-layout), with an ISO layout), but it has a physical switch to switch between MacOS mode and Windows/Android mode, and it seems to work for both modes.