### PR TITLE
fileselect: handle '...' display names

### DIFF
--- a/lua/lib/fileselect.lua
+++ b/lua/lib/fileselect.lua
@@ -142,7 +142,11 @@ fs.key = function(n,z)
       fs.redraw()
     end
     if #fs.list > 0 then
-      fs.file = fs.display_list[fs.pos+1]
+      if string.sub(fs.display_list[fs.pos+1], -3) == '...' then
+        fs.file = fs.list[fs.pos+1]
+      else
+        fs.file = fs.display_list[fs.pos+1]
+      end
       if fs.file == "../" then
         fs.folders[fs.depth] = nil
         fs.depth = fs.depth - 1


### PR DESCRIPTION
ah! i had totally spaced on the auto-shortening of long filenames by appending '...', which confused the "is this a file or is this a folder?" mechanism! #1681 is now fixed + and i will ask for community testing!