### PR TITLE
fix ticks size in clock_internal

### DIFF
--- a/matron/src/clocks/clock_internal.c
+++ b/matron/src/clocks/clock_internal.c
@@ -43,7 +43,7 @@ static void *clock_internal_thread_run(void *p) {
     double tick_duration;
     double reference_beat;
 
-    uint64_t ticks = -1;
+    uint64_t ticks = 0;
 
     current_time = clock_get_system_time();
     next_tick_time = current_time;


### PR DESCRIPTION
this should fix an issue with internal clock stuck at a given tempo, see https://llllllll.co/t/norns-clock/30738/152?u=artfwo