### PR TITLE
Fixes .clang-format syntax

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -91,7 +91,7 @@ PenaltyExcessCharacter: 1000000
 PenaltyReturnTypeOnItsOwnLine: 60
 PointerAlignment: Right
 RawStringFormats:
-  - Delimiter:       pb
+  - Delimiters:       [pb]
     Language:        TextProto
     BasedOnStyle:    google
 ReflowComments:  true
@@ -111,4 +111,3 @@ SpacesInSquareBrackets: false
 Standard:        Cpp11
 TabWidth:        8
 UseTab:          Never
-...


### PR DESCRIPTION
_what?_

Fixed incorrect syntax in `.clang-format` configuration file on line 94.

_why?_

The `RawStringFormats` section had invalid syntax (`Delimiter: pb` instead of `Delimiters: [pb]`), preventing clang-format from running properly.

_therefore_

clang-format now works correctly with the `clang-format.sh` script for formatting C/C++ code in the project.