### PR TITLE
fix: always push four quads to libmonome

### DIFF
--- a/matron/src/device/device_monome.c
+++ b/matron/src/device/device_monome.c
@@ -119,7 +119,7 @@ void dev_monome_arc_set_led(struct dev_monome *md, uint8_t n, uint8_t x, uint8_t
 
 // set all LEDs to value
 void dev_monome_all_led(struct dev_monome *md, uint8_t val) {
-    for (uint8_t q = 0; q < md->quads; q++) {
+    for (uint8_t q = 0; q < 4; q++) {
         for (uint8_t i = 0; i < 64; i++) {
             md->data[q][i] = val;
         }
@@ -136,7 +136,7 @@ void dev_monome_refresh(struct dev_monome *md) {
         return;
     }
 
-    for (int quad = 0; quad < md->quads; quad++) {
+    for (int quad = 0; quad < 4; quad++) {
         if (md->dirty[quad]) {
             if (md->type == DEVICE_MONOME_TYPE_ARC) {
                 monome_led_ring_map(md->m, quad, md->data[quad]);


### PR DESCRIPTION
when grid rotation is nonzero, device_monome.c is writing to quads that end up never being pushed to the device (quad 3, specifically). i'm not familiar with libmonome, and i have yet to test this on my norns, but this is the solution that i used in ryleelyman/seamstress#113 to get grid rotation working as expected.

closes #1767