### PR TITLE
feat(ci): add compile step to use Dockerfile to build norns

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -1,0 +1,23 @@
+name: compile
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  compile-norns:
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: compile norns
+        uses: addnab/docker-run-action@v3
+        with:
+          image: robbielyman/norns-ci:latest
+          options: -v ${{ github.workspace }}:/norns-build
+          run: |
+            ./waf configure --release && ./waf build --release


### PR DESCRIPTION
This commit adds `.github/workflows/compile.yml` which uses the Dockerfile from #1838 to run a build of the norns system via GitHub Actions.

thanks very much to @Dewb for the help wrangling Docker!

currently the workflow effectively just gives a heads up or down about whether the changes compiled or not, and the docker image is hosted by my account on Docker Hub, while a GitHub Container Registry entry owned by Monome might make more sense. plenty of interesting future work possible from here, too, such as building new norns images, automatically running a test script, that sort of thing.