### PR TITLE
fix factory + cm4s headphone and battery

### DIFF
--- a/lua/core/norns.lua
+++ b/lua/core/norns.lua
@@ -195,11 +195,11 @@ end
 -- 3 = PI3 (norns shield)
 norns.platform = _norns.platform()
 
---- true if we are running on norns (CM3)
-norns.is_norns = norns.platform == 2
+--- true if we are running on norns (CM3, CM4, CM4S)
+norns.is_norns = _norns.platform_factory()
 
---- true if we are running on norns shield (PI3)
-norns.is_shield = norns.platform == 3
+--- true if we are running on norns shield (PI3, PI4)
+norns.is_shield = _norns.platform_shield()
 
 -- Util (system_cmd)
 local system_cmd_q = {}

--- a/matron/src/hardware/battery.c
+++ b/matron/src/hardware/battery.c
@@ -28,7 +28,7 @@ void *battery_check(void *);
 // extern def
 
 void battery_init() {
-    if (platform() != PLATFORM_CM3)
+    if (!platform_factory())
         return;
 
     fd[0] = open("/sys/class/power_supply/bq27441-0/capacity", O_RDONLY | O_NONBLOCK);

--- a/matron/src/hardware/battery.c
+++ b/matron/src/hardware/battery.c
@@ -31,6 +31,8 @@ void battery_init() {
     if (!platform_factory())
         return;
 
+    fprintf(stderr, "battery init...\n");
+
     fd[0] = open("/sys/class/power_supply/bq27441-0/capacity", O_RDONLY | O_NONBLOCK);
     fd[1] = open("/sys/class/power_supply/bq27441-0/status", O_RDONLY | O_NONBLOCK);
     fd[2] = open("/sys/class/power_supply/bq27441-0/current_now", O_RDONLY | O_NONBLOCK);

--- a/matron/src/hardware/i2c.c
+++ b/matron/src/hardware/i2c.c
@@ -49,8 +49,9 @@ int adc_rev() {
 void *adc_read(void *);
 
 void i2c_init(void) {
-    if (platform() != PLATFORM_CM3)
+    if (!platform_factory())
         return;
+
     char filename[40];
 
     fprintf(stderr, "i2c init...\n");
@@ -82,25 +83,25 @@ void i2c_init(void) {
     buf[0] = 8; // 0-5 only
     buf[1] = 0xC0;
     if (write(file, buf, 2) != 2) {
-        fprintf(stderr, "ERROR (i2c/adc) failed to write\n");
+        fprintf(stderr, "ERROR (i2c/adc) failed to write [chan]\n");
         return;
     }
     buf[0] = 7; // continuous
     buf[1] = 1;
     if (write(file, buf, 2) != 2) {
-        fprintf(stderr, "ERROR (i2c/adc) failed to write\n");
+        fprintf(stderr, "ERROR (i2c/adc) failed to write [cont]\n");
         return;
     }
     buf[0] = 0xB; // ext vref
     buf[1] = 1;
     if (write(file, buf, 2) != 2) {
-        fprintf(stderr, "ERROR (i2c/hp) failed to write\n");
+        fprintf(stderr, "ERROR (i2c/adc) failed to write [vref]\n");
         return;
     }
     buf[0] = 0; // config, p20
     buf[1] = 1; // start
     if (write(file, buf, 2) != 2) {
-        fprintf(stderr, "ERROR (i2c/adc) failed to write\n");
+        fprintf(stderr, "ERROR (i2c/adc) failed to write [start]\n");
         return;
     }
 
@@ -115,7 +116,7 @@ void i2c_deinit() {
 }
 
 void i2c_hp(int level) {
-    if (platform() != PLATFORM_CM3)
+    if (!platform_factory())
         return;
 
     if (level < 0) {

--- a/matron/src/hardware/platform.c
+++ b/matron/src/hardware/platform.c
@@ -55,3 +55,19 @@ const char *platform_name() {
 
     return "unknown";
 }
+
+bool platform_factory() {
+    switch (platform()) {
+    case PLATFORM_CM3:
+    case PLATFORM_CM4:
+    case PLATFORM_CM4S:
+        return true;
+    default:
+        break;
+    }
+    return false;
+}
+
+bool platform_shield() {
+    return !platform_factory();
+}

--- a/matron/src/hardware/platform.h
+++ b/matron/src/hardware/platform.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <stdbool.h>
+
 typedef enum {
     PLATFORM_UNKNOWN = 0,
     PLATFORM_OTHER,
@@ -13,3 +15,6 @@ typedef enum {
 extern void init_platform(void);
 extern platform_t platform(void);
 extern const char *platform_name(void);
+
+extern bool platform_factory();
+extern bool platform_shield();

--- a/matron/src/hardware/screen/ssd1322.c
+++ b/matron/src/hardware/screen/ssd1322.c
@@ -181,15 +181,10 @@ void ssd1322_init() {
     write_command(SSD1322_SET_DISPLAY_MODE_NORMAL);
 
     // Flips the screen orientation if the device is a norns shield.
-    switch (platform()) {
-    case PLATFORM_CM3:
-    case PLATFORM_CM4:
-    case PLATFORM_CM4S:
+    if (platform_factory()) {
         write_command_with_data(SSD1322_SET_DUAL_COMM_LINE_MODE, 0x16, 0x11);
-        break;
-    default:
+    } else {
         write_command_with_data(SSD1322_SET_DUAL_COMM_LINE_MODE, 0x04, 0x11);
-        break;
     }
 
     // Do not turn display on until the first update has been called,

--- a/matron/src/weaver.c
+++ b/matron/src/weaver.c
@@ -319,6 +319,8 @@ static int _wall_time_get_delta(lua_State *l);
 
 // platform detection (CM3 vs PI3 vs OTHER)
 static int _platform(lua_State *l);
+static int _platform_factory(lua_State *l);
+static int _platform_shield(lua_State *l);
 
 // boilerplate: push a lua function to the lua stack, from named field in global 'norns'
 static inline void _push_norns_func(const char *field, const char *func) {
@@ -602,6 +604,8 @@ void w_init(void) {
 
     // platform
     lua_register_norns("platform", &_platform);
+    lua_register_norns("platform_factory", &_platform_factory);
+    lua_register_norns("platform_shield", &_platform_shield);
 
     // name global extern table
     lua_setglobal(lvm, "_norns");
@@ -3337,6 +3341,18 @@ int _system_glob(lua_State *l) {
 int _platform(lua_State *l) {
     lua_check_num_args(0);
     lua_pushinteger(l, platform());
+    return 1;
+}
+
+int _platform_factory(lua_State *l) {
+    lua_check_num_args(0);
+    lua_pushboolean(l, platform_factory());
+    return 1;
+}
+
+int _platform_shield(lua_State *l) {
+    lua_check_num_args(0);
+    lua_pushboolean(l, platform_shield());
     return 1;
 }
 


### PR DESCRIPTION
- adds `platform_{factory,shield}` functions to determine hw category
- changes screen flip logic to use `platform_factory`
- allows i2c and battery init if platform_factory == true
- allows i2c_hp if platform_factory == true

Overall this change appears bring a factory norns with cm4s up to functional parity with a cm3/cm3+ device. I would recommend testing on a cm3 based device before merging.