### PR TITLE
Update clang-format script to include additional source directories

### DIFF
--- a/clang-format.sh
+++ b/clang-format.sh
@@ -2,3 +2,6 @@
 # run this from top-level norns directory before committing...
 find ws-wrapper/src -regex .*[\.][ch] | xargs clang-format -i
 find matron/src -regex .*[\.][ch] | xargs clang-format -i
+find maiden-repl/src -regex .*[\.][ch] | xargs clang-format -i
+find crone/src -type f \( -name '*.c' -o -name '*.h' -o -name '*.cpp' \) | xargs clang-format -i
+find watcher/src -regex .*[\.][ch] | xargs clang-format -i


### PR DESCRIPTION
_what?_

Added `maiden-repl/src`, `crone/src`, and `watcher/src` to `clang-format.sh`

_why?_

I believe this should be the entirety of the norns C/C++ code. Let me know if I've missed anything.
With this norns will have a shared style upheld throughout the codebase.