### PR TITLE
feat: add `clock.link.get_number_of_peers()`

### DIFF
--- a/lua/core/clock.lua
+++ b/lua/core/clock.lua
@@ -190,6 +190,11 @@ clock.link.set_start_stop_sync = function(enabled)
   return _norns.clock_link_set_start_stop_sync(enabled)
 end
 
+--- returns the number of other devices present in the Link session with this norns.
+clock.link.get_number_of_peers = function()
+  return _norns.clock_link_get_number_of_peers()
+end
+
 _norns.clock.start = function()
   if clock.transport.start ~= nil then
     clock.transport.start()

--- a/matron/src/clock.c
+++ b/matron/src/clock.c
@@ -1,6 +1,7 @@
 #include <math.h>
 #include <pthread.h>
 #include <stdbool.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 
@@ -139,4 +140,8 @@ void clock_set_source(clock_source_t source) {
 
     clock_source = source;
     clock_scheduler_reschedule_sync_events();
+}
+
+uint64_t clock_number_of_link_peers() {
+    return clock_link_number_of_peers();
 }

--- a/matron/src/clock.h
+++ b/matron/src/clock.h
@@ -2,7 +2,6 @@
 
 #include <pthread.h>
 #include <stdbool.h>
-#include <stdint.h>
 
 typedef enum {
     CLOCK_SOURCE_INTERNAL = 0,
@@ -32,4 +31,3 @@ void clock_set_source(clock_source_t source);
 double clock_get_beats();
 double clock_get_system_time();
 double clock_get_tempo();
-uint64_t clock_number_of_link_peers();

--- a/matron/src/clock.h
+++ b/matron/src/clock.h
@@ -2,6 +2,7 @@
 
 #include <pthread.h>
 #include <stdbool.h>
+#include <stdint.h>
 
 typedef enum {
     CLOCK_SOURCE_INTERNAL = 0,
@@ -31,3 +32,4 @@ void clock_set_source(clock_source_t source);
 double clock_get_beats();
 double clock_get_system_time();
 double clock_get_tempo();
+uint64_t clock_number_of_link_peers();

--- a/matron/src/clocks/clock_link.c
+++ b/matron/src/clocks/clock_link.c
@@ -16,7 +16,6 @@ static pthread_t clock_link_thread;
 static struct clock_link_shared_data_t {
     double quantum;
     double requested_tempo;
-    uint64_t number_of_peers;
     bool playing;
     bool enabled;
     bool start_stop_sync;

--- a/matron/src/clocks/clock_link.c
+++ b/matron/src/clocks/clock_link.c
@@ -100,7 +100,6 @@ void clock_link_start() {
     pthread_attr_t attr;
     pthread_attr_init(&attr);
 
-    clock_link_shared_data.number_of_peers = 0;
     clock_link_shared_data.quantum = 4;
     clock_link_shared_data.requested_tempo = 0;
     clock_link_shared_data.enabled = false;

--- a/matron/src/clocks/clock_link.c
+++ b/matron/src/clocks/clock_link.c
@@ -25,15 +25,15 @@ static struct clock_link_shared_data_t {
     pthread_mutex_t lock;
 } clock_link_shared_data;
 
+static abl_link link;
+
 static clock_reference_t clock_link_reference;
 
 static void *clock_link_run(void *p) {
     (void)p;
 
-    abl_link link;
     abl_link_session_state state;
 
-    link = abl_link_create(120);
     state = abl_link_create_session_state();
 
     while (true) {
@@ -81,11 +81,6 @@ static void *clock_link_run(void *p) {
             }
 
             abl_link_enable(link, clock_link_shared_data.enabled);
-            if (!clock_link_shared_data.enabled) {
-                clock_link_shared_data.number_of_peers = 0;
-            } else {
-                clock_link_shared_data.number_of_peers = abl_link_num_peers(link);
-            }
             abl_link_enable_start_stop_sync(link, clock_link_shared_data.start_stop_sync);
 
             pthread_mutex_unlock(&clock_link_shared_data.lock);
@@ -98,6 +93,7 @@ static void *clock_link_run(void *p) {
 }
 
 void clock_link_init() {
+    link = abl_link_create(120);
     clock_reference_init(&clock_link_reference);
 }
 
@@ -164,8 +160,5 @@ double clock_link_get_tempo() {
 }
 
 uint64_t clock_link_number_of_peers() {
-    pthread_mutex_lock(&clock_link_shared_data.lock);
-    uint64_t ret = clock_link_shared_data.number_of_peers;
-    pthread_mutex_unlock(&clock_link_shared_data.lock);
-    return ret;
+    return abl_link_num_peers(link);
 }

--- a/matron/src/clocks/clock_link.c
+++ b/matron/src/clocks/clock_link.c
@@ -1,4 +1,3 @@
-#include <cstdint>
 #include <pthread.h>
 #include <stdbool.h>
 #include <stdint.h>
@@ -24,7 +23,7 @@ static struct clock_link_shared_data_t {
     pthread_mutex_t lock;
 } clock_link_shared_data;
 
-static abl_link link;
+static abl_link link_instance;
 
 static clock_reference_t clock_link_reference;
 
@@ -37,22 +36,22 @@ static void *clock_link_run(void *p) {
 
     while (true) {
         if (pthread_mutex_trylock(&clock_link_shared_data.lock) == 0) {
-            abl_link_capture_app_session_state(link, state);
+            abl_link_capture_app_session_state(link_instance, state);
 
-            uint64_t micros = abl_link_clock_micros(link);
+            uint64_t micros = abl_link_clock_micros(link_instance);
             double link_tempo = abl_link_tempo(state);
             bool link_playing = abl_link_is_playing(state);
 
 
             if (clock_link_shared_data.transport_start) {
                 abl_link_set_is_playing(state, true, micros);
-                abl_link_commit_app_session_state(link, state);
+                abl_link_commit_app_session_state(link_instance, state);
                 clock_link_shared_data.transport_start = false;
             }
 
             if (clock_link_shared_data.transport_stop) {
                 abl_link_set_is_playing(state, false, micros);
-                abl_link_commit_app_session_state(link, state);
+                abl_link_commit_app_session_state(link_instance, state);
                 clock_link_shared_data.transport_stop = false;
             }
 
@@ -63,7 +62,7 @@ static void *clock_link_run(void *p) {
 
                     // this will also reschedule pending sync events to beat 0
                     clock_start_from_source(CLOCK_SOURCE_LINK);
-                    abl_link_commit_app_session_state(link, state);
+                    abl_link_commit_app_session_state(link_instance, state);
                 } else if (clock_link_shared_data.playing && !link_playing) {
                     clock_link_shared_data.playing = false;
                     clock_stop_from_source(CLOCK_SOURCE_LINK);
@@ -75,12 +74,12 @@ static void *clock_link_run(void *p) {
 
             if (clock_link_shared_data.requested_tempo > 0) {
                 abl_link_set_tempo(state, clock_link_shared_data.requested_tempo, micros);
-                abl_link_commit_app_session_state(link, state);
+                abl_link_commit_app_session_state(link_instance, state);
                 clock_link_shared_data.requested_tempo = 0;
             }
 
-            abl_link_enable(link, clock_link_shared_data.enabled);
-            abl_link_enable_start_stop_sync(link, clock_link_shared_data.start_stop_sync);
+            abl_link_enable(link_instance, clock_link_shared_data.enabled);
+            abl_link_enable_start_stop_sync(link_instance, clock_link_shared_data.start_stop_sync);
 
             pthread_mutex_unlock(&clock_link_shared_data.lock);
         }
@@ -92,7 +91,7 @@ static void *clock_link_run(void *p) {
 }
 
 void clock_link_init() {
-    link = abl_link_create(120);
+    link_instance = abl_link_create(120);
     clock_reference_init(&clock_link_reference);
 }
 
@@ -158,5 +157,5 @@ double clock_link_get_tempo() {
 }
 
 uint64_t clock_link_number_of_peers() {
-    return abl_link_num_peers(link);
+    return abl_link_num_peers(link_instance);
 }

--- a/matron/src/clocks/clock_link.h
+++ b/matron/src/clocks/clock_link.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <stdint.h>
+
 void clock_link_init();
 void clock_link_start();
 void clock_link_join_session();
@@ -11,3 +13,4 @@ void clock_link_set_transport_stop();
 void clock_link_set_start_stop_sync(bool sync_enabled);
 double clock_link_get_beat();
 double clock_link_get_tempo();
+uint64_t clock_link_number_of_peers();

--- a/matron/src/weaver.c
+++ b/matron/src/weaver.c
@@ -2112,7 +2112,7 @@ int _clock_crow_in_div(lua_State *l) {
 
 #if HAVE_ABLETON_LINK
 int _clock_link_get_number_of_peers(lua_State *l) {
-    uint64_t peers = clock_number_of_link_peers();
+    uint64_t peers = clock_link_number_of_peers();
     lua_pushinteger(l, (lua_Integer)peers);
     return 1;
 }

--- a/matron/src/weaver.c
+++ b/matron/src/weaver.c
@@ -295,6 +295,7 @@ static int _clock_link_set_quantum(lua_State *l);
 static int _clock_link_set_transport_stop(lua_State *l);
 static int _clock_link_set_transport_start(lua_State *l);
 static int _clock_link_set_start_stop_sync(lua_State *l);
+static int _clock_link_get_number_of_peers(lua_State *l);
 #endif
 static int _clock_set_source(lua_State *l);
 static int _clock_get_time_beats(lua_State *l);
@@ -570,6 +571,7 @@ void w_init(void) {
 #if HAVE_ABLETON_LINK
     lua_register_norns("clock_link_set_tempo", &_clock_link_set_tempo);
     lua_register_norns("clock_link_set_quantum", &_clock_link_set_quantum);
+    lua_register_norns("clock_link_get_number_of_peers", &_clock_link_get_number_of_peers);
     lua_register_norns("clock_link_set_transport_start", &_clock_link_set_transport_start);
     lua_register_norns("clock_link_set_transport_stop", &_clock_link_set_transport_stop);
     lua_register_norns("clock_link_set_start_stop_sync", &_clock_link_set_start_stop_sync);
@@ -2109,6 +2111,12 @@ int _clock_crow_in_div(lua_State *l) {
 }
 
 #if HAVE_ABLETON_LINK
+int _clock_link_get_number_of_peers(lua_State *l) {
+    uint64_t peers = clock_number_of_link_peers();
+    lua_pushinteger(l, (lua_Integer)peers);
+    return 1;
+}
+
 int _clock_link_set_tempo(lua_State *l) {
     lua_check_num_args(1);
     double bpm = luaL_checknumber(l, 1);


### PR DESCRIPTION
this PR adds `_norns.clock_link_get_number_of_peers()` a new Lua function which will return the number of peers connected to this Norns over Ableton Link.

[related discussion on Lines:](https://llllllll.co/t/ableton-link-and-norns-question/39335/11?u=alanza)

~~this PR does *not* make a user-facing change to display the number of peers anywhere on norns, but it enables that change to be made solely in Lua. i'd happily help brainstorm or contribute that Lua change as well, if there's interest.~~