### PR TITLE
improve binary-style params

### DIFF
--- a/lua/core/menu.lua
+++ b/lua/core/menu.lua
@@ -31,6 +31,7 @@ _menu.errormsg = ""
 _menu.shownav = false
 _menu.showstats = false
 _menu.previewfile = ""
+_menu.binarystates = {triggered = {}, on = {}}
 
 -- menu pages
 local m = {}

--- a/lua/core/params/binary.lua
+++ b/lua/core/params/binary.lua
@@ -12,8 +12,8 @@ function Binary.new(id, name, behavior, default, allow_pmap)
   o.id = id
   o.name = name
   o.default = default or 0
-  o.value = o.default
   o.behavior = behavior or 'trigger'
+  o.value = o.behavior ~= 'trigger' and o.default or 1
   o.action = function() end
   if allow_pmap == nil then o.allow_pmap = true else o.allow_pmap = allow_pmap end
   return o
@@ -25,10 +25,18 @@ end
 
 function Binary:set(v, silent)
   local silent = silent or false
-  v = (v > 0) and 1 or 0
-  if self.value ~= v then
-    self.value = v
-    if silent==false then self:bang() end
+  local i = params.lookup[self.id]
+  v = v and v or 1
+  if self.behavior == 'trigger' and v > 0 then
+    _menu.binarystates.triggered[i] = 2
+    if silent == false then self:bang() end
+  elseif self.behavior ~= 'trigger' then
+    v = (v > 0) and 1 or 0
+    if self.value ~= v then
+      self.value = v
+      _menu.binarystates.on[i] = v
+      if silent == false then self:bang() end
+    end
   end
 end
 
@@ -47,7 +55,7 @@ function Binary:set_default()
 end
 
 function Binary:bang()
-  self.action(self.value)
+  self.action(self.behavior == 'trigger' and 1 or self.value)
 end
 
 function Binary:string()

--- a/lua/core/params/trigger.lua
+++ b/lua/core/params/trigger.lua
@@ -20,6 +20,8 @@ function Trigger:get()
 end
 
 function Trigger:set(v)
+  local i = params.lookup[self.id]
+  _menu.binarystates.triggered[i] = 2
   self:bang()
 end
 


### PR DESCRIPTION
while building docs for `binary`-style parameters, i came across a few API discontinuities, which this PR attempts to address.

- **E3 control**: as discussed in https://github.com/monome/norns/discussions/1752, E3 movement now only affects `"toggle"` behavior. it is ignored for `"momentary"` and `"trigger"`.
- **`params:set` now affects UI:**  previously, the `triggered` and `on` states for this param type did not update with `params:set`.
- **execute `"trigger"` without a value**: since triggers are _actions_, they can alternatively be executed with `params:set('example_trigger')` (this now matches the standard `trigger`-style parameter)

please  let me know if there's any additional questions or angles i missed! <3
