### PR TITLE
Add more Pi variant platforms

### DIFF
--- a/matron/src/hardware/platform.c
+++ b/matron/src/hardware/platform.c
@@ -2,16 +2,36 @@
 #include <stdlib.h>
 
 #include "platform.h"
+#include <string.h>
+#include <stdio.h>
 
 platform_t p;
 
 void init_platform() {
   if(access("/sys/firmware/devicetree/base/model", F_OK ) != -1) {
-    if(system("cat /sys/firmware/devicetree/base/model | grep 'Compute'")) {
-      p = PLATFORM_PI3;
-    } else {
-      p = PLATFORM_CM3;
-    }
+
+	FILE* fptr = fopen("/sys/firmware/devicetree/base/model","r");
+	char modelString[100];
+	fgets(modelString, 100, fptr);
+	fclose(fptr);
+
+   if (strstr(modelString, "Compute Module 3")){
+     p = PLATFORM_CM3;
+   } else if (strstr(modelString, "Compute Module 4")){
+     p = PLATFORM_CM4;   
+   } else if (strstr(modelString, "Compute Module 4S")){
+     p = PLATFORM_CM4S;   
+   } else if (strstr(modelString, "Raspberry Pi 3")){
+     p = PLATFORM_PI3;
+   } else if (strstr(modelString, "Raspberry Pi 4")){
+     p = PLATFORM_PI4;
+   }
+
+//     if(system("cat /sys/firmware/devicetree/base/model | grep 'Compute Module 3'")) {
+//       p = PLATFORM_PI3;
+//     } else {
+//       p = PLATFORM_CM3;
+//     }
   } else {
     p = PLATFORM_OTHER;
   }

--- a/matron/src/hardware/platform.c
+++ b/matron/src/hardware/platform.c
@@ -26,12 +26,6 @@ void init_platform() {
    } else if (strstr(modelString, "Raspberry Pi 4")){
      p = PLATFORM_PI4;
    }
-
-//     if(system("cat /sys/firmware/devicetree/base/model | grep 'Compute Module 3'")) {
-//       p = PLATFORM_PI3;
-//     } else {
-//       p = PLATFORM_CM3;
-//     }
   } else {
     p = PLATFORM_OTHER;
   }

--- a/matron/src/hardware/platform.h
+++ b/matron/src/hardware/platform.h
@@ -5,6 +5,9 @@ typedef enum {
   PLATFORM_OTHER,
   PLATFORM_CM3,
   PLATFORM_PI3,
+  PLATFORM_PI4,
+  PLATFORM_CM4,
+  PLATFORM_CM4S,
 } platform_t;
 
 extern void init_platform(void);


### PR DESCRIPTION
PR to expand `platform.c` to include other Pi variants including `PLATFORM_PI4`, `PLATFORM_CM4`, and `PLATFORM_CM4S`

Rationale: Addresses cases of norns shield users with a Compute Module 4 in a Waveshare carrier board where the user will get the display rotated by 180 because the platform is incorrectly interpreted.

Previously tested as working with CM4 in a Waveshare carrier board. Does not change original enum indexing, so it should not affect CM3 norns.