### PR TITLE
No option parameter overlap

### DIFF
--- a/lua/core/menu/params.lua
+++ b/lua/core/menu/params.lua
@@ -492,15 +492,20 @@ m.redraw = function()
             local label_width = screen.text_extents(label_str)
             local value_str = params:string(p)
             local value_width = screen.text_extents(value_str)
-            local original_font_size = screen.current_font_size()
-            local original_font_face = screen.current_font_face()
+            local orig_font_size = screen.current_font_size()
+            local orig_font_face = screen.current_font_face()
+            local orig_aa = screen.current_aa()
 
             if label_width + value_width + 1 > 127 then
               -- The value text is too long. First try using smaller font. Found that
               -- best somewhat smaller font is index 5 Roboto-Regular at size 7.
-              -- Anything smaller is simply not readable. The font for the edit params
-              -- page is set in core/menu.lua _menu.set_mode(). Default font size is 8
-              -- and default font face is 1.
+              -- Anything smaller is simply not readable. And it is important to make
+	      -- sure that anti-aliasing is off because it screws up some fonts like Robot.
+	      -- If want another smaller font can try 25 size 6, though it is actually wider
+	      -- than Roboto-Regular size 7. The font for the edit params page is set in 
+	      -- core/menu.lua _menu.set_mode(). Default font size is 8 and default font 
+	      -- face is 1.
+	      screen.aa(0)
               screen.font_face(5)
               screen.font_size(7)
               value_width = screen.text_extents(value_str)
@@ -515,13 +520,10 @@ m.redraw = function()
             -- Actually draw the value text
             screen.text_right(value_str)
 
-            -- If font size or face were changed, restore them
-            if screen.current_font_size() ~= original_font_size then
-              screen.font_size(original_font_size)
-            end
-            if screen.current_font_face() ~= original_font_face then
-              screen.font_face(original_font_face)
-            end
+            -- If font size, face, or anti-aliasing were changed, restore them
+            if screen.current_font_size() ~= orig_font_size then screen.font_size(orig_font_size) end
+            if screen.current_font_face() ~= orig_font_face then screen.font_face(orig_font_face) end
+            if screen.current_aa() ~= orig_aa then screen.aa(orig_aa) end
           end
         end
       end

--- a/lua/core/menu/params.lua
+++ b/lua/core/menu/params.lua
@@ -487,7 +487,41 @@ m.redraw = function()
               screen.fill()
             end
           else
-            screen.text_right(params:string(p))
+	    -- Display current selector value for param p
+            local label_str = params:get_name(p)
+            local label_width = screen.text_extents(label_str)
+            local value_str = params:string(p)
+            local value_width = screen.text_extents(value_str)
+            local original_font_size = screen.current_font_size()
+            local original_font_face = screen.current_font_face()
+
+            if label_width + value_width + 1 > 127 then
+              -- The value text is too long. First try using smaller font. Found that
+              -- best somewhat smaller font is index 5 Roboto-Regular at size 7.
+              -- Anything smaller is simply not readable. The font for the edit params
+              -- page is set in core/menu.lua _menu.set_mode(). Default font size is 8
+              -- and default font face is 1.
+              screen.font_face(5)
+              screen.font_size(7)
+              value_width = screen.text_extents(value_str)
+              if label_width + value_width + 1 > 127 then
+                -- Still too long. Don't want to try even smaller font so
+                -- move the value further to right so there is no overlap
+                local right_edge = label_width + value_width + 1
+                screen.move(right_edge, 10*i)
+              end
+            end
+
+            -- Actually draw the value text
+            screen.text_right(value_str)
+
+            -- If font size or face were changed, restore them
+            if screen.current_font_size() ~= original_font_size then
+              screen.font_size(original_font_size)
+            end
+            if screen.current_font_face() ~= original_font_face then
+              screen.font_face(original_font_face)
+            end
           end
         end
       end

--- a/lua/core/screen.lua
+++ b/lua/core/screen.lua
@@ -216,77 +216,86 @@ end
 Screen.current_point = function() return _norns.screen_current_point() end
 
 --- select font face.
--- @param index font face (see list, or Screen.font_face_names)
+-- @param index font face (see list, or use tab.print(screen.font_face_names) in the REPL for the full list)
 --
--- 1 norns (default)
--- 2 ALEPH
--- 3 Roboto Thin
--- 4 Roboto Light
--- 5 Roboto Regular
--- 6 Roboto Medium
--- 7 Roboto Bold
--- 8 Roboto Black
--- 9 Roboto Thin Italic
--- 10 Roboto Light Italic
--- 11 Roboto Italic
--- 12 Roboto Medium Italic
--- 13 Roboto Bold Italic
--- 14 Roboto Black Italic
--- 15 VeraBd
--- 16 VeraBI
--- 17 VeraIt
--- 18 VeraMoBd
--- 19 VeraMoBI
--- 20 VeraMoIt
--- 21 VeraMono
--- 22 VeraSeBd
--- 23 VeraSe
--- 24 Vera
--- 25 bmp/tom-thumb
--- 26 creep
--- 27 ctrld-fixed-10b
--- 28 ctrld-fixed-10r
--- 29 ctrld-fixed-13b
--- 30 ctrld-fixed-13b-i
--- 31 ctrld-fixed-13r
--- 32 ctrld-fixed-13r-i
--- 33 ctrld-fixed-16b
--- 34 ctrld-fixed-16b-i
--- 35 ctrld-fixed-16r
--- 36 ctrld-fixed-16r-i
--- 37 scientifica-11
--- 38 scientificaBold-11
--- 39 scientificaItalic-11
--- 40 ter-u12b
--- 41 ter-u12n
--- 42 ter-u14b
--- 43 ter-u14n
--- 44 ter-u14v
--- 45 ter-u16b
--- 46 ter-u16n
--- 47 ter-u16v
--- 48 ter-u18b
--- 49 ter-u18n
--- 50 ter-u20b
--- 51 ter-u20n
--- 52 ter-u22b
--- 53 ter-u22n
--- 54 ter-u24b
--- 55 ter-u24n
--- 56 ter-u28b
--- 57 ter-u28n
--- 58 ter-u32b
--- 59 ter-u32n
--- 60 unscii-16-full.pcf
--- 61 unscii-16.pcf
--- 62 unscii-8-alt.pcf
--- 63 unscii-8-fantasy.pcf
--- 64 unscii-8-mcr.pcf
--- 65 unscii-8.pcf
--- 66 unscii-8-tall.pcf
--- 67 unscii-8-thin.pcf
--- 68 Particle
-Screen.font_face = function(index) _norns.screen_font_face(index) end
+-- 1 04B_03 (norns default),
+-- 2 ALEPH,
+-- 3 Roboto Thin,
+-- 4 Roboto Light,
+-- 5 Roboto Regular,
+-- 6 Roboto Medium,
+-- 7 Roboto Bold,
+-- 8 Roboto Black,
+-- 9 Roboto Thin Italic,
+-- 10 Roboto Light Italic,
+-- 11 Roboto Italic,
+-- 12 Roboto Medium Italic,
+-- 13 Roboto Bold Italic,
+-- 14 Roboto Black Italic,
+-- 15 VeraBd,
+-- 16 VeraBI,
+-- 17 VeraIt,
+-- 18 VeraMoBd,
+-- 19 VeraMoBI,
+-- 20 VeraMoIt,
+-- 21 VeraMono,
+-- 22 VeraSeBd,
+-- 23 VeraSe,
+-- 24 Vera,
+-- 25 bmp/tom-thumb,
+-- 26 creep,
+-- 27 ctrld-fixed-10b,
+-- 28 ctrld-fixed-10r,
+-- 29 ctrld-fixed-13b,
+-- 30 ctrld-fixed-13b-i,
+-- 31 ctrld-fixed-13r,
+-- 32 ctrld-fixed-13r-i,
+-- 33 ctrld-fixed-16b,
+-- 34 ctrld-fixed-16b-i,
+-- 35 ctrld-fixed-16r,
+-- 36 ctrld-fixed-16r-i,
+-- 37 scientifica-11,
+-- 38 scientificaBold-11,
+-- 39 scientificaItalic-11,
+-- 40 ter-u12b,
+-- 41 ter-u12n,
+-- 42 ter-u14b,
+-- 43 ter-u14n,
+-- 44 ter-u14v,
+-- 45 ter-u16b,
+-- 46 ter-u16n,
+-- 47 ter-u16v,
+-- 48 ter-u18b,
+-- 49 ter-u18n,
+-- 50 ter-u20b,
+-- 51 ter-u20n,
+-- 52 ter-u22b,
+-- 53 ter-u22n,
+-- 54 ter-u24b,
+-- 55 ter-u24n,
+-- 56 ter-u28b,
+-- 57 ter-u28n,
+-- 58 ter-u32b,
+-- 59 ter-u32n,
+-- 60 unscii-16-full.pcf,
+-- 61 unscii-16.pcf,
+-- 62 unscii-8-alt.pcf,
+-- 63 unscii-8-fantasy.pcf,
+-- 64 unscii-8-mcr.pcf,
+-- 65 unscii-8.pcf,
+-- 66 unscii-8-tall.pcf,
+-- 67 unscii-8-thin.pcf,
+Screen.font_face = function(index) 
+	Screen._current_font_face_index = index
+	_norns.screen_font_face(index) 
+end
+
+-- Keeps track of last set font_face() 
+Screen._current_font_face_index = nil
+
+--- Retuns the last set font_face() index
+Screen.current_font_face = function(_) return Screen._current_font_face_index end
+
 Screen.font_face_count = 68
 Screen.font_face_names = {
    "norns",
@@ -359,9 +368,18 @@ Screen.font_face_names = {
    "Particle",
 }
 
+-- Keeps track of last font size used
+Screen._current_font_size = nil
+
 --- set font size.
 -- @tparam number size in pixel height.
-Screen.font_size = function(size) _norns.screen_font_size(size) end
+Screen.font_size = function(size) 
+	Screen._current_font_size = size
+	_norns.screen_font_size(size) 
+end
+
+--- returns the font size last set via Screen.font_size()
+Screen.current_font_size = function(_) return Screen._current_font_size end
 
 --- draw single pixel (requires integer x/y, fill afterwards).
 -- @tparam number x position

--- a/lua/core/screen.lua
+++ b/lua/core/screen.lua
@@ -57,9 +57,18 @@ end
 
 Screen.update = Screen.update_default
 
+Screen._current_aa = nil
+
 --- enable/disable anti-aliasing.
 -- @param state on(1) or off(0)
-Screen.aa = function(state) _norns.screen_aa(state) end
+Screen.aa = function(state) 
+  Screen._current_aa = state
+  _norns.screen_aa(state)
+end
+
+
+-- Get current anti-aliasing state
+Screen.current_aa = function() return Screen._current_aa end
 
 --- clear.
 Screen.clear = function() _norns.screen_clear() end


### PR DESCRIPTION
Modified menu/params.lua. If a script was using long names for a option parameter label and value then they could overlap. That looked really quite ugly! So changed the drawing of the selector so that if there would be an overlap it tries to use a smaller font. And if would overlap even with the smaller font, then will shift the value to the right, truncating it, so that there is no overlap. This will work for any script's parameter selector.

Since was changing the font, also updated screen.lua so can get current font attributes. That way can save the attributes, change to a narrower font, and then restore the initial font attributes.

An option parameter with the label "Group:" :
![small_so_no_overlap](https://github.com/user-attachments/assets/7d3db03b-4535-48ac-bedf-db5bea31818e)

If the value is long then there is ugly overlap:
![overlap](https://github.com/user-attachments/assets/9e2dfc7d-f7ca-475e-b56d-3b4294df960d)

But with this new software the value is reduced in size by using a narrower font, and clipping if need to:
![withSoftwareChange](https://github.com/user-attachments/assets/fda22337-8352-4a7e-b1a8-a2798ef47445)

You can test this yourself with this simple script:
```
-- testLongOptionParam.lua

-- For showing that a parameter selector where the label and value are
-- too long is still handled correctly, and that the label and value
-- do not overlap in an ugly way.

function init()
  params:clear()
  some_groups = {
    "short", 
    "longer group", 
    "now we are talking looong", 
    "now super duper long, truncates but works!"
  }
  
  params:add_separator("idSep1", "Option Parameter")
  params:add_option("group","Group:", some_groups, 1) 
end
```

