### PR TITLE
Alias 04B_03 font to norns.ttf

### DIFF
--- a/doc/modules/screen.html
+++ b/doc/modules/screen.html
@@ -1065,6 +1065,7 @@
  66 unscii-8-tall.pcf
  67 unscii-8-thin.pcf
  68 Particle
+ 69 04B_03 (aliased to norns.ttf)
         </li>
     </ul>
 

--- a/lua/core/screen.lua
+++ b/lua/core/screen.lua
@@ -286,6 +286,7 @@ Screen.current_point = function() return _norns.screen_current_point() end
 -- 66 unscii-8-tall.pcf
 -- 67 unscii-8-thin.pcf
 -- 68 Particle
+-- 69 04B_03 (aliased to norns.ttf)
 Screen.font_face = function(index) _norns.screen_font_face(index) end
 Screen.font_face_count = 68
 Screen.font_face_names = {
@@ -357,6 +358,7 @@ Screen.font_face_names = {
    "bmp/unscii-8-tall",
    "bmp/unscii-8-thin",
    "Particle",
+   "04B_03__",
 }
 
 --- set font size.

--- a/matron/src/hardware/screen.c
+++ b/matron/src/hardware/screen.c
@@ -25,7 +25,7 @@
 #include "hardware/screen.h"
 #include "hardware/screen/ssd1322.h"
 
-#define NUM_FONTS 68
+#define NUM_FONTS 69
 #define NUM_OPS 29
 
 static char font_path[NUM_FONTS][32];
@@ -231,7 +231,7 @@ void init_font_faces(void) {
     //------------------
     // not specifically bitmap but added to the tail of the font list to avoid breaking changes
     strcpy(font_path[font_idx++], "Particle.ttf");
-
+    strcpy(font_path[font_idx++], "norns.ttf"); // alias 04B_03__.TTF to norns.ttf
     assert(font_idx == NUM_FONTS);
 
 #if 0 // is this really necessary?


### PR DESCRIPTION
Provides  scripts with an alias from the old “04B_03__” system font that points to the new norns.ttf. 