### PR TITLE
Fix metro 'stage' bug

### DIFF
--- a/lua/core/metro.lua
+++ b/lua/core/metro.lua
@@ -95,12 +95,12 @@ function Metro:start(time, count, stage)
   if type(time) == "table" then
     if time.time then self.props.time = time.time end
     if time.count then self.props.count = time.count end
-    if time.stage then self.props.stage = time.stage end
+    if time.stage then self.props.init_stage = time.stage end
   else
 
     if time then self.props.time = time end
     if count then self.props.count = count end
-    if stage then self.init_stage = stage end
+    if stage then self.props.init_stage = stage end
   end
   self.is_running = true
   _norns.metro_start(self.props.id, self.props.time, self.props.count, self.props.init_stage) -- C function


### PR DESCRIPTION
This change fixes (what seems to be) a bug in the metro module. The bug is demonstrated by the code below - install it on a norns as script.

In the script, K2 should initialise a metronome then start it from stage = 3. However, by tracking the output in `journalctl -f` we see it starts from stage = 1. The expected output can be seen by pressing K3.

```lua
-- Demo of metro bug
-- K2 = Test with a table
-- K3 = Test with args


function print_stage(stage)
  print('stage = ' .. stage)
end


function key(n, z)
  if n == 2 and z == 1 then

    local m = metro.init(print_stage, 1, 6)
    print('Starting metro at stage 3 using a table...')
    m:start({stage = 3})

  elseif n == 3 and z == 1 then

    local m = metro.init(print_stage, 1, 6)
    print('Starting metro at stage 3 using multiple args...')
    m:start(1, 6, 3)

  end
end

function redraw()
  screen.move(0, 20)
  screen.text('Press K2 or K3')
  screen.move(0, 30)
  screen.text('and watch journalctl -f')
  screen.update()
end
```