### PR TITLE
[WIP] Midi clock filter

### DIFF
--- a/lua/core/clock.lua
+++ b/lua/core/clock.lua
@@ -239,7 +239,7 @@ function clock.add_params()
   params:add_number("link_quantum", "link quantum", 1, 32, norns.state.clock.link_quantum)
   params:set_action("link_quantum",
     function(x)
-      clock.link.set_quantum(x)
+      clock.link.set_quantum(x) 
       norns.state.clock.link_quantum = x
     end)
   params:set_save("link_quantum", false)
@@ -275,6 +275,19 @@ function clock.add_params()
     end
     params:set_save("clock_midi_out_"..i, false)
   end
+
+  params:add_separator("midi_clock_in_separator", "midi clock in")
+  local midi_clock_in_options = { "all", "none"}
+  for i=1,16 do 
+    table.insert(midi_clock_in_options, tostring(i))
+  end
+  params:add_option("clock_midi_in", "midi clock in", midi_clock_in_options, norns.state.clock.midi_in)
+  params:set_action("clock_midi_in", function(x)
+    norns.state.clock.midi_in = x
+    midi.update_clock_receive()
+  end)
+  params:set_save("clock_midi_in", false)
+
   params:add_separator("crow_clock_separator", "crow")
   params:add_option("clock_crow_out", "crow out",
       {"off", "output 1", "output 2", "output 3", "output 4"}, norns.state.clock.crow_out)

--- a/lua/core/midi.lua
+++ b/lua/core/midi.lua
@@ -175,6 +175,13 @@ function Midi:song_select(val)
   self:send{type="song_select", val=val}
 end
 
+--- enable/disable clock reception from this device
+-- @tparam boolean enabled
+function Midi:clock_receive(enabled)
+  print("Midi:clock_receive: "..enabled)
+  _norns.midi_clock_receive(self.dev, enabled)
+end
+
 --- create device, returns object with handler and send.
 -- @tparam integer n : vport index
 function Midi.connect(n)
@@ -399,6 +406,29 @@ function Midi.update_connected_state()
     end
   end
   _menu.rebuild_params()
+end
+
+function Midi.update_clock_receive()
+  local x = norns.state.clock.midi_in
+  if x == 1 then
+    --- enable all devices
+    for _, dev in pairs(Midi.devices) do
+      dev:clock_receive(1)
+    end
+  else
+    -- disable all devices...
+    for _, dev in pairs(Midi.devices) do
+      dev:clock_receive(0)
+    end
+    -- re-enable the selected one if called for
+    if x > 2 then
+      print("enabling clock input; x = "..x)
+      local dev = Midi.vports[x-2].device
+      if dev ~= nil then
+        dev:clock_receive(1)
+      end
+    end
+  end
 end
 
 -- add a device.

--- a/lua/core/state.lua
+++ b/lua/core/state.lua
@@ -51,6 +51,7 @@ state.clock.tempo = 90
 state.clock.link_quantum = 4
 state.clock.link_start_stop_sync = 1
 state.clock.midi_out = {}
+state.clock.midi_in = 1 -- all clock input enabled
 state.clock.crow_out = 1
 state.clock.crow_out_div = 4
 state.clock.crow_in_div = 4
@@ -151,6 +152,7 @@ state.save_state = function()
   for i = 1,16 do
     io.write("norns.state.clock.midi_out["..i.."] = " .. norns.state.clock.midi_out[i] .. "\n")
   end
+  io.write("norns.state.clock.midi_in = " .. norns.state.clock.midi_in .. "\n")
   io.write("norns.state.clock.crow_out = " .. norns.state.clock.crow_out .. "\n")
   io.write("norns.state.clock.crow_out_div = " .. norns.state.clock.crow_out_div .. "\n")
   io.write("norns.state.clock.crow_in_div = " .. norns.state.clock.crow_in_div .. "\n")

--- a/matron/src/device/device_midi.c
+++ b/matron/src/device/device_midi.c
@@ -99,11 +99,13 @@ int dev_midi_init(void *self, unsigned int port_index, bool multiport_device) {
     }
 
     if (midi->handle_in != NULL) { 
-	base->start = &dev_midi_start;
+	    base->start = &dev_midi_start;
     } else {
-	base->start = NULL;
+	    base->start = NULL;
     }
     base->deinit = &dev_midi_deinit;
+
+    midi->clock_enabled = true;
 
     return 0;
 }
@@ -282,7 +284,9 @@ static inline ssize_t dev_midi_consume_buffer(midi_input_state_t *state, ssize_t
         byte = state->buffer[i];
 
         if (byte >= 0xf8) {
-            clock_midi_handle_message(byte);
+            if (midi->clock_enabled) {
+                clock_midi_handle_message(byte);
+            }
         }
 
         if (is_status_byte(byte) && (byte != 0xf7)) {

--- a/matron/src/device/device_midi.h
+++ b/matron/src/device/device_midi.h
@@ -6,6 +6,7 @@
 
 struct dev_midi {
     struct dev_common dev;
+    bool clock_enabled;
     snd_rawmidi_t *handle_in;
     snd_rawmidi_t *handle_out;
 };

--- a/matron/src/weaver.c
+++ b/matron/src/weaver.c
@@ -169,6 +169,7 @@ static int _osc_send_crone(lua_State *l);
 
 // midi
 static int _midi_send(lua_State *l);
+static int _midi_clock_receive(lua_State *l);
 
 // crow
 static int _crow_send(lua_State *l);
@@ -507,6 +508,7 @@ void w_init(void) {
 
     // midi
     lua_register_norns("midi_send", &_midi_send);
+    lua_register_norns("midi_clock_receive", &_midi_clock_receive);
 
     // get list of available crone engines
     lua_register_norns("report_engines", &_request_engine_report);
@@ -1659,6 +1661,21 @@ int _midi_send(lua_State *l) {
     dev_midi_send(md, data, nbytes);
     free(data);
 
+    return 0;
+}
+
+/***
+ * midi: clock_receive
+ * @function midi_receive
+ */
+int _midi_clock_receive(lua_State *l) {
+    struct dev_midi *md;
+    lua_check_num_args(2);
+    luaL_checktype(l, 1, LUA_TLIGHTUSERDATA);
+    md = lua_touserdata(l, 1);
+    int enabled = lua_tointeger(l, 2);
+    md->clock_enabled = enabled > 0;
+    fprintf(stderr, "set clock_enabled to %d on device %p\n", enabled, md);
     return 0;
 }
 


### PR DESCRIPTION
addresses #1754 by means of a new clock parameter `clock_midi_in`. options are "all", "none", or a vport index. 

this seems to work, but needs:
- some cleanup (dbg prints)
- consideration of UI
- consideration of structure / efficiency (some quick and dirty loops and maybe not optimal FFI)