### PR TITLE
Implement character/key conversion

### DIFF
--- a/lua/core/keyboard.lua
+++ b/lua/core/keyboard.lua
@@ -173,33 +173,13 @@ end
 -- @treturn string    a string, or nil if no conversion is possible.
 --
 function keyboard.code_to_char(code)
-  if code == nil then return end
+  if code == nil then return nil end
 
   local c_mods = char_modifier.NONE
   if keyboard.shift() then c_mods = c_mods | char_modifier.SHIFT end
   if keyboard.altgr() then c_mods = c_mods | char_modifier.ALTGR end
 
   return km[c_mods][code]
-end
-
--- Invert the key map for chart_to_code.
-
-local ikm = {}
-for modifier in pairs(km) do
-  for code in pairs(km[modifier]) do
-    ikm[km[modifier][code]] = code
-  end
-end
-
---- for a given printable keyboard character return a code representing
--- the physical keyboard key.
--- @tparam string ch    a single character string, of the sort passed into
---     @{char}.
--- @treturn string    a string symbol representing the key, as used by
---     @{code}, or nil if no conversion is possible.
---
-function keyboard.char_to_code(ch)
-  return ch and ikm[ch]
 end
 
 keyboard.codes = {}


### PR DESCRIPTION
As discussed in #1657, enable developers to work with printable characters from within `keyboard.code()`, plus supporting documentation.
- Includes new function `keyboard.code_to_char()`. 
- Includes a new function `keyboard.char_to_code()`.
- Replaced some code from `keyboard.process()`, to use `code_to_char()` - which just uses that original code.

I suggest further discussion on this topic takes place here, not in the originating issue.

This PR does not include updates to the `docs/` directory because when I generated the docs it made too many changes (most notably updating every external reference in the docs to the Lua 5.3 manual). I presume the docs will be generated before an official release. However, I have tested locally using `ldoc`.

This PR does not include the suggested `keyboard.char_lift()` as it duplicates functionality (a bit) and I thought it might just be too much.

I have tested this manually using [the script over here](https://github.com/niksilver/norns-kcode-test) which can be installed via the maiden REPL using
```
;install https://github.com/niksilver/norns-kcode-test
```