### PR TITLE
serial handlers can transmit and receive messages with embedded zeroes

### DIFF
--- a/matron/src/device/device_serial.c
+++ b/matron/src/device/device_serial.c
@@ -193,9 +193,9 @@ void dev_serial_deinit(void *self) {
     free(di->handler_id);
 }
 
-void dev_serial_send(struct dev_serial *d, const char *line) {
+void dev_serial_send(struct dev_serial *d, const char *line, size_t len) {
     if (d == NULL) {
         return;
     }
-    write(d->fd, line, strlen(line));
+    write(d->fd, line, len);
 }

--- a/matron/src/device/device_serial.h
+++ b/matron/src/device/device_serial.h
@@ -23,5 +23,5 @@ int dev_serial_init(void *self, lua_State *l);
 void *dev_serial_start(void *self);
 void dev_serial_deinit(void *self);
 
-void dev_serial_send(struct dev_serial *d, const char *line);
+void dev_serial_send(struct dev_serial *d, const char *line, size_t len);
 

--- a/matron/src/device/device_serial.h
+++ b/matron/src/device/device_serial.h
@@ -10,7 +10,6 @@
 #include <libevdev/libevdev.h>
 
 #define BUFFER_SIZE 256
-static const unsigned int max_read = BUFFER_SIZE - 1;
 
 struct dev_serial {
     struct dev_common base;

--- a/matron/src/event_types.h
+++ b/matron/src/event_types.h
@@ -363,7 +363,9 @@ struct event_serial_event {
     struct event_common common;
     void *dev;
     uint32_t id;
-}; // +8
+    char *data;
+    ssize_t len;
+}; // +16
 
 // forward declaration to hide scripting layer dependencies
 struct event_custom_ops;

--- a/matron/src/events.c
+++ b/matron/src/events.c
@@ -145,6 +145,9 @@ MATRON_API void event_data_free(union event_data *ev) {
     case EVENT_SERIAL_REMOVE:
         free(ev->serial_remove.handler_id);
         break;
+    case EVENT_SERIAL_EVENT:
+        free(ev->serial_event.data);
+        break;
     case EVENT_CUSTOM:
         if (ev->custom.ops->free) {
             ev->custom.ops->free(ev->custom.value, ev->custom.context);
@@ -327,7 +330,7 @@ static void handle_event(union event_data *ev) {
         w_handle_serial_remove(ev->serial_remove.id, ev->serial_remove.handler_id);
         break;
     case EVENT_SERIAL_EVENT:
-        w_handle_serial_event(ev->serial_event.dev, ev->serial_event.id);
+        w_handle_serial_event(ev->serial_event.dev, ev->serial_event.id, ev->serial_event.data, ev->serial_event.len);
         break;
     } /* switch */
 

--- a/matron/src/events.c
+++ b/matron/src/events.c
@@ -147,6 +147,7 @@ MATRON_API void event_data_free(union event_data *ev) {
         break;
     case EVENT_SERIAL_EVENT:
         free(ev->serial_event.data);
+        ev->serial_event.data = NULL;
         break;
     case EVENT_CUSTOM:
         if (ev->custom.ops->free) {

--- a/matron/src/weaver.c
+++ b/matron/src/weaver.c
@@ -2356,12 +2356,12 @@ void w_handle_serial_remove(uint32_t id, char *handler_id) {
     l_report(lvm, l_docall(lvm, 2, 0));
 }
 
-void w_handle_serial_event(void *dev, uint32_t id) {
+void w_handle_serial_event(void *dev, uint32_t id, char *data, ssize_t len) {
     struct dev_serial *d = (struct dev_serial *)dev;
     _push_norns_func("serial", "event");
     lua_pushstring(lvm, d->handler_id);
     lua_pushinteger(lvm, id + 1); // convert to 1-base
-    lua_pushstring(lvm, d->line);
+    lua_pushlstring(lvm, data, len);
     l_report(lvm, l_docall(lvm, 3, 0));
 }
 

--- a/matron/src/weaver.c
+++ b/matron/src/weaver.c
@@ -1658,10 +1658,11 @@ int _serial_send(lua_State *l) {
 
     luaL_checktype(l, 1, LUA_TLIGHTUSERDATA);
     d = lua_touserdata(l, 1);
-    s = luaL_checkstring(l, 2);
+    size_t len = 0;
+    s = luaL_checklstring(l, 2, &len);
     lua_settop(l, 0);
 
-    dev_serial_send(d, s);
+    dev_serial_send(d, s, len);
 
     return 0;
 }

--- a/matron/src/weaver.h
+++ b/matron/src/weaver.h
@@ -51,7 +51,7 @@ extern void w_handle_crow_event(void *dev, int id);
 
 extern void w_handle_serial_add(void *dev);
 extern void w_handle_serial_remove(uint32_t id, char *handler_id);
-extern void w_handle_serial_event(void *dev, uint32_t id);
+extern void w_handle_serial_event(void *dev, uint32_t id, char *data, ssize_t len);
 
 extern void w_handle_serial_config(char *path, char *name, char *vendor, char *model, char *serial, char *interface);
 


### PR DESCRIPTION
Switch to using `lua_pushlstring` so that messages containing null characters can reach the Lua handler. This makes it possible to interpret the serial data as something other than ascii characters.

I also changed the serial event struct to embed a heap-allocated copy of the serial data. The serial read thread does not sleep other than waiting for IO. It's possible for it to read multiple times in a row before the event loop has a chance to process the messages if the serial device is sending a lot of data. This could lead to messages being overwritten in the buffer and effectively "dropped".

EDIT: Oops, just realized this affects sending messages also.