### PR TITLE
tune 'RESTART'

### DIFF
--- a/lua/core/menu/restart.lua
+++ b/lua/core/menu/restart.lua
@@ -8,10 +8,9 @@ m.key = function(n,z)
   elseif n==3 and z==1 then
     m.confirmed = true
     _menu.redraw()
-    _norns.reset()
+    _norns.restart()
   end
 end
-
 
 m.enc = function(n,delta) end
 

--- a/lua/core/norns.lua
+++ b/lua/core/norns.lua
@@ -242,6 +242,20 @@ _norns.reset = function()
   os.execute("sudo systemctl restart norns-matron.service")
 end
 
+-- restart device
+_norns.restart = function()
+  hook.system_pre_shutdown()
+  print("RESTARTING")
+  norns.script.clear()
+  _norns.free_engine()
+  norns.state.clean_shutdown = true
+  norns.state.save()
+  pcall(cleanup)
+  audio.level_dac(0)
+  audio.headphone_gain(0)
+  _norns.reset()
+end
+
 -- startup function will be run after I/O subsystems are initialized,
 -- but before I/O event loop starts ticking (see readme-script.md)
 _startup = function()


### PR DESCRIPTION
after [some discussion last month](https://llllllll.co/t/norns-mods-development/51013/69) about expectations re: `SYSTEM > RESTART`, this PR tries to flesh out the behavior closer to what users have articulated.

### current
`SYSTEM > RESTART` simply restarts sclang, crone, and matron via a `_norns.reset()` call:
https://github.com/monome/norns/blob/103f620fb7fd544080719b25e73bace507daa358/lua/core/menu/restart.lua#L11

calling `_norns.reset()` alone has a couple of (seemingly unwanted / unexpected) side-effects:
- any changes the user has made to PARAMS since boot will be wiped and reset to their last full shutdown state
- mod pre_shutdown hooks are not called
- the last-running script will restart on reboot

### proposed
this PR adds `_norns.restart()` which performs a few tasks:
- call `hook.system_pre_shutdown`
- clear the running script + free the running engine
- save the state
- reset services

this seems to be more closely aligned to expectations that restarting a computer will clear any open programs without totally overwriting changes to settings which the user might have purposefully committed. especially since `SYSTEM > RESTART` is the easiest way to recompile after changes to engines, it feels useful for parameter settings to persist between restarts.

`SYSTEM > RESET` still wipes all user settings, and is still the best way to get the system back to a default state if something unexpected occurs.