### PR TITLE
issue screen error on audio system fail

### DIFF
--- a/matron/src/jack_client.c
+++ b/matron/src/jack_client.c
@@ -4,6 +4,7 @@
 #include <jack/jack.h>
 
 #include "screen.h"
+#include "hardware/screen/ssd1322.h"
 
 static jack_client_t *jack_client;
 double jack_sample_rate;
@@ -35,9 +36,10 @@ int jack_client_init() {
 fail:
   screen_clear();
   screen_level(15);
-  screen_move(0, 60);
-  screen_text("jack fail.");
+  screen_move(10, 40);
+  screen_text("audio system fail.");
   screen_update();
+  ssd1322_refresh();
   return 1;
 }
 

--- a/matron/src/jack_client.c
+++ b/matron/src/jack_client.c
@@ -3,8 +3,6 @@
 
 #include <jack/jack.h>
 
-#include "screen.h"
-#include "hardware/screen/ssd1322.h"
 
 static jack_client_t *jack_client;
 double jack_sample_rate;
@@ -34,12 +32,6 @@ int jack_client_init() {
   jack_sample_rate = (float)jack_get_sample_rate(jack_client);
   return 0;
 fail:
-  screen_clear();
-  screen_level(15);
-  screen_move(10, 40);
-  screen_text("audio system fail.");
-  screen_update();
-  ssd1322_refresh();
   return 1;
 }
 

--- a/matron/src/main.c
+++ b/matron/src/main.c
@@ -74,8 +74,12 @@ int main(int argc, char **argv) {
     battery_init();
     stat_init();
     osc_init();
-    jack_client_init();
     ssd1322_init();
+    if(jack_client_init()) {
+    	usleep(1000000);
+    	ssd1322_deinit();
+    	return -1;
+    }
     clock_init();
     clock_internal_init();
     clock_midi_init();

--- a/matron/src/main.c
+++ b/matron/src/main.c
@@ -75,10 +75,15 @@ int main(int argc, char **argv) {
     stat_init();
     osc_init();
     ssd1322_init();
-    if(jack_client_init()) {
-    	usleep(1000000);
-    	return -1;
-    }
+		if(jack_client_init()) {
+			screen_clear();
+			screen_level(15);
+			screen_move(10, 40);
+			screen_text("audio system fail.");
+			screen_update();
+			ssd1322_refresh();
+			return -1;
+		}
     clock_init();
     clock_internal_init();
     clock_midi_init();

--- a/matron/src/main.c
+++ b/matron/src/main.c
@@ -77,7 +77,6 @@ int main(int argc, char **argv) {
     ssd1322_init();
     if(jack_client_init()) {
     	usleep(1000000);
-    	ssd1322_deinit();
     	return -1;
     }
     clock_init();


### PR DESCRIPTION
fixes #1830

Shows "audio system fail" when jack does not start.

Potential improvement might be "any key to shut down" --- currently shutdown requires remote login or white button. We don't want to shut down with a timer, to allow debugging.