### PR TITLE
Update docs for screen.fill() and screen.stroke()

### DIFF
--- a/lua/core/screen.lua
+++ b/lua/core/screen.lua
@@ -141,10 +141,16 @@ Screen.close = function() _norns.screen_close() end
 
 --- stroke current path.
 -- uses currently selected color.
+-- after this call the current path will be cleared, so the 'relative' functions
+-- (`move_rel`, `line_rel` and `curve_rel`) won't work - use their absolute
+-- alternatives instead.
 Screen.stroke = function() _norns.screen_stroke() end
 
 --- fill current path.
 -- uses currently selected color.
+-- after this call the current path will be cleared, so the 'relative' functions
+-- (`move_rel`, `line_rel` and `curve_rel`) won't work - use their absolute
+-- alternatives instead.
 Screen.fill = function() _norns.screen_fill() end
 
 --- draw text (left aligned).


### PR DESCRIPTION
Not knowing this foxed me for a good couple of hours, so adding it here to help others.

The source of this info is in the Cairo documentation for its [fill](https://www.cairographics.org/manual/cairo-cairo-t.html#cairo-fill) and [stroke](https://www.cairographics.org/manual/cairo-cairo-t.html#cairo-stroke) calls.