### PR TITLE
fix crash on tty device connection when no serial mod is enabled

### DIFF
--- a/lua/core/startup.lua
+++ b/lua/core/startup.lua
@@ -25,6 +25,7 @@ poll = require 'core/poll'
 engine = tab.readonly{table = require 'core/engine', except = {'name'}}
 softcut = require 'core/softcut'
 wifi = require 'core/wifi'
+serial = require 'core/serial'
 controlspec = require 'core/controlspec'
 paramset = require 'core/paramset'
 params = paramset.new()


### PR DESCRIPTION
This was being set in a mod so I didn't notice that it was missing from the standard globals. 🤦‍♀️ 

Without it, Norns was crashing as soon as a tty device was connected.