### PR TITLE
Ensure that disk field can represent size of larger sd cards

### DIFF
--- a/matron/src/event_types.h
+++ b/matron/src/event_types.h
@@ -238,7 +238,7 @@ struct event_power {
 
 struct event_stat {
     struct event_common common;
-    uint16_t disk;
+    uint32_t disk;
     uint8_t temp;
     uint8_t cpu;
     uint8_t cpu1;


### PR DESCRIPTION
Closes #1689 

The integer representing the disk size is getting truncated.

Uncommenting [the `fprintf` in `matron/src/hardware/stat.c`](https://github.com/monome/norns/blob/c5adf1cb64184c48c429c7b6c9fb9e90f2833d86/matron/src/hardware/stat.c#L74) shows the correct disk size in `/var/log/daemon.log`. 

This value is [assigned to the `ev->stat.disk` field](https://github.com/monome/norns/blob/c5adf1cb64184c48c429c7b6c9fb9e90f2833d86/matron/src/hardware/stat.c#L133), which is only [a `uint16_t`](https://github.com/monome/norns/blob/c5adf1cb64184c48c429c7b6c9fb9e90f2833d86/matron/src/event_types.h#L241).

However, in `weaver.c`, the `disk` value is [expected to be a `uint32_t`](https://github.com/monome/norns/blob/c5adf1cb64184c48c429c7b6c9fb9e90f2833d86/matron/src/weaver.c#L2373).

This fix changes the size of the `disk` field to `uint32_t` in  `event_types.h` so that the entire integer value is intact.

Recompiling with `./waf build targets="matron"` and restarting results in:
- correct disk size shown in stats
- correct recording time shown in recorder