### PR TITLE
Add `Screen.sleep()` to manually invoke the screensaver

### DIFF
--- a/lua/core/screen.lua
+++ b/lua/core/screen.lua
@@ -477,4 +477,8 @@ Screen.blend_mode = function(index)
   end
 end
 
+Screen.sleep = function()
+  screensaver:event()
+end
+
 return Screen


### PR DESCRIPTION
The default screensaver time is 15 minutes. I like to manually turn the screensaver on sooner, which I can do from Maiden by calling:
```lua
>> screensaver:event()
```

To be able to do this, `screensaver` needs to be a global.