### PR TITLE
Exclude directories from SELECT menu

### DIFF
--- a/lua/core/menu/select.lua
+++ b/lua/core/menu/select.lua
@@ -60,7 +60,7 @@ m.init = function()
   -- weird command, but it is fast, recursive, skips hidden dirs, and sorts
   norns.system_cmd('find ~/dust/code/ -mindepth 2 ' ..
                    '-name .git -prune -o -type f -name "*.lua" -printf "%P\n" | ' ..
-                   'grep -Ev "/(lib|data|crow|test)/" | ' ..
+                   'grep -Ev "/(lib|data|crow|test|docs)/" | ' ..
                    'sort',
                    sort_select_tree)
 end

--- a/lua/core/menu/select.lua
+++ b/lua/core/menu/select.lua
@@ -60,7 +60,7 @@ m.init = function()
   -- weird command, but it is fast, recursive, skips hidden dirs, and sorts
   norns.system_cmd('find ~/dust/code/ -mindepth 2 ' ..
                    '-name .git -prune -o -type f -name "*.lua" -printf "%P\n" | ' ..
-                   'grep -Ev "/(lib|data|crow)/" | ' ..
+                   'grep -Ev "/(lib|data|crow|test)/" | ' ..
                    'sort',
                    sort_select_tree)
 end


### PR DESCRIPTION
This is bug fix and an enhancement.
1. It would be good to put test scripts in their own folder, out of the way of the main code, and to not have them show up in the SELECT menu. This change allows that by excluding a `test` folder from the SELECT menu.
2. The documentation at https://monome.org/docs/norns/reference/#folder-structure says anything in a `docs` folder is excluded from the SELECT menu. That's not true (if it's a Lua script). This change also ensures that exclusion happens.

This change is documented in `monome/docs` PR [#435](https://github.com/monome/docs/pull/435).