### PR TITLE
fix text param val converting to number

### DIFF
--- a/lua/core/paramset.lua
+++ b/lua/core/paramset.lua
@@ -543,7 +543,7 @@ function ParamSet:read(filename, silent)
           local index = self.lookup[id]
 
           if index and self.params[index] and not param_already_set[index] then
-            if tonumber(value) ~= nil then
+            if self.params[index].t ~= self.tTEXT and tonumber(value) ~= nil then
               if self.params[index].t == self.tBINARY then
                 if self.params[index].behavior ~= "trigger" then
                   self.params[index]:set(tonumber(value), silent)


### PR DESCRIPTION
This PR addresses an issue that can cause "text" param values to be converted from strings to numbers when reading a pset file.

Note that the fix introduces the opposite behavior: if a text param was intentionally set with a number value, it will now be converted to a string upon pset read. That scenario seems like an edge case to me and is probably not how text params were intended to be used, but could still be seen as a breaking change.

Script to reproduce issue:
```lua
function init()
  -- init param with a string value that can be converted to a number
  params:add_text("text_1", "text_1", "1.1")
  print("param type at init: " .. type(params:string("text_1"))) -- string
  
  -- after saving and loading pset
  params.action_read = function()
    print("param type after pset read: " .. type(params:string("text_1"))) -- number
  end
end
```