### PR TITLE
Better handle k1 short press

### DIFF
--- a/lua/core/menu.lua
+++ b/lua/core/menu.lua
@@ -125,33 +125,55 @@ _menu.enc = function(n, delta)
 end
 
 
+-- Handles all button presses both for the script and for the menus.
+-- It is how short presses on key1 are detected and handled.
 _norns.key = function(n, z)
   -- key 1 detect for short press
   if n == 1 then
     if z == 1 then
+      -- key 1 pressed so start timer
       _menu.alt = true
       pending = true
       t:start()
-    elseif z == 0 and pending == true then
+    elseif pending == true then
+      -- Key 1 released within the timer's allowed time so was short press.
       _menu.alt = false
+
+      -- Toggle menu mode. If was in menu mode will go to application mode,
+      -- and visa versa.
       if _menu.mode == true and _menu.locked == false then
         _menu.set_mode(false)
-      else _menu.set_mode(true) end
+      else
+        _menu.key(n,z) -- always 1,0
+
+        _menu.set_mode(true)
+      end
+
+      -- Done with short press timer so clear it
       t:stop()
       pending = false
-    elseif z == 0 then
-      _menu.alt = false
-      _menu.key(n,z) -- always 1,0
-      if _menu.mode == true then _menu.redraw() end
     else
-      _menu.key(n,z) -- always 1,1
+      -- key 1 released but not within allowed short time so pass event to script
+      _menu.alt = false
+      if _menu.mode == true and _menu.locked == false then
+        -- In menu mode. Should treat long k1 press same as short press and get out
+        -- of menu mode. This avoids user getting confused with hitting k1 and it
+        -- not working because it was down a bit too long.
+        _menu.set_mode(false)
+      else
+        -- Not in menu mode so simply pass through the k1 up info to the script app
+        _menu.key(n,z) -- always 1,0
+      end
     end
-    -- key 2/3 pass
   else
+    -- key 2 or 3 so pass through to menu key handler
     _menu.key(n,z)
   end
+
+  -- Restart screen saver timer
   screen.ping()
 end
+
 
 -- _menu.set mode
 _menu.set_mode = function(mode)

--- a/lua/core/paramset.lua
+++ b/lua/core/paramset.lua
@@ -296,7 +296,7 @@ end
 -- can be hidden / shown.
 -- @tparam string id (no spaces)
 -- @tparam string name (can contain spaces)
--- @tparam int n
+-- @tparam int n the number of subsequent parameters that will be put into this group
 function ParamSet:add_group(id, name, n)
   if id == nil then id = "group" end
   n = type(name) == "number" and name or (n or 1)


### PR DESCRIPTION
Found that there were couple issues with the handling of k1 short presses.

1. Somewhat hard to understand, so added comments
2. When in menu mode one had to do a short press, under 0.25 sec, to get back to script. But sometimes would press down bit too long and then nothing would happen, which was really confusing. So changed so that when in menu mode that a longer key press would get the user back to the script.
3. Wanted ability to create a script where user can hit k1 and then go directly to the scripts PARAMS Edit page. This is really nice for apps where user will want to change params. Won't have to do the kind of magical sequence of a short key1 press to get to Menus, then turn encoder1 to get to PARAMS menu, then turn encoder2 to select Edit>, and then click on key3 to finally get to the script's param page. That is way too difficult. But to give my script the ability to jump straight to the parameters page I needed a way of handling short key1 presses myself.
4. Took out unreachable code by the "elseif z == 0 then" because z couldn't ever be 0 there.

Also, completely unrelated, improved a comment in paramset.lua