### PR TITLE
fix cm4s platform detection and screen

### DIFF
--- a/matron/src/hardware/platform.c
+++ b/matron/src/hardware/platform.c
@@ -10,27 +10,48 @@ platform_t p;
 void init_platform() {
   if(access("/sys/firmware/devicetree/base/model", F_OK ) != -1) {
 
-	FILE* fptr = fopen("/sys/firmware/devicetree/base/model","r");
-	char modelString[100];
-	fgets(modelString, 100, fptr);
-	fclose(fptr);
+    FILE* fptr = fopen("/sys/firmware/devicetree/base/model","r");
+    char modelString[100];
+    fgets(modelString, 100, fptr);
+    fclose(fptr);
 
-   if (strstr(modelString, "Compute Module 3")){
-     p = PLATFORM_CM3;
-   } else if (strstr(modelString, "Compute Module 4")){
-     p = PLATFORM_CM4;   
-   } else if (strstr(modelString, "Compute Module 4S")){
-     p = PLATFORM_CM4S;   
-   } else if (strstr(modelString, "Raspberry Pi 3")){
-     p = PLATFORM_PI3;
-   } else if (strstr(modelString, "Raspberry Pi 4")){
-     p = PLATFORM_PI4;
-   }
-  } else {
-    p = PLATFORM_OTHER;
+    if (strstr(modelString, "Compute Module 3")){
+      p = PLATFORM_CM3;
+    } else if (strstr(modelString, "Compute Module 4S")){
+      p = PLATFORM_CM4S;
+    } else if (strstr(modelString, "Compute Module 4")){
+      p = PLATFORM_CM4;
+    } else if (strstr(modelString, "Raspberry Pi 3")){
+      p = PLATFORM_PI3;
+    } else if (strstr(modelString, "Raspberry Pi 4")){
+      p = PLATFORM_PI4;
+    } else {
+      p = PLATFORM_OTHER;
+    }
   }
 }
 
 platform_t platform() {
   return p;
+}
+
+const char* platform_name() {
+  switch (platform()) {
+  case PLATFORM_CM3:
+    return "cm3";
+  case PLATFORM_CM4:
+    return "cm4";
+  case PLATFORM_CM4S:
+    return "cm4s";
+  case PLATFORM_PI3:
+    return "pi3";
+  case PLATFORM_PI4:
+    return "pi4";
+  case PLATFORM_OTHER:
+    return "other";
+  default:
+    break;
+  }
+
+  return "unknown";
 }

--- a/matron/src/hardware/platform.c
+++ b/matron/src/hardware/platform.c
@@ -5,7 +5,7 @@
 #include <string.h>
 #include <stdio.h>
 
-platform_t p;
+static platform_t p = PLATFORM_UNKNOWN;
 
 void init_platform() {
   if(access("/sys/firmware/devicetree/base/model", F_OK ) != -1) {

--- a/matron/src/hardware/platform.h
+++ b/matron/src/hardware/platform.h
@@ -12,3 +12,4 @@ typedef enum {
 
 extern void init_platform(void);
 extern platform_t platform(void);
+extern const char* platform_name(void);

--- a/matron/src/hardware/screen/ssd1322.c
+++ b/matron/src/hardware/screen/ssd1322.c
@@ -185,11 +185,15 @@ void ssd1322_init() {
     write_command(SSD1322_SET_DISPLAY_MODE_NORMAL);
 
     // Flips the screen orientation if the device is a norns shield.
-    if( platform() != PLATFORM_CM3 ){
-        write_command_with_data(SSD1322_SET_DUAL_COMM_LINE_MODE, 0x04, 0x11);
-    }
-    else{
+    switch (platform()) {
+    case PLATFORM_CM3:
+    case PLATFORM_CM4:
+    case PLATFORM_CM4S:
         write_command_with_data(SSD1322_SET_DUAL_COMM_LINE_MODE, 0x16, 0x11);
+        break;
+    default:
+        write_command_with_data(SSD1322_SET_DUAL_COMM_LINE_MODE, 0x04, 0x11);
+        break;
     }
 
     // Do not turn display on until the first update has been called,

--- a/matron/src/main.c
+++ b/matron/src/main.c
@@ -61,7 +61,7 @@ int main(int argc, char **argv) {
 
     print_version();
     init_platform();
-    printf("platform: %d\n",platform());
+    printf("platform: %s (%d)\n", platform_name(), platform());
 
     events_init(); // <-- must come first!
     if (config_init()) {


### PR DESCRIPTION
this probably impacts a very tiny number of norns users... possibly only one

* adds `platform_name()` function for obtaining a string representation of which platform was detected
* fixes "CM4S" detection, previously always reported as "CM4" due to substring matching
* chooses normal screen orientation for CM3, CM4, and CM4S devices (CM4 case is debatable)
* reports the platform name on startup along with platform enum number

warning: i haven't tested this on any other devices other than a unicorn og norns + cm4s