### PR TITLE
fix: tab.load with empty files

### DIFF
--- a/lua/lib/tabutil.lua
+++ b/lua/lib/tabutil.lua
@@ -193,22 +193,26 @@ function tab.load(sfile)
   local ftables,err = loadfile(sfile)
   if err then return _, err end
   local tables = ftables()
-  for idx = 1, #tables do
-    local tolinki = {}
-    for i, v in pairs(tables[idx]) do
-      if type(v) == "table" then
-        tables[idx][i] = tables[v[1]]
+  if tables ~= nil then
+    for idx = 1, #tables do
+      local tolinki = {}
+      for i, v in pairs(tables[idx]) do
+        if type(v) == "table" then
+          tables[idx][i] = tables[v[1]]
+        end
+        if type(i) == "table" and tables[i[1]] then
+          table.insert(tolinki, { i, tables[i[1]] })
+        end
       end
-      if type(i) == "table" and tables[i[1]] then
-        table.insert(tolinki, { i, tables[i[1]] })
+      -- link indices
+      for _, v in ipairs(tolinki) do
+        tables[idx][v[2]], tables[idx][v[1]] =  tables[idx][v[1]], nil
       end
     end
-    -- link indices
-    for _, v in ipairs(tolinki) do
-      tables[idx][v[2]], tables[idx][v[1]] =  tables[idx][v[1]], nil
-    end
+    return tables[1]
+  else
+    return nil
   end
-  return tables[1]
 end
 
 --- Create a read-only proxy for a given table.


### PR DESCRIPTION
fixes #1840 

currently, if `tab.load` is passed a file which *does* exist but *does not* have any content, it will pass this initial `err` check:
https://github.com/monome/norns/blob/7868b30da976ddb9d69b60d3cb5e6270980b3f81/lua/lib/tabutil.lua#L193-L196

...but Lua will error when returning an index of a `nil` table, as is attempted here:
https://github.com/monome/norns/blob/7868b30da976ddb9d69b60d3cb5e6270980b3f81/lua/lib/tabutil.lua#L211

so, this PR simply checks to see if the table is `nil` and if so, returns `nil`.
confirmed that this successfully bypasses the conditions of #1840, and the scripting user will see a script-level error (rather than a library error), which feels *a lot* clearer / friendlier.

eg. using this test script:

```lua
function init()
  stuff = tab.load(_path.data.."system.favorites") -- assumes `system.favorites` is empty
  print(stuff[1])
end
```

**before**
```bash
### SCRIPT ERROR: init
/home/we/norns/lua/lib/tabutil.lua:198: attempt to get length of a nil value (local 'tables')
stack traceback:
	/home/we/norns/lua/core/norns.lua:147: in metamethod '__len'
	/home/we/norns/lua/lib/tabutil.lua:198: in function 'tabutil.load'
	/home/we/dust/code/testing/test-stuff.lua:2: in global 'init'
	/home/we/norns/lua/core/script.lua:139: in function 'core/script.init'
	[C]: in function 'xpcall'
	/home/we/norns/lua/core/norns.lua:148: in field 'try'
	/home/we/norns/lua/core/engine.lua:96: in function </home/we/norns/lua/core/engine.lua:94>
```
**after**
```bash
### SCRIPT ERROR: init
/home/we/dust/code/testing/test-stuff.lua:3: attempt to index a nil value (global 'stuff')
stack traceback:
	/home/we/norns/lua/core/norns.lua:147: in metamethod '__index'
	/home/we/dust/code/testing/test-stuff.lua:3: in global 'init'
	/home/we/norns/lua/core/script.lua:139: in function 'core/script.init'
	[C]: in function 'xpcall'
	/home/we/norns/lua/core/norns.lua:148: in field 'try'
	/home/we/norns/lua/core/engine.lua:96: in function </home/we/norns/lua/core/engine.lua:94>
```