### PR TITLE
support crow ii functions with zero arguments

### DIFF
--- a/lua/core/crow.lua
+++ b/lua/core/crow.lua
@@ -216,7 +216,8 @@ local crowSub = {
     end,
 
     __call = function(self, ...)
-        local qt = quote(...)
+        local nargs = select("#", ...)
+        local qt = nargs > 0 and quote(...) or ''
         norns.crow.send(self.str .. '(' .. qt .. ')')
     end,
 }


### PR DESCRIPTION
While I playing around with the Norns wtape ii interface I noticed that `loop_start()` and `loop_end()` commands always failed:

```
> crow.ii.wtape[1].loop_start()
<ok>

crow:   repl:1: bad argument #1 to 'loop_start' (number expected, got nil)
crow:   stack traceback:
crow:   [C]: in field 'loop_start'
crow:   repl:1: in main chunk
crow:   runtime error.
```

This also happened for the wdel ii `clock()` command. After checking that Norns and crow were up-to-date, I tested the commands in druid and didn't have any issues. I also tested `crow.send("ii.wtape[1].loop_start()")` from Norns and didn't encounter the issue.

It turns out that Norns was sending the string `ii["wtape"][1]["loop_start"](nil)` to crow. I modified the `crowSub:__call` metamethod to check the number of varargs before calling quote.