### PR TITLE
tape: return false immediately on open() if stream is running

### DIFF
--- a/crone/src/Tape.h
+++ b/crone/src/Tape.h
@@ -70,10 +70,16 @@ namespace crone {
             virtual // from any thread
                 void start() {
                 if (isRunning) {
+                    std::cout << "Tape: already running" << std::endl;
                     return;
                 } else {
+                    std::cout << "Tape: starting.." << std::endl;
                     envIdx = 0;
                     envState = Starting;
+
+                /// FIXME: diskLoop() isn't designed to be re-entrant, 
+                // so we need to make very sure here that no existing disk loop thread is running
+
                     this->th = std::make_unique<std::thread>(
                                                              [this]() {
                                                                  this->diskLoop();
@@ -127,7 +133,7 @@ namespace crone {
                     envIdx = 0;
                     envState = Stopped;
                     shouldStop = true;
-                    std::cerr << "Tape: fade-out finished; stopping" << std::endl;
+                    std::cout << "Tape: fade-out finished; stopping" << std::endl;
                 }
             }
 
@@ -164,7 +170,7 @@ namespace crone {
                 
                 if (bytesToPush > bytesAvailable) {
 #if 0 
-                    std::cerr << "Tape: writer overrun: " 
+                    std::cout << "Tape: writer overrun: " 
                               << bytesAvailable << " bytes available; " 
                               << bytesToPush << " bytes to push; "
                               << numFramesCaptured << " frames captured" 
@@ -199,6 +205,7 @@ namespace crone {
 
             // call from disk thread
             void diskLoop() override {
+                std::cout << "tape write diskLoop()" << std::endl;
                 SfStream::isRunning = true;
                 SfStream::shouldStop = false;
                 numFramesCaptured = 0;
@@ -229,7 +236,7 @@ namespace crone {
                     
                     if (framesToWrite > (int) maxFramesToWrite) {
                         // _really_ shouldn't happen
-                        std::cerr << "warning: Tape::Writer has too many frames to write" << std::endl;
+                        std::cout << "warning: Tape::Writer has too many frames to write" << std::endl;
                         framesToWrite = (int) maxFramesToWrite;
                     }
 
@@ -243,22 +250,22 @@ namespace crone {
                     if (sf_writef_float(this->file, diskOutBuf, framesToWrite) != framesToWrite) {
                         char errstr[256];
                         sf_error_str(nullptr, errstr, sizeof(errstr) - 1);
-                        std::cerr << "error: Tape::writer failed to write (libsndfile: " << errstr << ")" << std::endl;
+                        std::cout << "error: Tape::writer failed to write (libsndfile: " << errstr << ")" << std::endl;
                         this->status = EIO;
                         break;
                     }
 
                     numFramesCaptured += framesToWrite;
                     if (numFramesCaptured >= maxFrames) {
-                        std::cerr << "Tape: writer exceeded max frame count; aborting.";
+                        std::cout << "Tape: writer exceeded max frame count; aborting.";
                         break;
                     }
 
                 }
 
-                std::cerr << "Tape::writer closing file...";
+                std::cout << "Tape::writer closing file...";
                 sf_close(this->file);
-                std::cerr << " done." << std::endl;
+                std::cout << " done." << std::endl;
                 SfStream::isRunning = false;
             }
 
@@ -267,6 +274,13 @@ namespace crone {
                       size_t maxFrames = JACK_MAX_FRAMES, // <-- ridiculous big number
                       int sampleRate = 48000,
                       int bitDepth = 24) {
+                
+                if (SfStream::isRunning) {
+                    std::cout << "Tape Writer: already running" << std::endl;
+                    return false;
+                }
+
+
                 SF_INFO sf_info;
                 int short_mask;
 
@@ -295,7 +309,7 @@ namespace crone {
                 if ((this->file = sf_open(path.c_str(), SFM_WRITE, &sf_info)) == NULL) {
                     char errstr[256];
                     sf_error_str(nullptr, errstr, sizeof(errstr) - 1);
-                    std::cerr << "cannot open sndfile" << path << " for output (" << errstr << ")" << std::endl;
+                    std::cout << "cannot open sndfile" << path << " for output (" << errstr << ")" << std::endl;
                     return false;
                 }
 
@@ -337,6 +351,7 @@ namespace crone {
         private:
             // prime the ringbuffer
             void prime() {
+                std::cout << "priming tape reader" << std::endl;
                 jack_ringbuffer_t *rb = this->ringBuf.get();
                 size_t framesToRead = jack_ringbuffer_write_space(rb) / frameSize;
                 if (framesToRead > maxFramesToRead) { framesToRead = maxFramesToRead; };
@@ -347,7 +362,7 @@ namespace crone {
 
                 // couldn't read enough, file is shorter than the buffer
                 if (framesRead < framesToRead) {
-                    std::cerr << "Tape::Reader: short file, disable loop" << std::endl;
+                    std::cout << "Tape::Reader: short file, disable loop" << std::endl;
                     SfStream::shouldStop = false;
                }
             }
@@ -379,6 +394,7 @@ namespace crone {
 
                 //  if ringbuf isn't full enough, probably EOF on a non-looped file
                 if(framesInBuf < numFrames) {
+                    std::cout << "tape reader: ringbuf is empty" << std::endl;
                     // pull from ringbuffer
                     jack_ringbuffer_read(rb, (char*)pullBuf, framesInBuf * frameSize);
                     float* src = pullBuf;
@@ -398,6 +414,7 @@ namespace crone {
                         fr++;
                     }
                     jack_ringbuffer_reset(rb);
+                    std::cout << "tape reader: isRunning = false" << std::endl;
                     SfStream::isRunning = false;
                 } else {
 
@@ -425,22 +442,28 @@ namespace crone {
 
             // from any thread
             bool open(const std::string &path) {
-                SF_INFO sfInfo;
+                std::cout << "tape reader; open: " << path << std::endl;
 
+                if (SfStream::isRunning) {
+                    std::cout << "Tape Reader: already running" << std::endl;
+                    return false;
+                }
+
+                SF_INFO sfInfo;
                 if ((this->file = sf_open(path.c_str(), SFM_READ, &sfInfo)) == NULL) {
                     char errstr[256];
                     sf_error_str(0, errstr, sizeof(errstr) - 1);
-                    std::cerr << "Tape Reader:: cannot open sndfile" << path << " for output (" << errstr << ")" << std::endl;
+                    std::cout << "Tape Reader:: cannot open sndfile" << path << " for output (" << errstr << ")" << std::endl;
                     return false;
                 }
 
                 if (sfInfo.frames < 1) {
 
-                    std::cerr << "Tape Reader:: error reading file " << path << " (no frames available)" << std::endl;
+                    std::cout << "Tape Reader:: error reading file " << path << " (no frames available)" << std::endl;
                     return false;
                 }
                 this->frames = static_cast<size_t>(sfInfo.frames);
-                std::cerr << "Tape Reader:: file size " << this->frames << " samples" << std::endl;
+                std::cout << "Tape Reader:: file size " << this->frames << " samples" << std::endl;
                 inChannels = sfInfo.channels;
                 if (inChannels > NumChannels)
                     return 0;//more than stereo is going to break things
@@ -461,8 +484,10 @@ namespace crone {
         private:
             // from disk thread
             void diskLoop() override {
+                std::cout << "tape reader diskLoop()" << std::endl;
                 prime();
                 isPrimed = true;
+                std::cout << "tape reader: isRunning = true" << std::endl;
                 SfStream::isRunning = true;
                 SfStream::shouldStop = false;
                 while (!SfStream::shouldStop) {
@@ -498,12 +523,13 @@ namespace crone {
                     if (loopFile) {
                         // couldn't perform full read so must be end of file. Seek to start of file and keep reading
                         while (framesRead < framesToRead) {
+                            std::cout << "tape reader: couldn't perform full read; looping file..." << std::endl;
                             sf_seek(this->file,0, SEEK_SET);
                             auto nextRead = (size_t) sf_readf_float(this->file, diskBufPtr, framesToRead-framesRead);
                             if (nextRead < 1)
                             {
                                   //Shouldn't happen
-                                  std::cerr << "Tape::Reader: unable to read file" << std::endl;
+                                  std::cout << "Tape::Reader: unable to read file" << std::endl;
                                   SfStream::shouldStop = true;
                                   break;
                             }
@@ -514,7 +540,7 @@ namespace crone {
                         }
                     }
                     else {
-                        std::cerr << "Tape::Reader::diskloop() reached EOF" << std::endl;
+                        std::cout << "Tape::Reader::diskloop() reached EOF" << std::endl;
                         SfStream::shouldStop = true;
                     }
 
@@ -525,7 +551,7 @@ namespace crone {
 
                 }
                 sf_close(this->file);
-                std::cerr << "Tape::reader closed file" << std::endl;
+                std::cout << "Tape::reader closed file" << std::endl;
             }
 
         }; // Reader class


### PR DESCRIPTION
this is a quick bandaid to begin addressing https://github.com/monome/norns/issues/1758

previous to the change, calling `open()` on a running stream would bork the state machine. 

with the change, calling `open()` on a running stream does nothing. not ideal but at least it keeps working.

next, i'll try and update such that the same action starts a fadeout and blocks the caller until fadeout is complete. i'd recommend merging this change first and i'll build on it (can't promise a timeline)