### PR TITLE
accel for potentiometers

### DIFF
--- a/lua/core/encoders.lua
+++ b/lua/core/encoders.lua
@@ -42,6 +42,10 @@ end
 --- process delta
 encoders.process = function(n,d)
   encoders.tick[n] = encoders.tick[n] + d
+  if encoders.accel[n] then
+		local s = d<0 and -1 or 1
+		d = s * math.pow(math.abs(d),1.6)
+  end
   if math.abs(encoders.tick[n]) >= encoders.sens[n] then
     local val = encoders.tick[n] / encoders.sens[n]
 		val = (val > 0) and math.floor(val) or math.ceil(val)

--- a/lua/core/norns.lua
+++ b/lua/core/norns.lua
@@ -130,8 +130,8 @@ norns.script = require 'core/script'
 norns.state = require 'core/state'
 norns.encoders = require 'core/encoders'
 
---_norns.enc = _norns.adc_rev() and norns.encoders.process or norns.encoders.process_with_accel
-_norns.enc = norns.encoders.process_with_accel
+_norns.enc = _norns.adc_rev() and norns.encoders.process or norns.encoders.process_with_accel
+--_norns.enc = norns.encoders.process_with_accel
 
 -- extend paths config table
 local p = _path


### PR DESCRIPTION
since adc reports at fixed rate, time-based encoder acceleration doesn't work.

this new code make the ticks exponential which emulates the feeling of the encoders.

tuned with magic number.