### PR TITLE
midi mapping touchups + extensions

### DIFF
--- a/lua/core/menu/params.lua
+++ b/lua/core/menu/params.lua
@@ -336,7 +336,7 @@ m.enc = function(n,d)
   -- MAPEDIT
   elseif m.mode == mMAPEDIT then
     if n==2 then
-      m.mpos = (m.mpos+d) % 11
+      m.mpos = (m.mpos+d) % 12
     elseif n==3 then
       local p = page[m.pos+1]
       local n = params:get_id(p)
@@ -377,6 +377,8 @@ m.enc = function(n,d)
         end
       elseif m.mpos==10 then
         if d>0 then pm.accum = true else pm.accum = false end
+      elseif m.mpos == 11 then
+        if d>0 then pm.echo = true else pm.echo = false end
       end
     end
     _menu.redraw()
@@ -551,29 +553,29 @@ m.redraw = function()
     screen.text(n)
     screen.move(127,10)
     screen.text_right(params:string(p))
-    screen.move(0,25)
+    screen.move(0,22)
     hl(1)
     if m.midilearn then screen.text("LEARNING") else screen.text("LEARN") end
-    screen.move(127,25)
+    screen.move(127,22)
     hl(2)
     screen.text_right("CLEAR")
 
     screen.level(4)
-    screen.move(0,40)
+    screen.move(0,32)
     screen.text("cc")
-    screen.move(55,40)
+    screen.move(55,32)
     hl(3)
     screen.text_right(m.cc)
     screen.level(4)
-    screen.move(0,50)
+    screen.move(0,42)
     screen.text("ch")
-    screen.move(55,50)
+    screen.move(55,42)
     hl(4)
     screen.text_right(m.ch)
     screen.level(4)
-    screen.move(0,60)
+    screen.move(0,52)
     screen.text("dev")
-    screen.move(55,60)
+    screen.move(55,52)
     hl(5)
 
     local long_name = midi.vports[m.dev].name
@@ -582,30 +584,36 @@ m.redraw = function()
     screen.text_right(tostring(m.dev)..": "..short_name)
 
     screen.level(4)
-    screen.move(63,40)
+    screen.move(63,32)
     screen.text("in")
-    screen.move(103,40)
+    screen.move(103,32)
     hl(6)
     screen.text_right(pm.in_lo)
     screen.level(4)
-    screen.move(127,40)
+    screen.move(127,32)
     hl(7)
     screen.text_right(pm.in_hi)
     screen.level(4)
-    screen.move(63,50)
+    screen.move(63,42)
     screen.text("out")
-    screen.move(103,50)
+    screen.move(103,42)
     hl(8)
     screen.text_right(out_lo)
-    screen.move(127,50)
+    screen.move(127,42)
     hl(9)
     screen.text_right(out_hi)
     screen.level(4)
-    screen.move(63,60)
+    screen.move(63,52)
     screen.text("accum")
-    screen.move(127,60)
+    screen.move(127,52)
     hl(10)
     screen.text_right(pm.accum and "yes" or "no")
+    screen.level(4)
+    screen.move(63,62)
+    screen.text("echo")
+    screen.move(127,62)
+    hl(11)
+    screen.text_right(pm.echo and "yes" or "no")
   -- PSET
   elseif m.mode == mPSET then
     screen.level(4)

--- a/lua/core/params/control.lua
+++ b/lua/core/params/control.lua
@@ -80,6 +80,14 @@ function Control:set_raw(value, silent)
     self.raw = clamped_value
     if silent==false then self:bang() end
   end
+  if norns.pmap.data[self.id] ~= nil then
+    local midi_prm = norns.pmap.data[self.id]
+    midi_prm.value = util.round(util.linlin(midi_prm.out_lo, midi_prm.out_hi, midi_prm.in_lo, midi_prm.in_hi, self.raw))
+    if midi_prm.echo then
+      local port = norns.pmap.data[self.id].dev
+      midi.vports[port]:cc(midi_prm.cc, midi_prm.value, midi_prm.ch)
+    end
+  end
 end
 
 --- get_delta.

--- a/lua/core/params/number.lua
+++ b/lua/core/params/number.lua
@@ -42,6 +42,14 @@ function Number:set(v, silent)
     self.value = c
     if silent==false then self:bang() end
   end
+  if norns.pmap.data[self.id] ~= nil then
+    local midi_prm = norns.pmap.data[self.id]
+    midi_prm.value = util.round(util.linlin(midi_prm.out_lo, midi_prm.out_hi, midi_prm.in_lo, midi_prm.in_hi, self.value))
+    if midi_prm.echo then
+      local port = norns.pmap.data[self.id].dev
+      midi.vports[port]:cc(midi_prm.cc, midi_prm.value, midi_prm.ch)
+    end
+  end
 end
 
 function Number:delta(d)

--- a/lua/core/params/option.lua
+++ b/lua/core/params/option.lua
@@ -36,6 +36,14 @@ function Option:set(v, silent)
     self.selected = c
     if silent==false then self:bang() end
   end
+  if norns.pmap.data[self.id] ~= nil then
+    local midi_prm = norns.pmap.data[self.id]
+    midi_prm.value = util.round(util.linlin(midi_prm.out_lo, midi_prm.out_hi, midi_prm.in_lo, midi_prm.in_hi, self.selected))
+    if midi_prm.echo then
+      local port = norns.pmap.data[self.id].dev
+      midi.vports[port]:cc(midi_prm.cc, midi_prm.value, midi_prm.ch)
+    end
+  end
 end
 
 function Option:delta(d)

--- a/lua/core/paramset.lua
+++ b/lua/core/paramset.lua
@@ -183,6 +183,22 @@ function ParamSet:add(args)
   if args.action then
     param.action = args.action
   end
+
+  local midi_prm = norns.pmap.data[param.id]
+  if midi_prm then
+    local val
+    if param.t == 3 then
+      val = params:get_raw(param.id)
+    else
+      val = params:get(param.id)
+    end
+    midi_prm.value = util.round(util.linlin(midi_prm.out_lo, midi_prm.out_hi, midi_prm.in_lo, midi_prm.in_hi, val))
+    if midi_prm.echo then
+      local port = norns.pmap.data[param.id].dev
+      midi.vports[port]:cc(midi_prm.cc, midi_prm.value, midi_prm.ch)
+    end
+  end
+
 end
 
 --- add number.
@@ -370,6 +386,20 @@ end
 function ParamSet:delta(index, d)
   local param = self:lookup_param(index)
   param:delta(d)
+  if norns.pmap.data[param.id] ~= nil then
+    local midi_prm = norns.pmap.data[param.id]
+    local val
+    if param.t == 3 then
+      val = param:get_raw()
+    else
+      val = param:get()
+    end
+    midi_prm.value = util.round(util.linlin(midi_prm.out_lo, midi_prm.out_hi, midi_prm.in_lo, midi_prm.in_hi, val))
+    if midi_prm.echo then
+      local port = norns.pmap.data[param.id].dev
+      midi.vports[port]:cc(midi_prm.cc, midi_prm.value, midi_prm.ch)
+    end
+  end
 end
 
 --- set action.

--- a/lua/core/pmap.lua
+++ b/lua/core/pmap.lua
@@ -17,6 +17,7 @@ function pmap.new(id)
   p.out_lo = 0
   p.out_hi = 1
   p.accum = false
+  p.echo = false
   p.value = 0
   pmap.data[id] = p
 end
@@ -89,12 +90,15 @@ function pmap.read()
   if fd then
     io.close(fd)
     for line in io.lines(filename) do
-      --local name, value = string.match(line, "(\".-\")%s*:%s*(.*)")
       local name, value = string.match(line, "(\".-\")%s*:%s*(.*)")
       if name and value and tonumber(value)==nil then
         --print(unquote(name) .. " : " .. unquote(value))
         local x = load("return "..unquote(value))
         pmap.data[unquote(name)] = x()
+        -- 230816: new 'echo' field added to the pmap constructor
+        if pmap.data[unquote(name)].echo == nil then
+          pmap.data[unquote(name)].echo = false
+        end
       end
     end
     pmap.refresh()


### PR DESCRIPTION
on the way to addressing #1649, i realized i could also add an 'echo' mode which sends a map of the parameter value back to the mapped controller -- this is useful for MIDI Fighter Twister, OP-Z, and select Faderfox units which have addressable LEDs.

so now, any MIDI-mapped parameter now updates the corresponding `norns.pmap.data[id].value` whenever `:set` or `:delta`'d, so that MIDI devices don't get out of sync if a parameter is changed on norns (either by scripting or physical interaction).

there's also now an `echo` option in the mapping menu, which sends the lo/hi-scaled `norns.pmap.data[id].value` back to the controller, to redraw LEDs and/or display current values.

i've tapped into the existing `params:set` and `params:delta` framework to get this done, which seems performant from my testing, but also totally open to any suggestions! lmk <3