### PR TITLE
Print serial terminal settings

### DIFF
--- a/lua/core/serial.lua
+++ b/lua/core/serial.lua
@@ -12,7 +12,8 @@ local serial = {
 -- @param args.match function(attrs) returning true if the handler should accept the device with the given attributes, 
 --   otherwise false
 -- @param args.configure function(term) receiving the device's initial terminal settings and returning the new terminal
---   settings. The callback should modify the input table using bitwise operations and then return the input table
+--   settings. The callback should modify the input table using bitwise operations and then return the input table. term
+--   is a TerminalIO instance.
 -- @param args.add function(id, name, dev) called when a new device for this handler has been connected and initialized
 -- @param args.remove function(id) called when a connected device for this  handler has been disconnected
 -- @param args.event function(id, data) called when a message is received from a connected device for this handler. The 
@@ -36,6 +37,9 @@ local serial = {
 --   end,
 --
 --   configure = function(term)
+--       -- print the current settings
+--       term:print()
+--
 --       -- set baud rate.
 --       term.ispeed = term.ispeed | serial.speed.B115200
 --       term.ospeed = term.ospeed | serial.speed.B115200

--- a/lua/core/serial.lua
+++ b/lua/core/serial.lua
@@ -149,7 +149,7 @@ serial.cc = tab.readonly{table = {
 -- @field ISTRIP Strip 8th bit off characters.
 -- @field INCLR Map NL to CR on input.
 -- @field IGNCR Ignore CR.
--- @field ICRNL Map CT to NL on input.
+-- @field ICRNL Map CR to NL on input.
 -- @field IUCLC Map uppercase characters to lowercase on input (not in POSIX).
 -- @field IXON Enable start/stop output control.
 -- @field IXANY Enable any character to restart output.

--- a/matron/src/device/device_serial.c
+++ b/matron/src/device/device_serial.c
@@ -74,7 +74,7 @@ int dev_serial_init(void *self, lua_State *l) {
     lua_createtable(l, NCCS, 0);
     for (int i = 0; i < NCCS; i++) {
         lua_pushinteger(l, d->oldtio.c_cc[i]);
-        lua_rawseti(l, -2, i+1);
+        lua_rawseti(l, -2, i);
     }
     lua_setfield(l, -2, CC);
     l_report(l, l_docall(l, 2, 1));


### PR DESCRIPTION
- Sets a TerminalIO metatable on the `term` table passed to `handler.configure(term)` with a `:print()` method for printing the current settings. This functions similarly to executing `stty -F /path/to/tty -a` on the command line.
- Fixes a small typo in the cc table docs
- Fixes an off-by-one error when loading the CC values into Lua