### PR TITLE
[WIP] link: store and access phase, delay transport start

### DIFF
--- a/matron/src/clocks/clock_link.h
+++ b/matron/src/clocks/clock_link.h
@@ -11,3 +11,4 @@ void clock_link_set_transport_stop();
 void clock_link_set_start_stop_sync(bool sync_enabled);
 double clock_link_get_beat();
 double clock_link_get_tempo();
+double clock_link_get_phase();

--- a/matron/src/weaver.c
+++ b/matron/src/weaver.c
@@ -287,6 +287,7 @@ static int _clock_link_set_quantum(lua_State *l);
 static int _clock_link_set_transport_stop(lua_State *l);
 static int _clock_link_set_transport_start(lua_State *l);
 static int _clock_link_set_start_stop_sync(lua_State *l);
+static int _clock_link_get_phase(lua_State *l);
 #endif
 static int _clock_set_source(lua_State *l);
 static int _clock_get_time_beats(lua_State *l);
@@ -560,6 +561,7 @@ void w_init(void) {
     lua_register_norns("clock_link_set_transport_start", &_clock_link_set_transport_start);
     lua_register_norns("clock_link_set_transport_stop", &_clock_link_set_transport_stop);
     lua_register_norns("clock_link_set_start_stop_sync", &_clock_link_set_start_stop_sync);
+    lua_register_norns("clock_link_get_phase", &_clock_link_get_phase);
 #endif
     lua_register_norns("clock_set_source", &_clock_set_source);
     lua_register_norns("clock_get_time_beats", &_clock_get_time_beats);
@@ -2088,6 +2090,12 @@ int _clock_link_set_start_stop_sync(lua_State *l) {
     clock_link_set_start_stop_sync(enabled);
     return 0;
 }
+
+int _clock_link_get_phase(lua_State *l) {
+    lua_pushnumber(l, clock_link_get_phase());
+    return 1;
+}
+
 #endif
 
 int _clock_set_source(lua_State *l) {


### PR DESCRIPTION
quick attempt to do two things related to ableton link:

- (1). query and store link phase, add weaver accessor for it
- (2). delay posting `EVENT_CLOCK_START` (which triggers `clock.transport.start`) until phase 0. this implements the recommended "quantized start" behavior without requiring scripts to track phase (which is a link-specific parameter.) 

idea is that scripts can still do stuff during "count-in" if they want to specifically be link-aware; if they don't they can still start at the same time as the Live transport.

**known issue**: there's a problem with this as it stands: the phase is updated in the main link clock routine, which updates every 10ms... and with the way the scheduler works, lua "sees" a 10-ms-old phase value on clock sync. need to find some other time to update the cached link phase.

there could well be other issues, i don't totally grok all the intent in the ableton API even after reading their user-story documentation.