### PR TITLE
fix user gamepad profile lookup + new model

### DIFF
--- a/lua/core/gamepad_model/index.lua
+++ b/lua/core/gamepad_model/index.lua
@@ -4,6 +4,7 @@ local models = {}
 -- bundled w/ core
 models['03000000830500006020000010010000'] = require 'gamepad_model/ibufalo_classic_usb'
 models['030000005e0400008e02000014010000'] = require 'gamepad_model/xbox_360'
+models['03000000790000001100000010010000'] = require 'gamepad_model/retro_controller'
 
 -- user-local
 local user_conf_dir = _path.data .. "gamepads/"

--- a/lua/core/gamepad_model/index.lua
+++ b/lua/core/gamepad_model/index.lua
@@ -10,7 +10,7 @@ local user_conf_dir = _path.data .. "gamepads/"
 if util.file_exists(user_conf_dir) then
   local user_confs = util.scandir(user_conf_dir)
   for _, conf_file in pairs(user_confs) do
-    if conf:sub(-#'.lua') == '.lua' then
+    if conf_file:sub(-#'.lua') == '.lua' then
       local conf_file_sans_ext = conf_file:gsub("%.lua", "")
       print("loading user gamepad conf: "..user_conf_dir..conf_file)
       local module_path = user_conf_dir .. conf_file_sans_ext

--- a/lua/core/gamepad_model/retro_controller.lua
+++ b/lua/core/gamepad_model/retro_controller.lua
@@ -1,0 +1,32 @@
+-- Retrolink B00GWKL3Y4 (NES-style)
+-- also sold by Elecom
+
+return {
+  alias = "Retro Controller",
+  guid = "03000000790000001100000010010000",
+  analog_axis_o = {
+    ABS_X = 127,
+    ABS_Y = 127
+  },
+  analog_axis_o_margin = {},
+  analog_axis_resolution = {
+    ABS_X = 256,
+    ABS_Y = 256
+  },
+  axis_invert = {
+    ABS_X = false,
+    ABS_Y = false
+  },
+  axis_mapping = {
+    ABS_X = "dpadx",
+    ABS_Y = "dpady"
+  },
+  button = {
+    A = 289,
+    B = 290,
+    SELECT = 296,
+    START = 297
+  },
+  dpad_is_analog = true,
+  hid_name = "USB Gamepad "
+}

--- a/lua/core/gamepad_model/retro_controller.lua
+++ b/lua/core/gamepad_model/retro_controller.lua
@@ -1,5 +1,5 @@
--- Retrolink B00GWKL3Y4 (NES-style)
--- also sold by Elecom
+-- Retrolink B00GWKL3Y4 ((S)NES-style)
+-- also sold by under other brands: iNNext, Elecom...
 
 return {
   alias = "Retro Controller",


### PR DESCRIPTION
thanks to the help of @xmacex i discovered a bug in the user-level gamepad model lookup (under `~/we/dust/data/gamepads/`).

also this PR adds support for a new gamepad model.