### PR TITLE
double the temp buffer size for systemcmd

### DIFF
--- a/matron/src/system_cmd.c
+++ b/matron/src/system_cmd.c
@@ -15,7 +15,7 @@
 #include "events.h"
 
 #if 1 // nice big buffers (allocated in worker thread)
-static const size_t CMD_CAPTURE_BYTES = 8192 * 8;
+static const size_t CMD_CAPTURE_BYTES = 8192 * 16;
 static const size_t CMD_LINE_BYTES = 1024;
 
 #else // test with stupid tiny buffers
@@ -74,9 +74,9 @@ void *run_cmd(void *cmd) {
         }
         capacity -= len;
 
-#if 0 // test..
+#if 1 // test..
 	fprintf(stderr, "last line: \n\t%s\n", line);
-	fprintf(stderr, "current buffer: \n\t %s\n", line);
+	// fprintf(stderr, "current buffer: \n\t %s\n", line);
 	fprintf(stderr, "remaining capacity: %d bytes\n", capacity);
 #endif
 


### PR DESCRIPTION
this simply doubles the size of the temp buffer used for shell command results, from 64kB to 128kB.

it's painful to look at this! it would be nice to make something more incremental.

e.g., it would be nice to make better use of POSIX dirent iterators (? or whatever) to make dedicated   C implementations for tasks like listing all files of a given type in a directory.

if that's too much, maybe we can just change this to use `realloc` incrementally at least. i'll update here if i get a chance, but the change as is should at least support current use cases and i don't think the extra temp allocation will break anything. 