### PR TITLE
Stop logging OSC

### DIFF
--- a/lua/core/osc.lua
+++ b/lua/core/osc.lua
@@ -75,7 +75,7 @@ local function param_handler(path, args)
         local param = pset:lookup_param(osc_param_id)
 
         if param.id == osc_param_id then
-          print('setting parameter '..pset_id..'/'..param.id..' to '..osc_param_value)
+          -- print('setting parameter '..pset_id..'/'..param.id..' to '..osc_param_value)
           param:set(osc_param_value)
         end
       end


### PR DESCRIPTION
Closes monome/norns-image#99

I'm often using OSC for modulating my Norns boxes from Ableton Live. It works very well but notoriously clogs up logs. This is from a few hours of runtime:

```
-rw-r-----   1 root adm             765M Nov  1 23:24 daemon.log
-rw-r-----   1 root adm             120M Nov  1 11:11 daemon.log.1
-rw-r-----   1 root adm              51K Oct 22 22:23 daemon.log.2.gz
-rw-r-----   1 root adm             201K Oct  8 13:18 daemon.log.3.gz
```

Sure, the logs get folded into gzip at some point but until that point literally gigabytes of space will be wasted. And the logs are harder to see during that time as when you are modulating a parameter with OSC, there can be 100+ log lines *per second* like:

```
Nov 01 23:23:49 shield ws-wrapper[516]: setting parameter /pw to 22.047245025635
Nov 01 23:23:49 shield ws-wrapper[516]: setting parameter /cutoff to 944.88189697266
Nov 01 23:23:49 shield ws-wrapper[516]: setting parameter /pw to 22.047245025635
Nov 01 23:23:49 shield ws-wrapper[516]: setting parameter /cutoff to 905.51184082031
Nov 01 23:23:49 shield ws-wrapper[516]: setting parameter /pw to 22.047245025635
Nov 01 23:23:49 shield ws-wrapper[516]: setting parameter /cutoff to 866.14172363281
Nov 01 23:23:49 shield ws-wrapper[516]: setting parameter /pw to 22.047245025635
Nov 01 23:23:49 shield ws-wrapper[516]: setting parameter /cutoff to 826.77166748047
Nov 01 23:23:49 shield ws-wrapper[516]: setting parameter /cutoff to 787.40155029297
Nov 01 23:23:49 shield ws-wrapper[516]: setting parameter /pw to 22.834646224976
```

Let's just comment this out, like other prints in that same file, shall we?