### PR TITLE
add cpu_time

### DIFF
--- a/matron/src/hardware/cpu_time.c
+++ b/matron/src/hardware/cpu_time.c
@@ -1,0 +1,29 @@
+#include "cpu_time.h"
+
+#include <time.h>
+
+struct timespec t0;
+
+static struct timespec diff(const struct timespec *start, const struct timespec *end)
+{
+    struct timespec temp;
+    if ((end->tv_nsec - start->tv_nsec)<0) {
+        temp.tv_sec = end->tv_sec - start->tv_sec - 1;
+        temp.tv_nsec = 1000000000 + end->tv_nsec - start->tv_nsec;
+    } else {
+        temp.tv_sec = end->tv_sec - start->tv_sec;
+        temp.tv_nsec = end->tv_nsec - start->tv_nsec;
+    }
+    return temp;
+}
+
+void cpu_time_start() {
+    clock_gettime(CLOCK_PROCESS_CPUTIME_ID, &t0);
+ }
+
+unsigned long int cpu_time_get_delta_ns() {
+    struct timespec t1;
+    clock_gettime(CLOCK_PROCESS_CPUTIME_ID, &t1);
+    struct timespec delta = diff(&t0, &t1);
+    return (delta.tv_sec * 1000000000) + delta.tv_nsec;
+ }

--- a/matron/src/hardware/cpu_time.h
+++ b/matron/src/hardware/cpu_time.h
@@ -1,0 +1,8 @@
+// extremely simple CPU time measurement module, for benchmarking
+// sets a single reference point, and computes time deltas since that point
+
+#pragma once
+
+extern void cpu_time_start();
+
+extern unsigned long int cpu_time_get_delta_ns();

--- a/matron/src/system_cmd.c
+++ b/matron/src/system_cmd.c
@@ -73,19 +73,8 @@ void *run_cmd(void *cmd) {
             strncat(capture, line, capacity);
         }
         capacity -= len;
-
-#if 1 // test..
-	fprintf(stderr, "last line: \n\t%s\n", line);
-	// fprintf(stderr, "current buffer: \n\t %s\n", line);
-	fprintf(stderr, "remaining capacity: %d bytes\n", capacity);
-#endif
-
     } while (capacity > 0); // ... or, stop if buffer is full
 
-#if 0 // test...
-    fprintf(stderr, "finished line loop; full buffer: \n");    
-    fprintf(stderr, "%s\n", capture);
-#endif
 
     // just use memcpy and include the null terminator
     size_t len = strlen(capture) + 1;

--- a/matron/src/weaver.c
+++ b/matron/src/weaver.c
@@ -28,6 +28,7 @@
 #include "clocks/clock_internal.h"
 #include "clocks/clock_link.h"
 #include "clocks/clock_scheduler.h"
+#include "cpu_time.h"
 #include "device_crow.h"
 #include "device_hid.h"
 #include "device_midi.h"
@@ -288,6 +289,10 @@ static int _clock_get_tempo(lua_State *l);
 static int _audio_get_cpu_load(lua_State *l);
 static int _audio_get_xrun_count(lua_State *l);
 
+// CPU time
+static int _cpu_time_start_timer(lua_State *l);
+static int _cpu_time_get_delta(lua_State *l);
+
 // platform detection (CM3 vs PI3 vs OTHER)
 static int _platform(lua_State *l);
 
@@ -547,6 +552,9 @@ void w_init(void) {
 
     lua_register_norns("audio_get_cpu_load", &_audio_get_cpu_load);
     lua_register_norns("audio_get_xrun_count", &_audio_get_xrun_count);
+
+    lua_register_norns("cpu_time_start_timer", &_cpu_time_start_timer);
+    lua_register_norns("cpu_time_get_delta", &_cpu_time_get_delta);
 
     // platform
     lua_register_norns("platform", &_platform);
@@ -1970,6 +1978,16 @@ int _audio_get_cpu_load(lua_State *l) {
 
 int _audio_get_xrun_count(lua_State *l) {
     lua_pushnumber(l, jack_client_get_xrun_count());
+    return 1;
+}
+
+int _cpu_time_start_timer(lua_State *l) {
+    cpu_time_start();
+    return 0;
+}
+
+int _cpu_time_get_delta(lua_State *l) {
+    lua_pushnumber(l, cpu_time_get_delta_ns());
     return 1;
 }
 

--- a/matron/wscript
+++ b/matron/wscript
@@ -12,6 +12,7 @@ def build(bld):
         'src/device/device_crow.c',
         'src/osc.c',
         'src/hardware/battery.c',
+        'src/hardware/cpu_time.c',
         'src/hardware/i2c.c',
         'src/hardware/input.c',
         'src/hardware/io.c',


### PR DESCRIPTION
adds a very simple module for measuring CPU time deltas accurately from lua. this is useful for benchmarking.

e.g.:

```
local perform_bench = function(nruns, nsteps, fn_step, fn_init)
    local times_ms = {}
    for i=1,nruns do
        fn_init()
        _norns.cpu_time_start_timer()
        for j=1,nsteps do
            fn_step()
        end
        local delta_ns = _norns.cpu_time_get_delta()
        table.insert(times_ms, delta_ns / 1e6)
    end
    return times_ms
end


```