### PR TITLE
fix: K3 on BATTERY WARNING

### DIFF
--- a/lua/core/menu/settings.lua
+++ b/lua/core/menu/settings.lua
@@ -10,10 +10,10 @@ m.key = function(n,z)
   if n==2 and z==1 then
     _menu.set_page("SYSTEM")
   elseif n==3 and z==1 then
-    if m.pages[m.pos]=="PASSWORD" then
+    if m.pages[m.pos]=="RESET" then
+      _menu.set_page("RESET")
+    elseif m.pages[m.pos]=="PASSWORD" then
       textentry.enter(m.passdone, "", "new password:", m.passcheck)
-    else
-      _menu.set_page(m.pages[m.pos])
     end
   end
 end
@@ -89,6 +89,5 @@ m.passdone = function(txt)
   end
   _menu.set_page("SETTINGS")
 end
-
 
 return m


### PR DESCRIPTION
fixes #1674

`SETTINGS` has two groups of entries -- `list` (`{"RESET", "PASSWORD >", "BATTERY WARNING"}`) and `pages` (`{"RESET", "PASSWORD"}`).

since `enc` turns increment `m.pos` by the number of `list` entries, hitting K3 on `BATTERY WARNING` tries to index `pages` with a non-existent entry. this fix specifies that K3 should only have an affect if `"RESET"` or `"PASSWORD"` are selected.