### PR TITLE
allow user to add gamepad profiles without tempering w/ core

### DIFF
--- a/lua/core/gamepad_model/index.lua
+++ b/lua/core/gamepad_model/index.lua
@@ -9,11 +9,11 @@ models['030000005e0400008e02000014010000'] = require 'gamepad_model/xbox_360'
 local user_conf_dir = _path.data .. "gamepads/"
 if util.file_exists(user_conf_dir) then
   local user_confs = util.scandir(user_conf_dir)
-  for _, conf in pairs(user_confs) do
+  for _, conf_file in pairs(user_confs) do
     if conf:sub(-#'.lua') == '.lua' then
-      local conf_sans_ext = conf:gsub("%.lua", "")
-      print("loading user gamepad conf: "..user_conf_dir..conf)
-      local module_path = user_conf_dir .. conf_sans_ext
+      local conf_file_sans_ext = conf_file:gsub("%.lua", "")
+      print("loading user gamepad conf: "..user_conf_dir..conf_file)
+      local module_path = user_conf_dir .. conf_file_sans_ext
       local user_conf = require(module_path)
       models[user_conf.guid] = user_conf
     end

--- a/lua/core/gamepad_model/index.lua
+++ b/lua/core/gamepad_model/index.lua
@@ -1,7 +1,23 @@
 
 local models = {}
 
+-- bundled w/ core
 models['03000000830500006020000010010000'] = require 'gamepad_model/ibufalo_classic_usb'
 models['030000005e0400008e02000014010000'] = require 'gamepad_model/xbox_360'
+
+-- user-local
+local user_conf_dir = _path.data .. "gamepads/"
+if util.file_exists(user_conf_dir) then
+  local user_confs = util.scandir(user_conf_dir)
+  for _, conf in pairs(user_confs) do
+    if conf:sub(-#'.lua') == '.lua' then
+      local conf_sans_ext = conf:gsub("%.lua", "")
+      print("loading user gamepad conf: "..user_conf_dir..conf)
+      local module_path = user_conf_dir .. conf_sans_ext
+      local user_conf = require(module_path)
+      models[user_conf.guid] = user_conf
+    end
+  end
+end
 
 return models


### PR DESCRIPTION
so rn only 2 gamepad models are suported natively (profile bundled w/ norns core).

i made a [small norns script](https://github.com/p3r7/gamepad_wiz) that allows one to generate profile from a pluggued in gamepad and output it under `~/we/dust/data/gamepads/`.

this PR enables sourcing those user-level profiles dynamically.

2 qs:
- is this a sane approach?
- what about the name / location of the user's gamepad profile (`~/we/dust/data/gamepads/`)?