### PR TITLE
Add return values for Audio.file_info

### DIFF
--- a/doc/modules/audio.html
+++ b/doc/modules/audio.html
@@ -969,6 +969,18 @@
         </li>
     </ul>
 
+    <h3>Returns:</h3>
+    <ol>
+        <li>
+           <span class="types"><span class="type">integer</span></span>
+        number of audio channels</li>
+        <li>
+           <span class="types"><span class="type">integer</span></span>
+        number of samples</li>
+        <li>
+           <span class="types"><span class="type">integer</span></span>
+        sample rate</li>
+    </ol>
 
 
 

--- a/lua/core/audio.lua
+++ b/lua/core/audio.lua
@@ -247,8 +247,11 @@ end
 
 --- print audio file info 
 -- @tparam string path (from dust directory)
+-- @treturn integer number of audio channels
+-- @treturn integer number of samples
+-- @treturn integer sample rate
 function Audio.file_info(path)
-  -- dur, ch, rate
+  -- ch, samples, rate
   --print("file_info: " .. path)
   return _norns.sound_file_inspect(path)
 end


### PR DESCRIPTION
This PR documents the return values for `Audio.file_info`. These return values were validated against a known tape file:

```
> ch, samples, rate = audio.file_info("/home/we/dust/audio/tape/0001.wav")
> ch
2
> samples
72782080
> rate
48000
```

I wasn't sure whether I was supposed to regenerate the output html or not, so happy to remove that if it should be regenerated some other way.