### PR TITLE
Trim away un-needed select menu content

### DIFF
--- a/lua/core/menu/select.lua
+++ b/lua/core/menu/select.lua
@@ -28,11 +28,7 @@ local function sort_select_tree(results)
 
   local t = {}
   for filename in results:gmatch("[^\r\n]+") do
-    if string.match(filename,"/data/")==nil and
-      string.match(filename,"/lib/")==nil and
-      string.match(filename,"/crow/")==nil then
-      table.insert(t,filename)
-    end
+    table.insert(t,'/home/we/dust/code/' .. filename)
   end
 
   for _,file in pairs(t) do
@@ -62,7 +58,11 @@ m.init = function()
     tabutil.save(m.favorites, paths.favorites)
   end
   -- weird command, but it is fast, recursive, skips hidden dirs, and sorts
-  norns.system_cmd('find ~/dust/code/ -name "*.lua" -printf "%P\n"| sort', sort_select_tree)
+  norns.system_cmd('find ~/dust/code/ -mindepth 2 ' ..
+                   '-name .git -prune -o -type f -name "*.lua" -printf "%P\n" | ' ..
+                   'grep -Ev "/(lib|data|crow)/" | ' ..
+                   'sort',
+                   sort_select_tree)
 end
 
 m.deinit = norns.none


### PR DESCRIPTION
* Do not scan through .git directories while looking for scripts (optimization of `find` call only).

* Filter out unwanted lua scripts before returning from shell.

This PR is a refinement of the tweaks to the `find` call that have already been merged (i.e., use of `-printf "%P\n"`).

Based on anecdotal tests on my local install, moving the filter for "crow", "lib" and so on from lua to `grep` removes 90% of the data transferred from the system call to crone.  This removes all lag on entering the select menu.  (Tested with an install base of 87 scripts having 555 unwanted internal lua files.)