### PR TITLE
refresh 'send_midi_clock' table with 'clock:add_params()'

### DIFF
--- a/lua/core/clock.lua
+++ b/lua/core/clock.lua
@@ -12,8 +12,6 @@ local function new_id()
   return id
 end
 
-local send_midi_clock = {}
-
 --- create and start a coroutine using the norns clock scheduler.
 -- @tparam function f coroutine body function
 -- @param[opt] ... any extra arguments will be passed to the body function
@@ -202,6 +200,7 @@ end
 
 
 function clock.add_params()
+  local send_midi_clock = {}
   params:add_group("CLOCK", 27)
 
   params:add_option("clock_source", "source", {"internal", "midi", "link", "crow"},


### PR DESCRIPTION
during release testing, i realized that after my ~40th script load, `clock.sync` calls were off by a tenth of a beat, compounding as i continued to load scripts.

i started rolling back through commits and when i verified that b932b0d sparked the issue's emergence, i realized that the `send_midi_clock` table was being added to each time `clock.add_params()` was called, but never emptied out. so, eventually, the clock was doing 24ppqn calls on a table with *tons* of entries.

i guess nice to accidentally stress-test that a lot of devices could receive MIDI clock before timing issues emerged? anyway, fixed now!