### PR TITLE
fix field accessors in grid example

### DIFF
--- a/lua/core/grid.lua
+++ b/lua/core/grid.lua
@@ -249,11 +249,11 @@ grid.connect( port )          create a grid table using device [port]
                                 this should be redefined by the script
 .tilt( x, y, z )               function called with incoming grid tilt event
                                 this should be redefined by the script
-.led( x, y, level )           set LED at [x,y] to [level]
+:led( x, y, level )           set LED at [x,y] to [level]
                                 [level] range is 0..15
-.all( level )                 set all grid LED to [level]
+:all( level )                 set all grid LED to [level]
                                 [level] range is 0..15
-.refresh()                    update the grid LED state
+:refresh()                    update the grid LED state
 
 --------------------------------------------------------------------------------
 -- example
@@ -274,9 +274,9 @@ end
 
 -- simple draw function
 draw_grid()
-  g.all(0)
-  g.led(lx,ly,lz)
-  g.refresh()
+  g:all(0)
+  g:led(lx,ly,lz)
+  g:refresh()
 end
 --------------------------------------------------------------------------------
 ]]      


### PR DESCRIPTION
from @catfact in https://llllllll.co/t/midigrid-use-launchpads-midi-grid-controllers-with-norns/42336/550:

> the examples in the comments in grid.lua incorrectly use the . field accessor in several places where i think they would need the : method accessor.

this PR swaps those field accessors for method accessors!