### PR TITLE
fix for paramset:read() not setting values

### DIFF
--- a/lua/core/paramset.lua
+++ b/lua/core/paramset.lua
@@ -548,6 +548,8 @@ function ParamSet:read(filename, silent)
                 if self.params[index].behavior ~= "trigger" then
                   self.params[index]:set(tonumber(value), silent)
                 end
+              else
+                self.params[index]:set(tonumber(value), silent)
               end
             elseif value == "-inf" then
               self.params[index]:set(-math.huge, silent)


### PR DESCRIPTION
Hi y'all, this fixes an issue introduced in #1785 which prevents paramset:read() from setting non-binary param values on .pset load. I'm not particularly confident poking around core files, but it seems to do the trick in my testing!