### PR TITLE
protect against decimals in menu/tape.lua

### DIFF
--- a/lua/core/menu/tape.lua
+++ b/lua/core/menu/tape.lua
@@ -54,9 +54,10 @@ local function read_tape_index()
   tape = util.os_capture("ls ".._path.tape, true)
   local t = {}
   for f in tape:gmatch("([^\n]+)") do
-    fs = string.sub(f,1,4)
-    if tonumber(fs) then
-      table.insert(t,tonumber(fs))
+    local fs = string.sub(f,1,4)
+    local fi = tonumber(fs)
+    if fi and fi % 1 == 0 then -- % protects against decimals
+      table.insert(t,fi)
     end
   end
 


### PR DESCRIPTION
_from https://llllllll.co/t/tape-isnt-recording/64461/10_

re:
https://github.com/monome/norns/blob/e8e210ac4b7da320ac80c65ce605bbaccb6e7db8/lua/core/menu/tape.lua#L56-L61

if a file in `audio/tape` is named something like `10.20.24.wav`, then it'll be `string.sub`'d as index `10.2` which passes the `tonumber` check and gets assumed as `m.fileindex`. but, later on, [this `string.format`](https://github.com/monome/norns/blob/e8e210ac4b7da320ac80c65ce605bbaccb6e7db8/lua/core/menu/tape.lua#L166) fails, since `10.2` doesn't have an integer representation and then the entire TAPE record process fails to initiate.

a more robust fix would add `tapeindex` to the `norns.state` table for iteration, removing the need for this checking, but this modulo check seems like the least invasive option. happy to spin up in the other direction, though!