### PR TITLE
norns.expand_filesystem()

### DIFF
--- a/lua/core/norns.lua
+++ b/lua/core/norns.lua
@@ -260,3 +260,13 @@ end
 norns.rerun = function()
   norns.script.load(norns.state.script)
 end
+
+-- expand the filesystem after a fresh installation
+norns.expand_filesystem = function()
+  if string.match(util.os_capture("cat /proc/device-tree/model"), "Raspberry Pi Compute Module 3 Rev 1.0") then 
+    print('4gb CM3; will not expand')
+  else
+    local next = norns.is_shield and 'expanding filesystem; unit will restart after' or 'expanding filesystem; unit will shut down after'
+    _norns.system_cmd('sudo raspi-config --expand-rootfs; sudo shutdown -r now', print(next))
+  end
+end

--- a/lua/core/norns.lua
+++ b/lua/core/norns.lua
@@ -263,10 +263,5 @@ end
 
 -- expand the filesystem after a fresh installation
 norns.expand_filesystem = function()
-  if string.match(util.os_capture("cat /proc/device-tree/model"), "Raspberry Pi Compute Module 3 Rev 1.0") then 
-    print('4gb CM3; will not expand')
-  else
-    local next = norns.is_shield and 'expanding filesystem; unit will restart after' or 'expanding filesystem; unit will shut down after'
-    _norns.system_cmd('sudo raspi-config --expand-rootfs; sudo shutdown -r now', print(next))
-  end
+  os.execute('sudo raspi-config --expand-rootfs')
 end


### PR DESCRIPTION
`norns.` helper to avoid [all of these steps](https://monome.org/docs/norns/help/#expanding-storage) after fresh installing.
if 4gb cm3 is installed, expand does not occur and prints a message to matron.