### PR TITLE
weaver: wrap jack functions introspect and alter port connections

### DIFF
--- a/matron/src/jack_client.c
+++ b/matron/src/jack_client.c
@@ -3,6 +3,8 @@
 
 #include <jack/jack.h>
 
+#include "jack_client.h"
+
 
 static jack_client_t *jack_client;
 double jack_sample_rate;
@@ -47,3 +49,32 @@ uint32_t jack_client_get_xrun_count() {
 double jack_client_get_current_time() {
   return (double)jack_frame_time(jack_client) / jack_sample_rate;
 }
+
+const char** jack_client_get_input_ports() {
+  return jack_get_ports(jack_client, NULL, NULL, JackPortIsInput);
+}
+
+const char** jack_client_get_output_ports() {
+  return jack_get_ports(jack_client, NULL, NULL, JackPortIsOutput);
+}
+
+const char** jack_client_get_port_connections(const char *port_name) {
+  const jack_port_t *port = jack_port_by_name(jack_client, port_name);
+  if (port != NULL) {
+    return jack_port_get_all_connections(jack_client, port);
+  }
+  return NULL;
+}
+
+bool jack_client_connect(const char *source_name, const char *destination_name) {
+  return jack_connect(jack_client, source_name, destination_name) == 0;
+}
+
+bool jack_client_disconnect(const char *source_name, const char *destination_name) {
+  return jack_disconnect(jack_client, source_name, destination_name) == 0;
+}
+
+void jack_client_free_port_list(const char **list) {
+  jack_free(list);
+}
+

--- a/matron/src/jack_client.h
+++ b/matron/src/jack_client.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <stdint.h>
+#include <stdbool.h>
 
 // exposed for the clock module?
 extern double jack_sample_rate;
@@ -10,7 +11,7 @@ extern int jack_client_init();
 
 extern void jack_client_deinit();
 
-// return the running estimate of audio CPU load reported by jack 
+// return the running estimate of audio CPU load reported by jack
 // returns ratio in [0,1]
 extern float jack_client_get_cpu_load();
 
@@ -19,3 +20,10 @@ extern uint32_t jack_client_get_xrun_count();
 
 // get JACks current system time estimate in seconds (computed from sample frames)
 extern double jack_client_get_current_time();
+
+extern const char** jack_client_get_input_ports();
+extern const char** jack_client_get_output_ports();
+extern const char** jack_client_get_port_connections(const char *port_name);
+extern void jack_client_free_port_list(const char **list);
+extern bool jack_client_connect(const char *source_name, const char *destination_name);
+extern bool jack_client_disconnect(const char *source_name, const char *destination_name);


### PR DESCRIPTION
this pulls over functionality from the stalled "converged" branch, expanding the internal `_norns.audio_*` functions suite to include:

- `audio_get_{input,output}_ports` - introspect available jack ports
- `audio_{connect,disconnect}` - change jack port connections
- `audio_get_port_connections` - introspect what is connected to a given port

this eliminates the need to run shell commands to manipulate connections. not included are changes to `startup.lua` which uses these functions as opposed to the current `os.execute(...)` approach. 