### PR TITLE
fix lfo constructor ahead of params

### DIFF
--- a/lua/lib/lfo.lua
+++ b/lua/lib/lfo.lua
@@ -14,7 +14,7 @@ local lfo_shapes = {'sine','tri','square','random','up','down'}
 
 local beat_sec = clock.get_beat_sec()
 
-local params_per_entry = 14
+local params_per_entry = 15
 
 function LFO.init()
   if norns.lfo == nil then
@@ -485,7 +485,7 @@ function LFO:add_params(id,sep,group)
       end)
       
       local mode_options = {'clocked', 'free'}
-      params:add_option("lfo_mode_"..id, "lfo mode", mode_options, mode_options[self:get('mode')])
+      params:add_option("lfo_mode_"..id, "lfo mode", mode_options, tab.key(mode_options,self:get('mode')))
       params:set_action("lfo_mode_"..id,
         function(x)
           self:set('mode',params:lookup_param("lfo_mode_"..id).options[x])
@@ -530,8 +530,8 @@ function LFO:add_params(id,sep,group)
       params:add_trigger("lfo_reset_"..id, "reset lfo")
       params:set_action("lfo_reset_"..id, function(x) self:reset_phase() end)
 
-      local reset_destinations = {"floor","ceiling","mid: rising","mid: falling"}
-      params:add_option("lfo_reset_target_"..id, "reset lfo to", reset_destinations, reset_destinations[self:get('reset_target')])
+      local reset_destinations = {"floor", "ceiling", "mid: rising", "mid: falling"}
+      params:add_option("lfo_reset_target_"..id, "reset lfo to", reset_destinations, tab.key(reset_destinations,self:get('reset_target')))
       params:set_action("lfo_reset_target_"..id, function(x)
         self:set('reset_target', params:lookup_param("lfo_reset_target_"..id).options[x])
       end)

--- a/lua/lib/lfo.lua
+++ b/lua/lib/lfo.lua
@@ -504,7 +504,7 @@ function LFO:add_params(id,sep,group)
         end
         )
 
-      local current_period_as_rate = self:get('mode') == 'clocked' and lfo_rates[lfo_rates_as_strings[self:get('period')]] or lfo_rates[self:get('period')]
+      local current_period_as_rate = self:get('mode') == 'clocked' and lfo_rates[lfo_rates_as_strings[self:get('period')]] or self:get('period')
       local rate_index = tab.key(lfo_rates,self:get('period'))
       params:add_option("lfo_clocked_"..id, "lfo rate", lfo_rates_as_strings, rate_index)
       params:set_action("lfo_clocked_"..id,


### PR DESCRIPTION
[as reported at lines](https://llllllll.co/t/lfo-lib/60274/14), creating an LFO using the constructor methods should automatically populate the relevant settings when `:add_params` is invoked.

`mode` and `reset_target` were not being set as parameters correctly, as their values were not being matched to the table of options -- instead of doing a key lookup, i had accidentally passed the string values as the index. `period` was also not being handled correctly. i also needed to extend the group parameter count.

this PR corrects these issues!

test script:
```lua
_lfos = require 'lfo' -- assign the library to a general variable
engine.name = 'PolyPerc'
s = require 'sequins'

function init()
  hz_vals = s{400,600,200,350}
  sync_vals = s{1,1/3,1/2,1/6,2}
  clock.run(iter)

  screen_dirty = true

  -- IMPORTANT! set your LFO's 'min' and 'max' *before* adding params, so they can scale appropriately:
  cutoff_lfo = _lfos:add{min = 200, max = 5000}
  cutoff_lfo:start()
  cutoff_lfo:set('mode','free')
  cutoff_lfo:set('depth',1)
  cutoff_lfo:set('period',2)
  -- now we can add params:
  cutoff_lfo:add_params('cutoff_lfo', 'cutoff', 'LFOs')

  cutoff_lfo:set('action', function(scaled, raw) engine.cutoff(scaled) screen_dirty = true end)

  redraw_screen = metro.init(check_dirty,1/15,-1)
  redraw_screen:start()
end

function iter()
  while true do
    clock.sync(sync_vals())
    hertz = hz_vals()
    engine.hz(hertz)
  end
end

function check_dirty()
  if screen_dirty then
    redraw()
    screen_dirty = false
  end
end

function redraw()
   screen.clear()
   screen.move(64,40)
   screen.font_size(20)
   screen.text_center(util.round(cutoff_lfo:get('scaled'),0.01)..'hz')
   screen.update()
end
```