### PR TITLE
small fixes: softcut API

### DIFF
--- a/lua/core/softcut.lua
+++ b/lua/core/softcut.lua
@@ -85,8 +85,8 @@ SC.loop = function(voice,state) _norns.cut_param("loop_flag",voice,state) end
 
 --- set fade time.
 -- @tparam int voice : voice index
--- @tparam number pos : crossfade time in seconds
-SC.fade_time = function(voice,pos) _norns.cut_param("fade_time",voice,pos) end
+-- @tparam number fade_time : crossfade time in seconds
+SC.fade_time = function(voice,fade_time) _norns.cut_param("fade_time",voice,fade_time) end
 
 --- set record level.
 -- this sets the realtime-modulated record level,

--- a/lua/core/softcut.lua
+++ b/lua/core/softcut.lua
@@ -120,10 +120,10 @@ SC.buffer = function(i,b) _norns.cut_param_ii("buffer",i,b) end
 
 --- synchronize two voices.
 --- position of "dst" will be immediately set to that of "source"
--- @tparam int src : source voice index
 -- @tparam int dst : destination voice index
+-- @tparam int src : source voice index
 -- @tparam number offset : additional offset in seconds
-SC.voice_sync = function(src, dst, offset) _norns.cut_param_iif("voice_sync",src,dst,offset) end
+SC.voice_sync = function(dst, src, offset) _norns.cut_param_iif("voice_sync",dst,src,offset) end
 
 --- set pre_filter cutoff frequency.
 --- @tparam int voice : voice index

--- a/lua/core/softcut.lua
+++ b/lua/core/softcut.lua
@@ -85,7 +85,7 @@ SC.loop = function(voice,state) _norns.cut_param("loop_flag",voice,state) end
 
 --- set fade time.
 -- @tparam int voice : voice index
--- @tparam number pos : loop start position in seconds
+-- @tparam number pos : crossfade time in seconds
 SC.fade_time = function(voice,pos) _norns.cut_param("fade_time",voice,pos) end
 
 --- set record level.


### PR DESCRIPTION
softcut's `voice_sync` command has its arguments reversed in the API docs.

[current documentation](https://monome.org/docs/norns/api/modules/softcut.html#voice_sync): `voice_sync (src, dst, offset)`
[source](https://github.com/monome/softcut-lib/blob/57fb9877e13b991aa642246ced70e7fff00c5b1b/softcut-lib/include/softcut/Softcut.h#L176-L178): `syncVoice(int follow, int lead, float offset)`

(@tehn , this'll need a docs re-gen!)