### PR TITLE
add c/c++ testing infrastructure and tests + fix for clock internal and jack client timing issues

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,42 @@ on:
     branches: [main]
   workflow_dispatch:
 jobs:
+  test-c_cpp:
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - name: check out repository
+        uses: actions/checkout@v4
+        with:
+          submodules: 'recursive'
+
+      - name: ensure build directory exists
+        # this is needed so that the cache action can do the caching
+        run: mkdir -p build
+
+      - name: cache waf build directory
+        uses: actions/cache@v4
+        with:
+          path: build
+          # create a cache key based on the wscript files
+          key: ${{ runner.os }}-waf-build-${{ hashFiles('**/wscript') }}
+          restore-keys: |
+            ${{ runner.os }}-waf-build-
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2 
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pre-build dev container image and run tests inside dev container
+        uses: devcontainers/ci@v0.3
+        with:
+          imageName: ghcr.io/monome/norns-ci
+          cacheFrom: ghcr.io/monome/norns-ci
+          push: never
+          runCmd: ./waf configure && sh ./test.sh
+
   test-lua:
     runs-on: ubuntu-latest
     steps:

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,12 @@
+[submodule "third-party/doctest"]
+	path = third-party/doctest
+	url = https://github.com/doctest/doctest.git
 [submodule "third-party/link"]
 	path = third-party/link
 	url = https://github.com/Ableton/link.git
+[submodule "third-party/trompeloeil"]
+	path = third-party/trompeloeil
+	url = https://github.com/rollbear/trompeloeil.git
 [submodule "crone/softcut"]
 	path = crone/softcut
 	url = https://github.com/monome/softcut-lib.git

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,4 +57,61 @@ api docs for main
 to view the api docs for the `main` branch,
 visit https://monome.org/docs/norns/api.
 
+testing c/c++ code
+------------------
 
+### quick start
+
+run all tests:
+```bash
+./test.sh
+```
+
+run specific test:
+```bash
+# example: run matron `clock.h` tests
+./test.sh --targets=test_matron_clock
+```
+
+see [tests/README.md](tests/README.md) for infrastructure details, advanced patterns, and comprehensive examples.
+
+### writing your first test
+
+tests mirror source structure. create `test_*.cpp` files, and they get picked up by the test runner automatically:
+
+```
+tests/matron/test_args.cpp               → matron/src/args.c
+tests/crone/test_window.cpp              → crone/src/Window.cpp
+```
+
+**test C code:**
+
+```cpp
+#include <doctest/doctest.h>
+
+extern "C" {
+#include "args.h"
+}
+
+TEST_CASE("args_parse handles local port") {
+    char *argv[] = {"matron", "-l", "8888", nullptr};
+    args_parse(3, argv);
+    CHECK(std::string(args_local_port()) == "8888");
+}
+```
+
+**test C++ code:**
+
+```cpp
+#include <doctest/doctest.h>
+#include "Window.h"
+
+TEST_CASE("window starts at zero") {
+    CHECK(Window::raisedCosShort[0] == doctest::Approx(0.0f));
+}
+```
+
+**assertions:**
+- `CHECK(expr)` — non-fatal
+- `REQUIRE(expr)` — fatal, stops test
+- `CHECK(value == doctest::Approx(expected))` — floating point

--- a/clang-format.sh
+++ b/clang-format.sh
@@ -5,3 +5,4 @@ find matron/src -regex .*[\.][ch] | xargs clang-format -i
 find maiden-repl/src -regex .*[\.][ch] | xargs clang-format -i
 find crone/src -type f \( -name '*.c' -o -name '*.h' -o -name '*.cpp' \) | xargs clang-format -i
 find watcher/src -regex .*[\.][ch] | xargs clang-format -i
+find tests -type f \( -name '*.c' -o -name '*.h' -o -name '*.cpp' -o -name '*.hpp' \) | xargs clang-format -i

--- a/crone/src/Window.cpp
+++ b/crone/src/Window.cpp
@@ -6,6 +6,8 @@
 
 using namespace crone;
 
+constexpr size_t Window::raisedCosShortLen;
+
 const float Window::raisedCosShort[Window::raisedCosShortLen] = {
 #include "cos_win.h"
 };

--- a/matron/src/args.c
+++ b/matron/src/args.c
@@ -26,16 +26,19 @@ int args_parse(int argc, char **argv) {
     while ((opt = getopt(argc, argv, "o:e:l:c:f:h")) != -1) {
         switch (opt) {
         case 'l':
-            strncpy(a.loc_port, optarg, ARG_BUF_SIZE - 1);
+            snprintf(a.loc_port, ARG_BUF_SIZE, "%s", optarg);
             break;
         case 'e':
-            strncpy(a.ext_port, optarg, ARG_BUF_SIZE - 1);
+            snprintf(a.ext_port, ARG_BUF_SIZE, "%s", optarg);
             break;
         case 'o':
-            strncpy(a.remote_port, optarg, ARG_BUF_SIZE - 1);
+            snprintf(a.remote_port, ARG_BUF_SIZE, "%s", optarg);
             break;
         case 'c':
-            strncpy(a.crone_port, optarg, ARG_BUF_SIZE - 1);
+            snprintf(a.crone_port, ARG_BUF_SIZE, "%s", optarg);
+            break;
+        case 'f':
+            snprintf(a.framebuffer, ARG_BUF_SIZE, "%s", optarg);
             break;
         case '?':
         case 'h':
@@ -43,7 +46,9 @@ int args_parse(int argc, char **argv) {
             fprintf(stdout, "Start matron with optional overrides:\n");
             fprintf(stdout, "-l   override OSC local port [default %s]\n", a.loc_port);
             fprintf(stdout, "-e   override OSC ext port [default %s]\n", a.ext_port);
+            fprintf(stdout, "-o   override OSC remote port [default %s]\n", a.remote_port);
             fprintf(stdout, "-c   override crone port [default %s]\n", a.crone_port);
+            fprintf(stdout, "-f   override framebuffer path [default %s]\n", a.framebuffer);
             exit(1);
             ;
         }
@@ -65,4 +70,8 @@ const char *args_remote_port(void) {
 
 const char *args_crone_port(void) {
     return a.crone_port;
+}
+
+const char *args_framebuffer_path(void) {
+    return a.framebuffer;
 }

--- a/matron/src/args.h
+++ b/matron/src/args.h
@@ -6,4 +6,4 @@ extern const char *args_local_port(void);
 extern const char *args_ext_port(void);
 extern const char *args_remote_port(void);
 extern const char *args_crone_port(void);
-extern const char *args_monome_path(void);
+extern const char *args_framebuffer_path(void);

--- a/matron/src/clock.h
+++ b/matron/src/clock.h
@@ -2,6 +2,7 @@
 
 #include <pthread.h>
 #include <stdbool.h>
+#include <stdint.h>
 
 typedef enum {
     CLOCK_SOURCE_INTERNAL = 0,
@@ -31,3 +32,4 @@ void clock_set_source(clock_source_t source);
 double clock_get_beats();
 double clock_get_system_time();
 double clock_get_tempo();
+uint64_t clock_number_of_link_peers();

--- a/matron/src/clocks/clock_internal.c
+++ b/matron/src/clocks/clock_internal.c
@@ -1,5 +1,6 @@
 #include <math.h>
 #include <pthread.h>
+#include <stdatomic.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -18,11 +19,24 @@ typedef struct {
 } clock_internal_tempo_t;
 
 static pthread_t clock_internal_thread;
+static bool clock_internal_thread_started = false;
 static clock_reference_t clock_internal_reference;
 static bool clock_internal_restarted;
 
 static clock_internal_tempo_t clock_internal_tempo;
 static pthread_mutex_t clock_internal_tempo_lock;
+
+#ifdef NORNS_TEST
+// test synchronization and state variables
+static bool clock_internal_threadless = false;
+static uint64_t clock_internal_test_ticks = 0;
+static _Atomic uint64_t clock_internal_published_ticks = 0;
+static volatile bool clock_internal_thread_stop = false;
+static volatile double clock_internal_last_sleep_s = 0.0;
+static volatile double clock_internal_last_next_tick_time = 0.0;
+static volatile double clock_internal_last_current_time = 0.0;
+static volatile double clock_internal_last_tick_duration = 0.0;
+#endif
 
 static void clock_internal_sleep(double seconds) {
     struct timespec ts;
@@ -49,6 +63,12 @@ static void *clock_internal_thread_run(void *p) {
     next_tick_time = current_time;
 
     while (true) {
+#ifdef NORNS_TEST
+        // allow tests to stop the thread loop cleanly.
+        if (clock_internal_thread_stop) {
+            break;
+        }
+#endif
         current_time = clock_get_system_time();
 
         pthread_mutex_lock(&clock_internal_tempo_lock);
@@ -56,7 +76,19 @@ static void *clock_internal_thread_run(void *p) {
         tick_duration = clock_internal_tempo.tick_duration;
         pthread_mutex_unlock(&clock_internal_tempo_lock);
 
-        clock_internal_sleep(tick_duration + (next_tick_time - current_time));
+        // compute sleep: base tick interval + drift correction.
+        double raw_sleep_s = tick_duration + (next_tick_time - current_time);
+        double sleep_s = raw_sleep_s < 0 ? 0 : raw_sleep_s;
+
+#ifdef NORNS_TEST
+        // expose loop internals to validate scheduling.
+        clock_internal_last_current_time = current_time;
+        clock_internal_last_next_tick_time = next_tick_time;
+        clock_internal_last_tick_duration = tick_duration;
+        // expose pre-clamp sleep value.
+        clock_internal_last_sleep_s = raw_sleep_s;
+#endif
+        clock_internal_sleep(sleep_s);
 
         if (clock_internal_restarted) {
             ticks = 0;
@@ -72,7 +104,23 @@ static void *clock_internal_thread_run(void *p) {
             clock_update_source_reference(&clock_internal_reference, reference_beat, beat_duration);
         }
 
+#ifdef NORNS_TEST
+        // count publishes so tests can wait for progress without sleeps.
+        atomic_fetch_add(&clock_internal_published_ticks, 1);
+#endif
+
         next_tick_time += tick_duration;
+
+        // if schedule is >1 tick behind (time jump, suspend, or jack stall),
+        // skip ahead to avoid runaway catchup.
+        current_time = clock_get_system_time();
+        if (next_tick_time + tick_duration < current_time) {
+            double lag = current_time - next_tick_time;
+            // calculate skipped ticks. place
+            // next_tick_time one tick after current_time to resume pacing.
+            uint64_t catchup_ticks = (uint64_t)floor(lag / tick_duration);
+            next_tick_time += (catchup_ticks + 1) * tick_duration;
+        }
     }
 
     return NULL;
@@ -81,9 +129,17 @@ static void *clock_internal_thread_run(void *p) {
 static void clock_internal_start() {
     pthread_attr_t attr;
 
+#ifdef NORNS_TEST
+    // in tests, skip background thread creation.
+    if (clock_internal_threadless) {
+        return;
+    }
+#endif
+
     pthread_attr_init(&attr);
     pthread_create(&clock_internal_thread, &attr, &clock_internal_thread_run, NULL);
     pthread_attr_destroy(&attr);
+    clock_internal_thread_started = true;
 }
 
 void clock_internal_init() {
@@ -117,3 +173,89 @@ double clock_internal_get_beat() {
 double clock_internal_get_tempo() {
     return clock_get_reference_tempo(&clock_internal_reference);
 }
+
+// -----------------------------------------------------------------------------
+// test seams
+// test-only code. compiled only with NORNS_TEST.
+// -----------------------------------------------------------------------------
+
+#ifdef NORNS_TEST
+// allow disabling background thread. step one tick manually.
+// expose internals and counters for test synchronization.
+
+void clock_internal_test_enable_threadless(bool enable) {
+    clock_internal_threadless = enable;
+}
+
+// step single tick without background thread.
+void clock_internal_test_tick_once() {
+    double beat_duration;
+    double tick_duration;
+
+    pthread_mutex_lock(&clock_internal_tempo_lock);
+    beat_duration = clock_internal_tempo.beat_duration;
+    tick_duration = clock_internal_tempo.tick_duration;
+    pthread_mutex_unlock(&clock_internal_tempo_lock);
+
+    (void)tick_duration; // unused in test stepping.
+
+    if (clock_internal_restarted) {
+        clock_internal_test_ticks = 0;
+        double reference_beat = 0;
+
+        clock_update_source_reference(&clock_internal_reference, reference_beat, beat_duration);
+        clock_start_from_source(CLOCK_SOURCE_INTERNAL);
+
+        clock_internal_restarted = false;
+    } else {
+        clock_internal_test_ticks++;
+        double reference_beat = (double)clock_internal_test_ticks / CLOCK_INTERNAL_TICKS_PER_BEAT;
+        clock_update_source_reference(&clock_internal_reference, reference_beat, beat_duration);
+    }
+    atomic_fetch_add(&clock_internal_published_ticks, 1);
+}
+
+// set internal tick counter. simulate uptime and boundary cases.
+void clock_internal_test_set_ticks(uint64_t v) {
+    clock_internal_test_ticks = v;
+}
+
+// read published ticks for test sync.
+uint64_t clock_internal_test_get_published_ticks(void) {
+    return atomic_load(&clock_internal_published_ticks);
+}
+
+// reset published tick counter.
+void clock_internal_test_reset_published_ticks(void) {
+    atomic_store(&clock_internal_published_ticks, 0);
+}
+
+// stop background thread. join for clean teardown.
+void clock_internal_test_stop_thread(void) {
+    clock_internal_thread_stop = true;
+    // join thread only if started.
+    // no background thread in threadless mode.
+    if (clock_internal_thread_started) {
+        pthread_join(clock_internal_thread, NULL);
+        clock_internal_thread_started = false;
+    }
+    clock_internal_thread_stop = false;
+}
+
+// expose last computed sleep (seconds) before clamping.
+double clock_internal_test_get_last_sleep_s(void) {
+    return clock_internal_last_sleep_s;
+}
+// expose last scheduled next_tick_time.
+double clock_internal_test_get_last_next_tick_time(void) {
+    return clock_internal_last_next_tick_time;
+}
+// expose last sampled current_time.
+double clock_internal_test_get_last_current_time(void) {
+    return clock_internal_last_current_time;
+}
+// expose current tick_duration.
+double clock_internal_test_get_last_tick_duration(void) {
+    return clock_internal_last_tick_duration;
+}
+#endif // NORNS_TEST

--- a/matron/src/clocks/clock_link.c
+++ b/matron/src/clocks/clock_link.c
@@ -27,6 +27,59 @@ static abl_link clock_link;
 
 static clock_reference_t clock_link_reference;
 
+static void clock_link_step(abl_link_session_state state) {
+    // exit early if lock is not available
+    if (pthread_mutex_trylock(&clock_link_shared_data.lock) != 0) {
+        return;
+    }
+
+    abl_link_capture_app_session_state(clock_link, state);
+
+    uint64_t micros = abl_link_clock_micros(clock_link);
+    double link_tempo = abl_link_tempo(state);
+    bool link_playing = abl_link_is_playing(state);
+
+    if (clock_link_shared_data.transport_start) {
+        abl_link_set_is_playing(state, true, micros);
+        abl_link_commit_app_session_state(clock_link, state);
+        clock_link_shared_data.transport_start = false;
+    }
+
+    if (clock_link_shared_data.transport_stop) {
+        abl_link_set_is_playing(state, false, micros);
+        abl_link_commit_app_session_state(clock_link, state);
+        clock_link_shared_data.transport_stop = false;
+    }
+
+    if (clock_link_shared_data.start_stop_sync) {
+        if (!clock_link_shared_data.playing && link_playing) {
+            abl_link_request_beat_at_start_playing_time(state, 0, clock_link_shared_data.quantum);
+            clock_link_shared_data.playing = true;
+
+            // this will also reschedule pending sync events to beat 0
+            clock_start_from_source(CLOCK_SOURCE_LINK);
+            abl_link_commit_app_session_state(clock_link, state);
+        } else if (clock_link_shared_data.playing && !link_playing) {
+            clock_link_shared_data.playing = false;
+            clock_stop_from_source(CLOCK_SOURCE_LINK);
+        }
+    }
+
+    double link_beat = abl_link_beat_at_time(state, micros, clock_link_shared_data.quantum);
+    clock_update_source_reference(&clock_link_reference, link_beat, 60.0f / link_tempo);
+
+    if (clock_link_shared_data.requested_tempo > 0) {
+        abl_link_set_tempo(state, clock_link_shared_data.requested_tempo, micros);
+        abl_link_commit_app_session_state(clock_link, state);
+        clock_link_shared_data.requested_tempo = 0;
+    }
+
+    abl_link_enable(clock_link, clock_link_shared_data.enabled);
+    abl_link_enable_start_stop_sync(clock_link, clock_link_shared_data.start_stop_sync);
+
+    pthread_mutex_unlock(&clock_link_shared_data.lock);
+}
+
 static void *clock_link_run(void *p) {
     (void)p;
 
@@ -35,53 +88,7 @@ static void *clock_link_run(void *p) {
     state = abl_link_create_session_state();
 
     while (true) {
-        if (pthread_mutex_trylock(&clock_link_shared_data.lock) == 0) {
-            abl_link_capture_app_session_state(clock_link, state);
-
-            uint64_t micros = abl_link_clock_micros(clock_link);
-            double link_tempo = abl_link_tempo(state);
-            bool link_playing = abl_link_is_playing(state);
-
-            if (clock_link_shared_data.transport_start) {
-                abl_link_set_is_playing(state, true, micros);
-                abl_link_commit_app_session_state(clock_link, state);
-                clock_link_shared_data.transport_start = false;
-            }
-
-            if (clock_link_shared_data.transport_stop) {
-                abl_link_set_is_playing(state, false, micros);
-                abl_link_commit_app_session_state(clock_link, state);
-                clock_link_shared_data.transport_stop = false;
-            }
-
-            if (clock_link_shared_data.start_stop_sync) {
-                if (!clock_link_shared_data.playing && link_playing) {
-                    abl_link_request_beat_at_start_playing_time(state, 0, clock_link_shared_data.quantum);
-                    clock_link_shared_data.playing = true;
-
-                    // this will also reschedule pending sync events to beat 0
-                    clock_start_from_source(CLOCK_SOURCE_LINK);
-                    abl_link_commit_app_session_state(clock_link, state);
-                } else if (clock_link_shared_data.playing && !link_playing) {
-                    clock_link_shared_data.playing = false;
-                    clock_stop_from_source(CLOCK_SOURCE_LINK);
-                }
-            }
-
-            double link_beat = abl_link_beat_at_time(state, micros, clock_link_shared_data.quantum);
-            clock_update_source_reference(&clock_link_reference, link_beat, 60.0f / link_tempo);
-
-            if (clock_link_shared_data.requested_tempo > 0) {
-                abl_link_set_tempo(state, clock_link_shared_data.requested_tempo, micros);
-                abl_link_commit_app_session_state(clock_link, state);
-                clock_link_shared_data.requested_tempo = 0;
-            }
-
-            abl_link_enable(clock_link, clock_link_shared_data.enabled);
-            abl_link_enable_start_stop_sync(clock_link, clock_link_shared_data.start_stop_sync);
-
-            pthread_mutex_unlock(&clock_link_shared_data.lock);
-        }
+        clock_link_step(state);
 
         usleep(1000000 / 100);
     }
@@ -103,6 +110,7 @@ void clock_link_start() {
     clock_link_shared_data.enabled = false;
 
     pthread_create(&clock_link_thread, &attr, &clock_link_run, NULL);
+    pthread_attr_destroy(&attr);
 }
 
 void clock_link_join_session() {
@@ -158,3 +166,11 @@ double clock_link_get_tempo() {
 uint64_t clock_link_number_of_peers() {
     return abl_link_num_peers(clock_link);
 }
+
+#ifdef NORNS_TEST
+void clock_link_run_once(void) {
+    abl_link_session_state state = abl_link_create_session_state();
+    clock_link_step(state);
+    abl_link_destroy_session_state(state);
+}
+#endif

--- a/matron/src/clocks/clock_scheduler.h
+++ b/matron/src/clocks/clock_scheduler.h
@@ -6,9 +6,15 @@
 
 void clock_scheduler_init();
 void clock_scheduler_start();
+void clock_scheduler_stop();
+void clock_scheduler_join();
 bool clock_scheduler_schedule_sync(int thread_id, double sync_beat, double sync_beat_offset);
 bool clock_scheduler_schedule_sleep(int thread_id, double seconds);
 void clock_scheduler_clear(int thread_id);
 void clock_scheduler_clear_all();
 void clock_scheduler_reschedule_sync_events();
 void clock_scheduler_reset_sync_events();
+
+#ifdef NORNS_TEST
+double clock_scheduler_test_next_clock_beat(double clock_beat, double sync_beat, double sync_beat_offset);
+#endif

--- a/matron/src/event_types.h
+++ b/matron/src/event_types.h
@@ -1,10 +1,10 @@
 #pragma once
 
 #include <stdint.h>
+#include <sys/types.h>
 
-#include "oracle.h"
-#include "osc.h"
-#include "screen.h"
+// lo_message is opaque here. files using it include oracle.h for the full definition.
+typedef void *lo_message;
 
 // NOTE: new event types *must* be added to the end of the enum in the order
 // maintain ABI compatibility with compiled modules which interact with the

--- a/matron/src/hardware/stat.c
+++ b/matron/src/hardware/stat.c
@@ -7,6 +7,7 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <pthread.h>
+#include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/matron/src/jack_client.h
+++ b/matron/src/jack_client.h
@@ -15,10 +15,11 @@ extern void jack_client_deinit();
 // returns ratio in [0,1]
 extern float jack_client_get_cpu_load();
 
-// update and return estimate of undderun count since last query
+// update and return estimate of underrun count since last query
 extern uint32_t jack_client_get_xrun_count();
 
-// get JACks current system time estimate in seconds (computed from sample frames)
+// get system time in seconds derived from JACK frames.
+// tracks wraparound to maintain a monotonic 64-bit frame counter.
 extern double jack_client_get_current_time();
 
 extern const char **jack_client_get_input_ports();

--- a/matron/src/metro.c
+++ b/matron/src/metro.c
@@ -5,6 +5,7 @@
  */
 
 // std
+#include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# norns C/C++ test runner – builds and runs C/C++ unit tests
+#
+# usage:
+#   ./test.sh                    run all tests
+#   ./test.sh --test-dry-run     preview discovered tests without building
+#   ./test.sh --skip-self-test   skip test runner validation (faster)
+#   ./test.sh -j 8               run tests in parallel with 8 jobs
+#   ./test.sh --targets=test_matron_args               run single target
+#   ./test.sh --targets=test_matron_args,test_crone    run multiple targets
+
+echo -e "\033[1mrunning norns C/C++ tests\033[0m"
+echo "-"
+
+# run unit tests (--alltests forces execution even if cached)
+./waf --alltests test "$@"
+

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,306 @@
+# norns c/c++ testing
+
+a shared test infrastructure for matron, crone, ws-wrapper, maiden-repl, etc.
+
+discovery, build, and execution of c/c++ tests across all of norns components.
+
+this document covers:
+- test infrastructure (discovery, build system, directory structure)
+- advanced patterns (mocking c dependencies, helper files, test seams)
+- comprehensive examples and reference material
+
+for a quick start guide to writing your first test, see [CONTRIBUTING.md](../CONTRIBUTING.md#testing-cc-code).
+
+all c/c++ components share one test runner system. `tests/wscript` discovers `test_*.cpp` files, links matching system sources, and builds one test binary per subdirectory. no manual configuration required.
+
+⸻
+
+## directory structure
+
+this is an example layout for the `tests/` directory structure to illustrate the conventions:
+
+```
+tests/
+  common/
+    test_main.cpp          # doctest main (shared across all tests)
+  <proj>/                  # matron, crone, ws-wrapper, maiden-repl, etc.
+    test_*.cpp             # project-root tests (auto-map to src/*.{c,cpp})
+    common/                # optional: helper files and stubs (auto-included)
+      helpers.{c,cpp}
+      stubs.c
+    <unit>/                # or nest by unit
+      test_*.cpp           # one or more test files
+      common/              # optional: helper files and stubs (auto-included)
+        helpers.{c,cpp}
+        stubs.c
+```
+
+**common folders**: place helper functions, mock implementations, and stubs in `common/` subdirectories. all `.c` and `.cpp` files in `common/` are automatically included when building that directory's test binary. use these for shared test utilities, c function stubs for mocking, or test-specific implementations.
+
+## mirror mapping
+
+test directories automatically discover system sources:
+
+**project-root mapping**:
+- `tests/<proj>/test_foo.cpp` → `<proj>/src/foo.*` or `<proj>/src/Foo.*`
+
+the test runner tries multiple case variants for project-root tests:
+- `test_window.cpp` → `window.c`, `Window.c`, `Window.cpp`, `window.cpp`
+- `test_peak_meter.cpp` → `peak_meter.c`, `PeakMeter.cpp`, `peakmeter.c`, etc.
+
+this handles both snake_case c sources and CamelCase c++ sources automatically.
+
+**nested mapping**:
+- `tests/<proj>/<unit>/` → `<proj>/src/<unit>.*` (exact file) or
+- `tests/<proj>/<unit>/` → `<proj>/src/<unit>/*.{c,cpp}` (directory)
+
+nested mappings use exact paths without case variants.
+
+examples:
+```
+tests/crone/test_window.cpp              → crone/src/Window.cpp
+tests/matron/test_args.cpp               → matron/src/args.c
+tests/matron/clocks/test_clock_crow.cpp  → matron/src/clocks/clock_crow.c
+```
+
+## how it works
+
+the test build is driven by `tests/wscript`, which automatically discovers tests and sources:
+
+1. **self-test**: validates test runner logic before discovering tests
+2. **find all tests**: scans for `test_*.cpp` files throughout `tests/`
+3. **group by directory**: each directory becomes one test binary
+4. **discover system sources**: uses mirror mapping to find matching code in `<proj>/src/`
+5. **build and link**: creates standalone test binaries with doctest and system code
+
+the test runner self-tests its own functionality on every run, verifying discovery patterns, path resolution, and source collection work correctly. skip with `--skip-self-test` if needed.
+
+**build details:**
+
+each directory builds one test binary combining all its `test_*.cpp` files. helper files and stubs in `common/` subdirectories are automatically included. the `NORNS_TEST` preprocessor define is set during test builds, enabling test seams in system code (see below). tests run independently with isolated failures.
+
+## test seams
+
+`NORNS_TEST` is a preprocessor define enabled only during test builds. it allows creating test seams in system code without affecting runtime behavior.
+
+common use cases:
+- expose private functions for testing using `#ifdef NORNS_TEST`
+- inject test-only interfaces for dependency injection
+- add hooks for verifying internal state
+
+**expose private functions:**
+
+```c
+static void internal_helper() { /* ... */ }
+
+#ifdef NORNS_TEST
+void test_internal_helper() { internal_helper(); }
+#endif
+```
+
+```cpp
+class AudioProcessor {
+private:
+    void processBuffer() { /* ... */ }
+
+#ifdef NORNS_TEST
+public:
+    void test_processBuffer() { processBuffer(); }
+#endif
+};
+```
+
+**inject test interface:**
+
+```c
+#ifdef NORNS_TEST
+static struct TestCallbacks {
+    void (*on_state_change)(int state);
+} test_callbacks = {0};
+#endif
+
+void update_state(int new_state) {
+    state = new_state;
+#ifdef NORNS_TEST
+    if (test_callbacks.on_state_change) {
+        test_callbacks.on_state_change(new_state);
+    }
+#endif
+}
+```
+
+```cpp
+class Engine {
+#ifdef NORNS_TEST
+public:
+    std::function<void(float)> test_onLevelChange;
+#endif
+
+    void setLevel(float level) {
+        level_ = level;
+#ifdef NORNS_TEST
+        if (test_onLevelChange) {
+            test_onLevelChange(level);
+        }
+#endif
+    }
+};
+```
+
+**verify internal state:**
+
+```c
+static int retry_count = 0;
+
+#ifdef NORNS_TEST
+int test_get_retry_count() { return retry_count; }
+#endif
+```
+
+```cpp
+class Connection {
+private:
+    int retryCount_ = 0;
+
+#ifdef NORNS_TEST
+public:
+    int test_getRetryCount() const { return retryCount_; }
+#endif
+};
+```
+
+keep seams minimal and prefer testing through public APIs. seams help test internal state or isolate dependencies. use seams for existing code, prefer dependency injection for new code.
+
+## mocking c dependencies
+
+when testing c code that calls external functions, use trompeloeil to mock those dependencies. the pattern uses three components:
+
+1. **c++ mock class** with `MAKE_MOCK*` macros
+2. **global pointer** to the mock instance
+3. **c stub functions** that delegate to the mock via the global pointer
+
+### complete example
+
+here's the complete pattern from `tests/matron/clock/test_clock.cpp`:
+
+```cpp
+#include <doctest/doctest.h>
+#include <trompeloeil.hpp>
+
+extern "C" {
+#include "clock.h"
+}
+
+// 1. define c++ mock class
+namespace {
+struct ClockDepsMock {
+    MAKE_MOCK0(internal_get_beat, double());
+    MAKE_MOCK0(internal_get_tempo, double());
+    MAKE_MOCK0(scheduler_reset_sync_events, void());
+};
+
+// 2. create global pointer to mock instance
+static ClockDepsMock *g_mock = nullptr;
+} // namespace
+
+// 3. implement c stubs that delegate to mock
+extern "C" {
+double clock_internal_get_beat() {
+    return g_mock ? g_mock->internal_get_beat() : 0.0;
+}
+
+double clock_internal_get_tempo() {
+    return g_mock ? g_mock->internal_get_tempo() : 0.0;
+}
+
+void clock_scheduler_reset_sync_events() {
+    if (g_mock) {
+        g_mock->scheduler_reset_sync_events();
+    }
+}
+}
+
+// 4. use in tests
+TEST_CASE("clock delegates to active source") {
+    ClockDepsMock mock;
+    g_mock = &mock;
+
+    REQUIRE_CALL(mock, internal_get_beat()).RETURN(1.25);
+    REQUIRE_CALL(mock, internal_get_tempo()).RETURN(110.0);
+
+    clock_set_source(CLOCK_SOURCE_INTERNAL);
+    CHECK(clock_get_beats() == doctest::Approx(1.25));
+    CHECK(clock_get_tempo() == doctest::Approx(110.0));
+}
+```
+
+### when to use
+
+use c++ mocks when the c code under test calls functions from other modules and you need to:
+- verify those calls happened
+- control return values
+- isolate the unit under test from its dependencies
+
+### trompeloeil reference
+
+```cpp
+// expect exactly one call with specific return
+REQUIRE_CALL(mock, function_name()).RETURN(value);
+
+// allow any number of calls (0 or more)
+ALLOW_CALL(mock, function_name()).RETURN(value);
+
+// forbid any calls (test fails if called)
+FORBID_CALL(mock, function_name());
+
+// verify call order with sequences
+trompeloeil::sequence seq;
+REQUIRE_CALL(mock, first()).IN_SEQUENCE(seq);
+REQUIRE_CALL(mock, second()).IN_SEQUENCE(seq);
+```
+
+reference: `tests/matron/clock/test_clock.cpp` for complete working example.
+
+## helper files and stubs
+
+place shared test utilities in `common/` subdirectories. all `.c` and `.cpp` files in `common/` are automatically included when building that directory's test binary.
+
+### stub implementations
+
+provide fake implementations of external dependencies:
+
+```c
+// tests/matron/clocks/common/abl_link_stubs.c
+// provides controllable fake of ableton link API
+
+volatile double g_stub_tempo = 120.0;
+volatile double g_stub_beat = 0.0;
+
+double abl_link_tempo(abl_link_session_state state) {
+    (void)state;
+    return g_stub_tempo;
+}
+
+double abl_link_beat_at_time(abl_link_session_state state, int64_t micros, double quantum) {
+    (void)state;
+    (void)micros;
+    (void)quantum;
+    return g_stub_beat;
+}
+```
+
+tests manipulate the global variables to control behavior:
+
+```cpp
+extern "C" {
+extern volatile double g_stub_tempo;
+extern volatile double g_stub_beat;
+}
+
+TEST_CASE("link clock reads tempo from link session") {
+    g_stub_tempo = 98.5;
+    CHECK(clock_link_get_tempo() == doctest::Approx(98.5));
+}
+```
+
+reference: `tests/matron/clocks/common/abl_link_stubs.c`

--- a/tests/common/test_main.cpp
+++ b/tests/common/test_main.cpp
@@ -1,0 +1,49 @@
+// shared test main for all C/C++ tests
+// integrates doctest with trompeloeil and provides concise output defaults
+
+#define DOCTEST_CONFIG_IMPLEMENT
+#include <cstdlib>
+#include <cstring>
+#include <doctest/doctest.h>
+#include <string>
+#include <trompeloeil.hpp>
+
+int main(int argc, char **argv) {
+    // route Trompeloeil reports to doctest before tests run
+    trompeloeil::set_reporter(
+        [](trompeloeil::severity s,
+           const char *file,
+           unsigned long line,
+           const std::string &msg) {
+            const char *f = line ? file : "[file/line unavailable]";
+            if (s == trompeloeil::severity::fatal) {
+                DOCTEST_ADD_FAIL_AT(f, line, doctest::String(msg.c_str()));
+            } else {
+                DOCTEST_ADD_FAIL_CHECK_AT(f, line, doctest::String(msg.c_str()));
+            }
+        },
+        [](const char *ok_msg) {
+#ifdef DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
+            DOCTEST_REQUIRE_UNARY(ok_msg);
+#else
+            DOCTEST_REQUIRE_NE(doctest::String(ok_msg), "");
+#endif
+        });
+
+    doctest::Context ctx;
+
+    // default to concise, plain output—easier to read in colored wrappers
+    // opt in to verbose via `NORNS_TEST_VERBOSE`
+    const char *verbose = std::getenv("NORNS_TEST_VERBOSE");
+    const bool want_verbose = verbose && std::strcmp(verbose, "0") != 0 && std::strcmp(verbose, "false") != 0;
+    if (!want_verbose) {
+        // hide assertion successes and stop after first failure — reduce noise
+        ctx.setOption("success", false);
+        ctx.setOption("abort-after", 1);
+    }
+
+    // allow CLI options to override defaults
+    ctx.applyCommandLine(argc, argv);
+    int res = ctx.run();
+    return res;
+}

--- a/tests/crone/peak_meter/common/taper_vu_table_stub.cpp
+++ b/tests/crone/peak_meter/common/taper_vu_table_stub.cpp
@@ -1,0 +1,10 @@
+// test-local stub for crone::Taper::Vu lookup table symbols
+// provides a small linear table to exercise peak meter without the full LUT
+
+#include "Taper.h"
+
+using namespace crone;
+
+// 5-point linear table from 0 to 1, enough for behavior tests
+const unsigned int Taper::Vu::ampPosTableSize = 5u;
+const float Taper::Vu::ampPosTable[] = {0.0f, 0.25f, 0.5f, 0.75f, 1.0f};

--- a/tests/crone/peak_meter/test_peak_meter.cpp
+++ b/tests/crone/peak_meter/test_peak_meter.cpp
@@ -1,0 +1,95 @@
+// tests for crone/src/PeakMeter.h behavior
+// covers peak detection, decay, and VU meter position mapping
+
+#include <doctest/doctest.h>
+
+#include "PeakMeter.h"
+
+using namespace crone;
+
+TEST_CASE("PeakMeter rises immediately to peak") {
+    // meter captures maximum absolute value in block instantly
+    PeakMeter m;
+    float block[4] = {0.1f, -0.75f, 0.2f, 0.3f};
+    m.update(block, 4);
+    CHECK(doctest::Approx(m.get()).epsilon(1e-6) == 0.75f);
+}
+
+TEST_CASE("PeakMeter falls smoothly from previous peak") {
+    // meter decays gradually when new input is below previous peak
+    PeakMeter m;
+    float block_hi[2] = {0.75f, 0.1f};
+    m.update(block_hi, 2);
+    CHECK(m.get() == doctest::Approx(0.75f));
+
+    float block_lo[2] = {0.25f, 0.0f};
+    m.update(block_lo, 2);
+    const float v = m.get();
+    CHECK(v < 0.75f);
+    CHECK(v > 0.25f);
+}
+
+TEST_CASE("PeakMeter non-negative and no spurious rise after high input") {
+    // negative values converted to absolute, meter never rises without higher input
+    PeakMeter m;
+    float neg_block[3] = {-0.1f, -0.2f, -0.3f};
+    m.update(neg_block, 3);
+    CHECK(m.get() >= 0.0f);
+
+    float high_block[3] = {1.2f, 2.0f, -1.5f};
+    m.update(high_block, 3);
+    float peak = m.get();
+
+    float lower_block[3] = {0.9f, 0.8f, 0.7f};
+    m.update(lower_block, 3);
+    CHECK(m.get() <= peak);
+}
+
+TEST_CASE("PeakMeter decays under sustained zero input") {
+    // meter gradually returns to zero when fed silence
+    PeakMeter m;
+    float hi[2] = {0.8f, 0.7f};
+    m.update(hi, 2);
+    float prev = m.get();
+    CHECK(prev > 0.0f);
+
+    float z[4] = {0.f, 0.f, 0.f, 0.f};
+    for (int i = 0; i < 8; ++i) {
+        m.update(z, 4);
+        float v = m.get();
+        CHECK(v <= prev);
+        CHECK(v >= 0.0f);
+        prev = v;
+    }
+}
+
+TEST_CASE("PeakMeter remains at zero for only zero input") {
+    // meter stays at zero when only fed silence
+    PeakMeter m;
+    float z[8] = {0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f};
+    for (int i = 0; i < 4; ++i) {
+        m.update(z, 8);
+        CHECK(m.get() == doctest::Approx(0.f));
+    }
+}
+
+TEST_CASE("PeakMeter getPos in [0,1] and increases with level") {
+    // VU position maps amplitude to normalized [0,1] range for display
+    PeakMeter m;
+
+    float z[4] = {0.f, 0.f, 0.f, 0.f};
+    m.update(z, 4);
+    CHECK(m.getPos() == doctest::Approx(0.f));
+
+    float mid[4] = {0.5f, 0.4f, 0.3f, 0.2f};
+    m.update(mid, 4);
+    float pos_mid = m.getPos();
+    CHECK(pos_mid >= 0.0f);
+    CHECK(pos_mid <= 1.0f);
+
+    float hi[2] = {1.0f, 0.9f};
+    m.update(hi, 2);
+    float pos_hi = m.getPos();
+    CHECK(pos_hi >= pos_mid);
+    CHECK(pos_hi == doctest::Approx(1.0f));
+}

--- a/tests/crone/test_taper.cpp
+++ b/tests/crone/test_taper.cpp
@@ -1,0 +1,68 @@
+// tests for crone/src/Taper.h and Taper.cpp behavior
+// covers VU meter position mapping using real ampPosTable from Taper.cpp
+
+#include <doctest/doctest.h>
+
+#include "Taper.h"
+
+using namespace crone;
+
+// -----------------------------------------------------------------------------
+// Taper::Vu::getPos range tests
+
+TEST_CASE("Taper::Vu::getPos returns values in [0,1]") {
+    // sample across amplitude range to verify output stays within bounds
+    for (float amp = 0.0f; amp <= 1.0f; amp += 0.05f) {
+        float pos = Taper::Vu::getPos(amp);
+        CHECK(pos >= 0.0f);
+        CHECK(pos <= 1.0f);
+    }
+}
+
+TEST_CASE("Taper::Vu::getPos saturates for amplitude > 1") {
+    // clipping inputs return maximum position
+    CHECK(Taper::Vu::getPos(1.5f) == 1.0f);
+    CHECK(Taper::Vu::getPos(2.0f) == 1.0f);
+    CHECK(Taper::Vu::getPos(100.0f) == 1.0f);
+}
+
+// -----------------------------------------------------------------------------
+// Taper::Vu::getPos monotonicity tests
+
+TEST_CASE("Taper::Vu::getPos is monotonic non-decreasing") {
+    // position should never decrease as amplitude increases
+    float prev = Taper::Vu::getPos(0.0f);
+    for (float amp = 0.0f; amp <= 1.0f; amp += 0.01f) {
+        float pos = Taper::Vu::getPos(amp);
+        CHECK(pos >= prev);
+        prev = pos;
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Taper::Vu::getPos anchor point tests
+
+TEST_CASE("Taper::Vu::getPos anchor points match IEC-60268 taper") {
+    // validate representative points against actual lookup table values
+    // IEC-60268 perceptual taper maps amplitude to VU meter position
+
+    // amp=0.1 interpolates table[3]=0.4906 and table[4]=0.5336
+    CHECK(Taper::Vu::getPos(0.1f) == doctest::Approx(0.494865f).epsilon(1e-4f));
+
+    // amp=0.5 interpolates table[15]=0.8113 and table[16]=0.8231
+    CHECK(Taper::Vu::getPos(0.5f) == doctest::Approx(0.817191f).epsilon(1e-4f));
+
+    // amp=0.9 interpolates table[27]=0.9528 and table[28]=0.9646
+    CHECK(Taper::Vu::getPos(0.9f) == doctest::Approx(0.963438f).epsilon(1e-4f));
+}
+
+// -----------------------------------------------------------------------------
+// Taper::Vu::getPos endpoint tests
+
+TEST_CASE("Taper::Vu::getPos endpoints match table bounds") {
+    // zero amplitude maps to zero position
+    CHECK(Taper::Vu::getPos(0.0f) == 0.0f);
+
+    // unity amplitude maps to unity position
+    CHECK(Taper::Vu::getPos(1.0f) == 1.0f);
+}

--- a/tests/crone/test_utilities.cpp
+++ b/tests/crone/test_utilities.cpp
@@ -1,0 +1,376 @@
+// tests for crone/src/Utilities.h behavior
+// covers denormal filtering (zapgremlins), smoothing, ramping, and lookup tables
+
+#include <cmath>
+#include <doctest/doctest.h>
+#include <limits>
+
+#include "Utilities.h"
+
+using namespace crone;
+
+// -----------------------------------------------------------------------------
+// zapgremlins
+
+TEST_CASE("zapgremlins clamps extreme values and passes normals") {
+    CHECK(zapgremlins(0.0f) == 0.0f);
+    CHECK(zapgremlins(1.0f) == doctest::Approx(1.0f));
+    CHECK(zapgremlins(-1.0f) == doctest::Approx(-1.0f));
+
+    CHECK(zapgremlins(1e-16f) == 0.0f);
+    CHECK(zapgremlins(1e16f) == 0.0f);
+}
+
+TEST_CASE("zapgremlins zaps NaN and infinities") {
+    float nan = std::numeric_limits<float>::quiet_NaN();
+    float inf = std::numeric_limits<float>::infinity();
+    CHECK(zapgremlins(nan) == 0.0f);
+    CHECK(zapgremlins(inf) == 0.0f);
+    CHECK(zapgremlins(-inf) == 0.0f);
+}
+
+TEST_CASE("zapgremlins clamps exactly at numeric thresholds") {
+    const float too_small_boundary = 1e-15f;
+    const float too_large_boundary = 1e15f;
+    CHECK(zapgremlins(too_small_boundary) == 0.0f);
+    CHECK(zapgremlins(-too_small_boundary) == 0.0f);
+    CHECK(zapgremlins(too_large_boundary) == 0.0f);
+    CHECK(zapgremlins(-too_large_boundary) == 0.0f);
+}
+
+// -----------------------------------------------------------------------------
+// tau2pole
+
+TEST_CASE("tau2pole yields coefficient in (0,1)") {
+    const float t = 0.1f;
+    const float sr = 48000.0f;
+    float b = tau2pole(t, sr);
+    CHECK(b > 0.0f);
+    CHECK(b < 1.0f);
+}
+
+TEST_CASE("tau2pole approaches 0 for very small time and 1 for large time") {
+    const float sr = 48000.0f;
+    float b_small_t = tau2pole(1e-6f, sr);
+    float b_large_t = tau2pole(10.0f, sr);
+    CHECK(b_small_t < 1e-6f);
+    CHECK(b_large_t > 0.99f);
+}
+
+TEST_CASE("tau2pole increases with sample rate for fixed time") {
+    const float t = 0.1f;
+    float b_sr_low = tau2pole(t, 1000.0f);
+    float b_sr_high = tau2pole(t, 48000.0f);
+    CHECK(b_sr_high > b_sr_low);
+}
+
+// -----------------------------------------------------------------------------
+// smooth1pole
+
+TEST_CASE("smooth1pole edge cases b=0 and b=1") {
+    const float x = 1.0f;
+    const float x0 = 0.0f;
+    CHECK(smooth1pole(x, x0, 0.0f) == doctest::Approx(1.0f)); // pass-through
+    CHECK(smooth1pole(x, x0, 1.0f) == doctest::Approx(0.0f)); // hold previous
+}
+
+TEST_CASE("smooth1pole output stays within input and previous bounds") {
+    const float x = 1.0f;
+    const float x0 = 0.0f;
+    float y1 = smooth1pole(x, x0, 0.25f);
+    float y2 = smooth1pole(x, x0, 0.75f);
+    CHECK(y1 >= 0.0f);
+    CHECK(y1 <= 1.0f);
+    CHECK(y2 >= 0.0f);
+    CHECK(y2 <= 1.0f);
+}
+
+// -----------------------------------------------------------------------------
+// running average
+
+TEST_CASE("RunningAverage zero-padding then steady-state under-read") {
+    RunningAverage<float, 4> avg;
+    CHECK(avg.update(1.0f) == doctest::Approx(0.25f));
+    for (int i = 0; i < 8; ++i)
+        avg.update(1.0f);
+    CHECK(avg.update(1.0f) == doctest::Approx(0.75f));
+}
+
+TEST_CASE("RunningAverage tracks moving average over window size") {
+    RunningAverage<float, 4> avg;
+    for (int i = 0; i < 4; ++i) {
+        avg.update(0.0f);
+    }
+    CHECK(avg.update(1.0f) == doctest::Approx(0.25f));
+    CHECK(avg.update(2.0f) == doctest::Approx(0.75f));
+    CHECK(avg.update(3.0f) == doctest::Approx(1.5f));
+    CHECK(avg.update(4.0f) == doctest::Approx(2.25f));
+}
+
+TEST_CASE("RunningAverage handles negative values") {
+    RunningAverage<float, 4> avg;
+    for (int i = 0; i < 3; ++i) {
+        avg.update(-1.0f);
+    }
+    float mean = avg.update(-1.0f);
+    CHECK(mean == doctest::Approx(-0.75f));
+}
+
+// -----------------------------------------------------------------------------
+// linear ramp
+
+TEST_CASE("LinearRamp approaches target monotonically without overshoot") {
+    LinearRamp ramp(200.0f, 0.5f);
+    float prev = 0.0f;
+    for (int i = 0; i < 50; ++i) {
+        float y = ramp.process(1.0f);
+        CHECK(y >= prev);
+        CHECK(y <= 1.0f);
+        prev = y;
+    }
+}
+
+TEST_CASE("LinearRamp clamps when step would overshoot") {
+    LinearRamp ramp(100.0f, 0.0001f);
+    CHECK(ramp.process(1.0f) == doctest::Approx(1.0f));
+    CHECK(ramp.process(0.0f) == doctest::Approx(0.0f));
+}
+
+TEST_CASE("LinearRamp downward ramp approaches target monotonically") {
+    LinearRamp ramp(200.0f, 0.5f);
+    for (int i = 0; i < 50; ++i) {
+        ramp.process(1.0f);
+    }
+    float prev = 1.0f;
+    for (int i = 0; i < 50; ++i) {
+        float current = ramp.process(0.0f);
+        CHECK(current <= prev);
+        CHECK(current >= 0.0f);
+        prev = current;
+    }
+}
+
+TEST_CASE("LinearRamp downward step clamps at target") {
+    LinearRamp ramp(1.0f, 0.001f);
+    ramp.process(0.5f);
+    float result = ramp.process(0.0f);
+    CHECK(result == doctest::Approx(0.0));
+    CHECK(result >= 0.0f);
+}
+
+TEST_CASE("LinearRamp setSampleRate mid-ramp recomputes increment") {
+    LinearRamp ramp(10.0f, 1.0f);
+    float first = ramp.process(1.0f);
+    CHECK(first == doctest::Approx(0.1f));
+    ramp.setSampleRate(20.0f);
+    float second = ramp.process(1.0f);
+    // remaining 0.9, new inc = 0.9 / (1 * 20) = 0.045
+    CHECK(second == doctest::Approx(0.145f));
+}
+
+TEST_CASE("LinearRamp setTime recomputes increment") {
+    LinearRamp ramp(10.0f, 1.0f);
+    float first = ramp.process(1.0f);
+    CHECK(first == doctest::Approx(0.1));
+    ramp.setTime(0.5f);
+    float second = ramp.process(1.0f);
+    // remaining 0.9, new inc = 0.9 / (0.5 * 10) = 0.18
+    CHECK(second == doctest::Approx(0.1 + 0.18));
+}
+
+TEST_CASE("LinearRamp doubling time mid-ramp halves increment") {
+    LinearRamp ramp(10.0f, 1.0f);
+    CHECK(ramp.process(1.0f) == doctest::Approx(0.1f));
+    ramp.setTime(2.0f);
+    CHECK(ramp.process(1.0f) == doctest::Approx(0.145f));
+}
+
+TEST_CASE("LinearRamp approaches negative target monotonically") {
+    LinearRamp ramp(200.0f, 0.5f);
+    float prev = 0.0f;
+    for (int i = 0; i < 50; ++i) {
+        float y = ramp.process(-1.0f);
+        CHECK(y <= prev);
+        CHECK(y >= -1.0f);
+        prev = y;
+    }
+}
+
+// -----------------------------------------------------------------------------
+// log ramp
+
+TEST_CASE("LogRamp rising monotonic and bounded") {
+    LogRamp ramp(1000.0f, 0.01f);
+    float prev = 0.0f;
+    for (int i = 0; i < 100; ++i) {
+        float y = ramp.process(1.0f);
+        CHECK(y >= prev);
+        CHECK(y <= 1.0f);
+        prev = y;
+    }
+}
+
+TEST_CASE("LogRamp falling monotonic and bounded") {
+    LogRamp ramp(1000.0f, 0.01f);
+    for (int i = 0; i < 100; ++i)
+        ramp.process(1.0f);
+    float prev = 1.0f;
+    for (int i = 0; i < 100; ++i) {
+        float y = ramp.process(0.0f);
+        CHECK(y <= prev);
+        CHECK(y >= 0.0f);
+        prev = y;
+    }
+}
+
+TEST_CASE("LogRamp setSampleRate mid-ramp stretches time without discontinuity") {
+    LogRamp ramp(1000.0f, 0.05f);
+    float before = 0.0f;
+    for (int i = 0; i < 5; ++i) {
+        before = ramp.process(1.0f);
+    }
+    ramp.setSampleRate(2000.0f);
+    float after = ramp.process(1.0f);
+    CHECK(after >= before); // still moving toward target
+    CHECK(after <= 1.0f);   // bounded by target
+}
+
+TEST_CASE("LogRamp setTime mid-ramp adjusts convergence speed smoothly") {
+    LogRamp ramp(1000.0f, 0.05f);
+    float y1 = ramp.process(1.0f);
+    ramp.setTime(0.10f);
+    float y2 = ramp.process(1.0f);
+    CHECK(y2 >= y1);
+    CHECK(y2 <= 1.0f);
+    ramp.setTime(0.01f);
+    float y3 = ramp.process(1.0f);
+    CHECK(y3 >= y2);
+    CHECK(y3 <= 1.0f);
+}
+
+TEST_CASE("LogRamp handles negative target with monotonic approach") {
+    LogRamp ramp(1000.0f, 0.02f);
+    float prev = 0.0f;
+    for (int i = 0; i < 100; ++i) {
+        float y = ramp.process(-1.0f);
+        CHECK(y <= prev);
+        CHECK(y >= -1.0f);
+        prev = y;
+    }
+}
+
+TEST_CASE("LogRamp setTarget/getTarget symmetry") {
+    LogRamp ramp(1000.0f, 0.05f);
+    ramp.setTarget(0.42f);
+    CHECK(ramp.getTarget() == doctest::Approx(0.42f));
+}
+
+TEST_CASE("LogRamp update() continues toward fixed target") {
+    LogRamp ramp(1000.0f, 0.02f);
+    ramp.setTarget(1.0f);
+    float y1 = ramp.update();
+    float y2 = ramp.update();
+    float y3 = ramp.update();
+    CHECK(y1 >= 0.0f);
+    CHECK(y2 >= y1);
+    CHECK(y3 >= y2);
+    CHECK(y3 <= 1.0f);
+}
+
+// -----------------------------------------------------------------------------
+// slew
+
+TEST_CASE("Slew faster rise reaches target sooner") {
+    Slew fastRise(1000.0f, 0.01f, 0.1f);
+    Slew slowRise(1000.0f, 0.1f, 0.1f);
+    float yf = 0.0f, ys = 0.0f;
+    for (int i = 0; i < 10; ++i) {
+        yf = fastRise.process(1.0f);
+        ys = slowRise.process(1.0f);
+        CHECK(yf >= 0.0f);
+        CHECK(ys >= 0.0f);
+        CHECK(yf <= 1.0f);
+        CHECK(ys <= 1.0f);
+    }
+    CHECK(yf > ys);
+}
+
+TEST_CASE("Slew faster fall decays sooner without undershoot") {
+    Slew a(1000.0f, 0.05f, 0.01f);
+    Slew b(1000.0f, 0.05f, 0.1f);
+    for (int i = 0; i < 100; ++i) {
+        a.process(1.0f);
+        b.process(1.0f);
+    }
+    float ya = 1.0f, yb = 1.0f;
+    for (int i = 0; i < 10; ++i) {
+        ya = a.process(0.0f);
+        yb = b.process(0.0f);
+        CHECK(ya <= 1.0f);
+        CHECK(yb <= 1.0f);
+        CHECK(ya >= 0.0f);
+        CHECK(yb >= 0.0f);
+    }
+    CHECK(ya < yb);
+}
+
+TEST_CASE("Slew setSampleRate recomputes rise/fall coefficients") {
+    Slew s(10.0f, 1.0f, 2.0f);
+    float y1 = s.process(1.0f);
+    s.setSampleRate(20.0f);
+    float y2 = s.process(1.0f);
+    CHECK(y2 >= y1);
+    CHECK(y2 <= 1.0f);
+}
+
+TEST_CASE("Slew extreme small/large times behave reasonably") {
+    Slew nearInstant(1000.0f, 1e-6f, 1e-6f);
+    float yi = nearInstant.process(1.0f);
+    CHECK(yi > 0.9f);
+    Slew verySlow(1000.0f, 10.0f, 10.0f);
+    float ys = verySlow.process(1.0f);
+    CHECK(ys < 0.2f);
+}
+
+TEST_CASE("Slew independent rise time slows upward movement") {
+    Slew s(1000.0f, 0.1f, 0.1f);
+    float before = 0.0f;
+    for (int i = 0; i < 8; ++i) {
+        before = s.process(1.0f);
+    }
+    float y_pre = s.process(1.0f);
+    float delta_pre = y_pre - before;
+    s.setRiseTime(0.5f);
+    float y_post = s.process(1.0f);
+    float delta_post = y_post - y_pre;
+    CHECK(delta_post < delta_pre);
+}
+
+// -----------------------------------------------------------------------------
+// lookup table
+
+TEST_CASE("LUT::lookupLinear interpolates between points") {
+    float tab[2] = {0.0f, 10.0f};
+    CHECK(LUT<float>::lookupLinear(0.0f, tab, 2) == doctest::Approx(0.0f));
+    CHECK(LUT<float>::lookupLinear(1.0f, tab, 2) == doctest::Approx(10.0f));
+    CHECK(LUT<float>::lookupLinear(0.5f, tab, 2) == doctest::Approx(5.0f));
+}
+
+TEST_CASE("LUT::lookupLinear clamps x > 1 to last entry") {
+    const float tab[5] = {0.0f, 2.0f, 4.0f, 6.0f, 8.0f};
+    CHECK(LUT<float>::lookupLinear(1.0f, tab, 5) == doctest::Approx(8.0f));
+    CHECK(LUT<float>::lookupLinear(1.25f, tab, 5) == doctest::Approx(8.0f));
+}
+
+TEST_CASE("LUT::lookupLinear handles interior fractional indices") {
+    const float tab[4] = {0.0f, 10.0f, 20.0f, 30.0f};
+    CHECK(LUT<float>::lookupLinear(0.25f, tab, 4) == doctest::Approx(7.5f));
+    CHECK(LUT<float>::lookupLinear(0.75f, tab, 4) == doctest::Approx(22.5f));
+}
+
+TEST_CASE("LUT::lookupLinear size-1 table returns the only element") {
+    const float tab[1] = {3.14f};
+    CHECK(LUT<float>::lookupLinear(0.0f, tab, 1) == doctest::Approx(3.14f));
+    CHECK(LUT<float>::lookupLinear(0.5f, tab, 1) == doctest::Approx(3.14f));
+    CHECK(LUT<float>::lookupLinear(1.0f, tab, 1) == doctest::Approx(3.14f));
+}

--- a/tests/crone/test_window.cpp
+++ b/tests/crone/test_window.cpp
@@ -1,0 +1,41 @@
+// tests for crone/src/Window.h and Window.cpp behavior
+// covers raised cosine window lookup table used for envelope shaping
+
+#include <algorithm>
+#include <cmath>
+#include <doctest/doctest.h>
+
+#include "Window.h"
+
+using namespace crone;
+
+TEST_CASE("raisedCosShort: size and value validity") {
+    // size must match declared length
+    constexpr size_t sz = sizeof(Window::raisedCosShort) / sizeof(Window::raisedCosShort[0]);
+    CHECK(sz == Window::raisedCosShortLen);
+
+    // all values finite and within [0,1]
+    CHECK(std::all_of(&Window::raisedCosShort[0],
+                      &Window::raisedCosShort[0] + Window::raisedCosShortLen,
+                      [](float v) { return std::isfinite(v) && v >= 0.0f && v <= 1.0f; }));
+}
+
+TEST_CASE("raisedCosShort: shape monotonic and mean around 0.5") {
+    // starts at 0, ends at 1
+    CHECK(Window::raisedCosShort[0] == doctest::Approx(0.0f));
+    CHECK(Window::raisedCosShort[Window::raisedCosShortLen - 1] == doctest::Approx(1.0f));
+
+    // monotonic non-decreasing across table
+    const float *tab = &Window::raisedCosShort[0];
+    for (size_t i = 0; i + 1 < Window::raisedCosShortLen; ++i) {
+        CHECK(tab[i] <= tab[i + 1] + 1e-7f);
+    }
+
+    // mean near 0.5
+    double sum = 0.0;
+    for (size_t i = 0; i < Window::raisedCosShortLen; ++i) {
+        sum += Window::raisedCosShort[i];
+    }
+    double mean = sum / static_cast<double>(Window::raisedCosShortLen);
+    CHECK(mean == doctest::Approx(0.5).epsilon(0.05));
+}

--- a/tests/matron/clock/test_clock.cpp
+++ b/tests/matron/clock/test_clock.cpp
@@ -1,0 +1,411 @@
+// tests for matron/src/clock.h and clock.c behavior
+// uses mocks for cross-module calls and C stubs to isolate deps
+
+#include <atomic>
+#include <cmath>
+#include <doctest/doctest.h>
+#include <pthread.h>
+#include <trompeloeil.hpp>
+
+extern "C" {
+#include "clock.h"
+#include "events.h"
+}
+
+// -----------------------------------------------------------------------------
+// C stubs delegating to a C++ mock for cross-module calls
+// allows isolation of clock.c logic from external dependencies
+// -----------------------------------------------------------------------------
+
+namespace {
+struct ClockDepsMock {
+    // clock backends
+    MAKE_MOCK0(internal_get_beat, double());
+    MAKE_MOCK0(midi_get_beat, double());
+    MAKE_MOCK0(link_get_beat, double());
+    MAKE_MOCK0(crow_get_beat, double());
+
+    MAKE_MOCK0(internal_get_tempo, double());
+    MAKE_MOCK0(midi_get_tempo, double());
+    MAKE_MOCK0(link_get_tempo, double());
+    MAKE_MOCK0(crow_get_tempo, double());
+
+    // scheduler + events
+    MAKE_MOCK0(scheduler_reset_sync_events, void());
+    MAKE_MOCK0(scheduler_reschedule_sync_events, void());
+    MAKE_MOCK1(event_data_new, union event_data *(event_t));
+    MAKE_MOCK1(event_post, void(union event_data *));
+
+    // link session
+    MAKE_MOCK0(link_join_session, void());
+    MAKE_MOCK0(link_leave_session, void());
+    MAKE_MOCK0(link_number_of_peers, uint64_t());
+};
+
+static ClockDepsMock *g_mock = nullptr;
+static double g_now = 0.0;
+} // namespace
+
+extern "C" {
+double jack_client_get_current_time() {
+    return g_now;
+}
+
+// clock backends
+double clock_internal_get_beat() {
+    return g_mock ? g_mock->internal_get_beat() : 0.0;
+}
+double clock_midi_get_beat() {
+    return g_mock ? g_mock->midi_get_beat() : 0.0;
+}
+double clock_link_get_beat() {
+    return g_mock ? g_mock->link_get_beat() : 0.0;
+}
+double clock_crow_get_beat() {
+    return g_mock ? g_mock->crow_get_beat() : 0.0;
+}
+
+double clock_internal_get_tempo() {
+    return g_mock ? g_mock->internal_get_tempo() : 0.0;
+}
+double clock_midi_get_tempo() {
+    return g_mock ? g_mock->midi_get_tempo() : 0.0;
+}
+double clock_link_get_tempo() {
+    return g_mock ? g_mock->link_get_tempo() : 0.0;
+}
+double clock_crow_get_tempo() {
+    return g_mock ? g_mock->crow_get_tempo() : 0.0;
+}
+
+// scheduler and notifications
+void clock_scheduler_reset_sync_events() {
+    if (g_mock) {
+        g_mock->scheduler_reset_sync_events();
+    }
+}
+void clock_scheduler_reschedule_sync_events() {
+    if (g_mock) {
+        g_mock->scheduler_reschedule_sync_events();
+    }
+}
+union event_data *event_data_new(event_t evcode) {
+    return g_mock ? g_mock->event_data_new(evcode) : nullptr;
+}
+void event_post(union event_data *ev) {
+    if (g_mock) {
+        g_mock->event_post(ev);
+    }
+}
+
+// link session
+void clock_link_join_session() {
+    if (g_mock) {
+        g_mock->link_join_session();
+    }
+}
+void clock_link_leave_session() {
+    if (g_mock) {
+        g_mock->link_leave_session();
+    }
+}
+uint64_t clock_link_number_of_peers() {
+    return g_mock ? g_mock->link_number_of_peers() : 0u;
+}
+}
+
+// helper to create event_data for mocking event_data_new to match production
+// behavior
+static union event_data *make_event(event_t type) {
+    auto *ev = (union event_data *)calloc(1, sizeof(union event_data));
+    ev->type = type;
+    return ev;
+}
+
+TEST_CASE("clock: init triggers reschedule") {
+    ClockDepsMock mock;
+    g_mock = &mock;
+
+    REQUIRE_CALL(mock, scheduler_reschedule_sync_events()).TIMES(1);
+    ALLOW_CALL(mock, internal_get_tempo()).RETURN(120.0);
+    ALLOW_CALL(mock, internal_get_beat()).RETURN(0.0);
+
+    clock_init();
+}
+
+TEST_CASE("clock: get system time proxies to jack") {
+    ClockDepsMock mock;
+    g_mock = &mock;
+    g_now = 123.456;
+    CHECK(clock_get_system_time() == doctest::Approx(123.456));
+}
+
+TEST_CASE("clock: set source join/leave link + reschedule") {
+    ClockDepsMock mock;
+    g_mock = &mock;
+
+    // init sets internal and reschedules
+    ALLOW_CALL(mock, scheduler_reschedule_sync_events());
+    clock_init();
+
+    // switch to LINK: join + reschedule
+    {
+        trompeloeil::sequence seq1;
+        REQUIRE_CALL(mock, link_join_session()).IN_SEQUENCE(seq1);
+        REQUIRE_CALL(mock, scheduler_reschedule_sync_events()).IN_SEQUENCE(seq1);
+        clock_set_source(CLOCK_SOURCE_LINK);
+    }
+
+    // switch to MIDI: leave + reschedule
+    {
+        trompeloeil::sequence seq2;
+        REQUIRE_CALL(mock, link_leave_session()).IN_SEQUENCE(seq2);
+        REQUIRE_CALL(mock, scheduler_reschedule_sync_events()).IN_SEQUENCE(seq2);
+        clock_set_source(CLOCK_SOURCE_MIDI);
+    }
+}
+
+TEST_CASE("clock: beats and tempo delegate to active source") {
+    ClockDepsMock mock;
+    g_mock = &mock;
+
+    ALLOW_CALL(mock, scheduler_reschedule_sync_events());
+    ALLOW_CALL(mock, link_join_session());
+    ALLOW_CALL(mock, link_leave_session());
+    clock_init();
+
+    // internal
+    REQUIRE_CALL(mock, internal_get_beat()).RETURN(1.25);
+    REQUIRE_CALL(mock, internal_get_tempo()).RETURN(110.0);
+    clock_set_source(CLOCK_SOURCE_INTERNAL);
+    CHECK(clock_get_beats() == doctest::Approx(1.25));
+    CHECK(clock_get_tempo() == doctest::Approx(110.0));
+
+    // midi
+    REQUIRE_CALL(mock, midi_get_beat()).RETURN(2.5);
+    REQUIRE_CALL(mock, midi_get_tempo()).RETURN(98.0);
+    clock_set_source(CLOCK_SOURCE_MIDI);
+    CHECK(clock_get_beats() == doctest::Approx(2.5));
+    CHECK(clock_get_tempo() == doctest::Approx(98.0));
+
+    // link
+    REQUIRE_CALL(mock, link_get_beat()).RETURN(8.0);
+    REQUIRE_CALL(mock, link_get_tempo()).RETURN(123.0);
+    clock_set_source(CLOCK_SOURCE_LINK);
+    CHECK(clock_get_beats() == doctest::Approx(8.0));
+    CHECK(clock_get_tempo() == doctest::Approx(123.0));
+
+    // crow
+    REQUIRE_CALL(mock, crow_get_beat()).RETURN(4.0);
+    REQUIRE_CALL(mock, crow_get_tempo()).RETURN(60.0);
+    clock_set_source(CLOCK_SOURCE_CROW);
+    CHECK(clock_get_beats() == doctest::Approx(4.0));
+    CHECK(clock_get_tempo() == doctest::Approx(60.0));
+}
+
+TEST_CASE("clock: start/stop/reschedule only when source matches") {
+    ClockDepsMock mock;
+    g_mock = &mock;
+
+    ALLOW_CALL(mock, scheduler_reschedule_sync_events());
+    clock_init();
+    clock_set_source(CLOCK_SOURCE_INTERNAL);
+
+    // when source matches, expect reset, event data new, and post
+    {
+        trompeloeil::sequence seq;
+        REQUIRE_CALL(mock, scheduler_reset_sync_events()).IN_SEQUENCE(seq);
+        REQUIRE_CALL(mock, event_data_new(EVENT_CLOCK_START))
+            .IN_SEQUENCE(seq)
+            .LR_RETURN(make_event(EVENT_CLOCK_START));
+        REQUIRE_CALL(mock, event_post(trompeloeil::_)).IN_SEQUENCE(seq);
+        clock_start_from_source(CLOCK_SOURCE_INTERNAL);
+    }
+
+    {
+        trompeloeil::sequence seq;
+        REQUIRE_CALL(mock, event_data_new(EVENT_CLOCK_STOP))
+            .IN_SEQUENCE(seq)
+            .LR_RETURN(make_event(EVENT_CLOCK_STOP));
+        REQUIRE_CALL(mock, event_post(trompeloeil::_)).IN_SEQUENCE(seq);
+        clock_stop_from_source(CLOCK_SOURCE_INTERNAL);
+    }
+
+    // when source does not match, none of these should be called
+    FORBID_CALL(mock, scheduler_reset_sync_events());
+    FORBID_CALL(mock, event_data_new(trompeloeil::_));
+    FORBID_CALL(mock, event_post(trompeloeil::_));
+    clock_start_from_source(CLOCK_SOURCE_MIDI);
+    clock_stop_from_source(CLOCK_SOURCE_MIDI);
+
+    // reschedule from source must match
+    REQUIRE_CALL(mock, scheduler_reschedule_sync_events()).TIMES(1);
+    clock_reschedule_sync_events_from_source(CLOCK_SOURCE_INTERNAL);
+    FORBID_CALL(mock, scheduler_reschedule_sync_events());
+    clock_reschedule_sync_events_from_source(CLOCK_SOURCE_MIDI);
+}
+
+TEST_CASE("clock reference: beat and tempo computation") {
+    ClockDepsMock mock;
+    g_mock = &mock;
+
+    clock_reference_t ref;
+
+    g_now = 100.0;
+    clock_reference_init(&ref);
+
+    // default tempo 120 bpm (0.5s per beat)
+    CHECK(clock_get_reference_tempo(&ref) == doctest::Approx(120.0));
+
+    // after 0.25s, beat advanced by 0.5
+    g_now = 100.25;
+    CHECK(clock_get_reference_beat(&ref) == doctest::Approx(0.5));
+
+    // update reference: set beat to 2.0, duration 1.0s
+    g_now = 101.0;
+    clock_update_source_reference(&ref, 2.0, 1.0);
+
+    // tempo now 60 bpm
+    CHECK(clock_get_reference_tempo(&ref) == doctest::Approx(60.0));
+
+    // after 0.5s, beat advanced by 0.5
+    g_now = 101.5;
+    CHECK(clock_get_reference_beat(&ref) == doctest::Approx(2.5));
+}
+
+TEST_CASE("clock: number of Link peers delegates to link") {
+    ClockDepsMock mock;
+    g_mock = &mock;
+    REQUIRE_CALL(mock, link_number_of_peers()).RETURN(3u);
+    CHECK(clock_number_of_link_peers() == 3u);
+}
+
+TEST_CASE("clock: set_source is idempotent for same source") {
+    ClockDepsMock mock1;
+    g_mock = &mock1;
+
+    // allow init reschedule
+    ALLOW_CALL(mock1, scheduler_reschedule_sync_events());
+    clock_init();
+
+    // switch to MIDI once -> reschedule exactly once across two identical calls
+    ClockDepsMock mock2;
+    g_mock = &mock2;
+
+    REQUIRE_CALL(mock2, scheduler_reschedule_sync_events()).TIMES(1);
+    clock_set_source(CLOCK_SOURCE_MIDI);
+    clock_set_source(CLOCK_SOURCE_MIDI);
+}
+
+TEST_CASE("clock: non-link transitions do not call link join/leave") {
+    ClockDepsMock mock;
+    g_mock = &mock;
+
+    // init sets INTERNAL; allow its reschedule
+    ALLOW_CALL(mock, scheduler_reschedule_sync_events());
+    clock_init();
+
+    // forbid any link session calls for non-link transitions
+    FORBID_CALL(mock, link_join_session());
+    FORBID_CALL(mock, link_leave_session());
+
+    // INTERNAL -> MIDI -> CROW -> INTERNAL should never touch link
+    ALLOW_CALL(mock, scheduler_reschedule_sync_events());
+    clock_set_source(CLOCK_SOURCE_MIDI);
+    clock_set_source(CLOCK_SOURCE_CROW);
+    clock_set_source(CLOCK_SOURCE_INTERNAL);
+}
+
+TEST_CASE("clock reference: update reflects immediately in beat/tempo getters") {
+    ClockDepsMock mock;
+    g_mock = &mock;
+
+    clock_reference_t ref;
+
+    // establish a known time
+    g_now = 200.0;
+    clock_reference_init(&ref);
+
+    // update the reference and verify immediate values
+    clock_update_source_reference(&ref, 10.0, 0.75); // 80 bpm
+    CHECK(clock_get_reference_beat(&ref) == doctest::Approx(10.0));
+    CHECK(clock_get_reference_tempo(&ref) == doctest::Approx(80.0));
+
+    // after 0.75s, beat advances by 1
+    g_now = 200.75;
+    CHECK(clock_get_reference_beat(&ref) == doctest::Approx(11.0));
+}
+
+TEST_CASE("clock reference: concurrent updates and reads stay thread-safe and monotonic") {
+    ClockDepsMock mock;
+    g_mock = &mock;
+
+    clock_reference_t ref;
+    g_now = 0.0;
+    clock_reference_init(&ref);
+
+    // track cross-thread failures: invalid values or position moving backwards
+    std::atomic<int> bad_monotonic{0};
+    std::atomic<int> bad_value{0};
+
+    pthread_t updater;
+    pthread_t reader1;
+    pthread_t reader2;
+
+    // updater thread: write new position (in beats) and tempo repeatedly
+    auto update_func = +[](void *p) -> void * {
+        auto *r = reinterpret_cast<clock_reference_t *>(p);
+        for (int i = 0; i < 5000; ++i) {
+            g_now = i * 0.001; // advance virtual time monotonically
+            // vary tempo to exercise different beat durations
+            clock_update_source_reference(r, i * 0.1, 0.5 + (i % 10) * 0.01);
+        }
+        return nullptr;
+    };
+
+    struct reader_args {
+        clock_reference_t *ref;
+        std::atomic<int> *bad_mono;
+        std::atomic<int> *bad_val;
+    };
+
+    // reader threads: read position and tempo and check invariants
+    auto read_func = +[](void *p) -> void * {
+        auto *ctx = reinterpret_cast<reader_args *>(p);
+        clock_reference_t *r = ctx->ref;
+        std::atomic<int> *bad_mono = ctx->bad_mono;
+        std::atomic<int> *bad_val = ctx->bad_val;
+
+        double last_beat = -1.0;
+        for (int i = 0; i < 5000; ++i) {
+            double b = clock_get_reference_beat(r);
+            double t = clock_get_reference_tempo(r);
+
+            // require finite position and strictly positive tempo
+            if (!(std::isfinite(b) && t > 0.0)) {
+                ++(*bad_val);
+            }
+            // position should not move backwards (allow tiny epsilon for float error)
+            if (last_beat >= 0.0 && b < last_beat - 1e-6) {
+                ++(*bad_mono);
+            }
+            last_beat = b;
+        }
+        return nullptr;
+    };
+
+    reader_args arg{&ref, &bad_monotonic, &bad_value};
+
+    // run one updater and two readers concurrently
+    pthread_create(&updater, nullptr, update_func, &ref);
+    pthread_create(&reader1, nullptr, read_func, &arg);
+    pthread_create(&reader2, nullptr, read_func, &arg);
+
+    pthread_join(updater, nullptr);
+    pthread_join(reader1, nullptr);
+    pthread_join(reader2, nullptr);
+
+    // verify no failures: values are valid and position remains monotonic
+    CHECK(bad_value.load() == 0);
+    CHECK(bad_monotonic.load() == 0);
+}

--- a/tests/matron/clocks/clock_crow/test_clock_crow.cpp
+++ b/tests/matron/clocks/clock_crow/test_clock_crow.cpp
@@ -1,0 +1,164 @@
+// tests for matron/src/clocks/clock_crow.c behavior
+// covers tempo measurement and reschedule logic
+
+#include <cmath>
+#include <doctest/doctest.h>
+
+extern "C" {
+#include "clocks/clock_crow.h"
+#include "helpers.h"
+}
+
+static int g_reschedule_calls = 0;
+
+// override the helpers.c stub to track reschedule calls for this test
+extern "C" void clock_reschedule_sync_events_from_source(clock_source_t source) {
+    if (source == CLOCK_SOURCE_CROW) {
+        g_reschedule_calls++;
+    }
+}
+
+// warmup iterations to fill duration buffer and reach steady state (size 4 + 1)
+static const int BUFFER_WARMUP_ITERATIONS = 5;
+
+TEST_CASE("crow: init sets default tempo 120") {
+    tests_set_now(100.0);
+    clock_crow_init();
+    CHECK(clock_crow_get_tempo() == doctest::Approx(120.0));
+}
+
+TEST_CASE("crow: in_div change triggers reschedule on next clock") {
+    g_reschedule_calls = 0;
+    tests_set_now(10.0);
+    clock_crow_init();
+
+    // first tick sets last time
+    clock_crow_handle_clock();
+
+    // change divider and tick again with non-trivial dt
+    clock_crow_in_div(4);
+    tests_set_now(10.0 + 0.02);
+    clock_crow_handle_clock();
+
+    CHECK(g_reschedule_calls == 1);
+}
+
+TEST_CASE("crow: tempo follows measured interval and divider ratio") {
+    double time = 0.0;
+    tests_set_now(time);
+    clock_crow_init();
+    clock_crow_handle_clock(); // set last time
+
+    clock_crow_in_div(4);
+    for (int i = 0; i < BUFFER_WARMUP_ITERATIONS; ++i) {
+        time += 0.125;
+        tests_set_now(time);
+        clock_crow_handle_clock();
+    }
+    double tempo1 = clock_crow_get_tempo();
+    CHECK(tempo1 > 0.0);
+
+    clock_crow_in_div(2);
+    for (int i = 0; i < BUFFER_WARMUP_ITERATIONS; ++i) {
+        time += 0.125;
+        tests_set_now(time);
+        clock_crow_handle_clock();
+    }
+    double tempo2 = clock_crow_get_tempo();
+    CHECK(tempo2 > tempo1);
+    // expect approx 2x increase when divider halves (tolerate smoothing error)
+    CHECK(tempo2 / tempo1 == doctest::Approx(2.0).epsilon(0.25));
+}
+
+TEST_CASE("crow: tempo remains finite with very high frequency ticks") {
+    double time = 0.0;
+    tests_set_now(time);
+    clock_crow_init();
+    clock_crow_handle_clock();
+
+    clock_crow_in_div(4);
+    double dt = 0.0001; // 0.1ms between ticks, simulates thousands of BPM
+    for (int i = 0; i < BUFFER_WARMUP_ITERATIONS; ++i) {
+        time += dt;
+        tests_set_now(time);
+        clock_crow_handle_clock();
+    }
+
+    double tempo = clock_crow_get_tempo();
+    // verify no inf or NaN (smoothing may produce unusual values with extreme timing)
+    CHECK(std::isfinite(tempo));
+    CHECK(!std::isnan(tempo));
+}
+
+TEST_CASE("crow: tempo remains finite with very low frequency ticks") {
+    double time = 0.0;
+    tests_set_now(time);
+    clock_crow_init();
+    clock_crow_handle_clock();
+
+    clock_crow_in_div(4);
+    // 0.9s between ticks -> 3.6s beat_duration (just under 4s threshold)
+    double dt = 0.9;
+    for (int i = 0; i < BUFFER_WARMUP_ITERATIONS; ++i) {
+        time += dt;
+        tests_set_now(time);
+        clock_crow_handle_clock();
+    }
+
+    double tempo = clock_crow_get_tempo();
+    // tempo should be very low and finite
+    CHECK(tempo > 0.0);
+    CHECK(tempo < 20.0); // sanity check: should be very slow tempo
+    CHECK(std::isfinite(tempo));
+    CHECK(!std::isnan(tempo));
+}
+
+TEST_CASE("crow: zero dt ticks do not produce inf or NaN") {
+    double time = 0.0;
+    tests_set_now(time);
+    clock_crow_init();
+    clock_crow_handle_clock();
+
+    clock_crow_in_div(4);
+    // first tick with normal dt
+    time += 0.125;
+    tests_set_now(time);
+    clock_crow_handle_clock();
+
+    // send tick with exact same timestamp (dt = 0)
+    clock_crow_handle_clock();
+
+    double tempo = clock_crow_get_tempo();
+    // verify no inf or NaN despite zero dt
+    CHECK(std::isfinite(tempo));
+    CHECK(!std::isnan(tempo));
+}
+
+TEST_CASE("crow: ticks beyond 4s beat_duration threshold reset timing") {
+    double time = 0.0;
+    tests_set_now(time);
+    clock_crow_init();
+    clock_crow_handle_clock();
+
+    clock_crow_in_div(4);
+    double dt = 0.25; // 60 BPM equivalent
+    for (int i = 0; i < BUFFER_WARMUP_ITERATIONS; ++i) {
+        time += dt;
+        tests_set_now(time);
+        clock_crow_handle_clock();
+    }
+    double tempo_before = clock_crow_get_tempo();
+    CHECK(std::isfinite(tempo_before));
+
+    // send tick beyond 4s beat_duration threshold (dt=5.0, div=4 -> beat_duration=20.0)
+    // this triggers the "clock stopped" reset path which updates last_time but not buffer
+    time += 5.0;
+    tests_set_now(time);
+    clock_crow_handle_clock();
+
+    // tempo should be unchanged (buffer wasn't updated)
+    double tempo_after = clock_crow_get_tempo();
+    CHECK(tempo_after == doctest::Approx(tempo_before));
+    CHECK(std::isfinite(tempo_after));
+    CHECK(!std::isnan(tempo_after));
+}

--- a/tests/matron/clocks/clock_internal/test_clock_internal.cpp
+++ b/tests/matron/clocks/clock_internal/test_clock_internal.cpp
@@ -1,0 +1,197 @@
+// tests for matron/src/clocks/clock_internal.c behavior
+// covers thread loop, tempo publish, restarts
+
+#include <doctest/doctest.h>
+
+extern "C" {
+#include "clocks/clock_internal.h"
+#include "helpers.h"
+}
+
+extern "C" {
+void clock_internal_test_enable_threadless(bool enable);
+void clock_internal_test_tick_once();
+void clock_internal_test_set_ticks(unsigned long long v);
+unsigned long long clock_internal_test_get_published_ticks(void);
+void clock_internal_test_reset_published_ticks(void);
+void clock_internal_test_stop_thread(void);
+double clock_internal_test_get_last_sleep_s(void);
+double clock_internal_test_get_last_next_tick_time(void);
+double clock_internal_test_get_last_current_time(void);
+double clock_internal_test_get_last_tick_duration(void);
+}
+
+TEST_CASE("internal clock") {
+    // most tests run in threadless mode.
+    // init runs once.
+    tests_set_now(0.0);
+    clock_internal_test_enable_threadless(true);
+    clock_internal_init();
+
+    SUBCASE("default tempo is 120 bpm after init") {
+        CHECK(clock_internal_get_tempo() == doctest::Approx(120.0));
+    }
+
+    SUBCASE("set_tempo updates on next tick (not immediately)") {
+        // initial 120 bpm
+        REQUIRE(clock_internal_get_tempo() == doctest::Approx(120.0));
+
+        // change tempo; without a tick, reported tempo remains the old value
+        clock_internal_set_tempo(90.0);
+        CHECK(clock_internal_get_tempo() == doctest::Approx(120.0));
+
+        // after one tick publish, reported tempo reflects the new value
+        clock_internal_test_tick_once();
+        CHECK(clock_internal_get_tempo() == doctest::Approx(90.0));
+    }
+
+    SUBCASE("long-run tick stepping still publishes tempo changes") {
+        // run 50000 ticks to verify the publish path keeps working
+        for (int i = 0; i < 50000; ++i) {
+            clock_internal_test_tick_once();
+        }
+
+        // change tempo and confirm it publishes on the next tick
+        clock_internal_set_tempo(60.0);
+        CHECK(clock_internal_get_tempo() != doctest::Approx(60.0)); // not yet published
+        clock_internal_test_tick_once();
+        CHECK(clock_internal_get_tempo() == doctest::Approx(60.0));
+    }
+
+    SUBCASE("tick counter does not overflow near INT_MAX") {
+        // seed counter near 32-bit signed max to simulate long uptime
+        // INT_MAX - 2 = 2147483645; step a few times across the boundary
+        unsigned long long near_int_max = 2147483645ULL;
+        clock_internal_test_set_ticks(near_int_max);
+
+        // capture beat and ensure monotonic increase across several ticks
+        double prev_beat = clock_internal_get_beat();
+        for (int i = 0; i < 10; ++i) {
+            clock_internal_test_tick_once();
+            double beat = clock_internal_get_beat();
+            CHECK(beat > prev_beat);
+            prev_beat = beat;
+        }
+
+        // tempo should remain finite and at default 120 bpm (no tempo change applied)
+        CHECK(clock_internal_get_tempo() == doctest::Approx(120.0));
+    }
+
+    SUBCASE("manual tick publishes tempo changes and survives time jump") {
+        // initial tempo is 120
+        REQUIRE(clock_internal_get_tempo() == doctest::Approx(120.0));
+
+        // change tempo; until a tick publishes, reported tempo remains previous value
+        clock_internal_set_tempo(90.0);
+        CHECK(clock_internal_get_tempo() == doctest::Approx(120.0));
+        clock_internal_test_tick_once();
+        CHECK(clock_internal_get_tempo() == doctest::Approx(90.0));
+
+        // simulate a large forward jump in system time—publish still works on the next tick
+        tests_set_now(6.0 * 3600.0);
+        clock_internal_set_tempo(60.0);
+        CHECK(clock_internal_get_tempo() == doctest::Approx(90.0));
+        clock_internal_test_tick_once();
+        CHECK(clock_internal_get_tempo() == doctest::Approx(60.0));
+    }
+
+    SUBCASE("restart resets beat and applies latest tempo on next publish") {
+        // advance a few ticks so beat > 0
+        for (int i = 0; i < 10; ++i) {
+            clock_internal_test_tick_once();
+        }
+        REQUIRE(clock_internal_get_beat() > 0.0);
+
+        // change tempo and restart; next publish should reset beat to 0 and apply tempo
+        clock_internal_set_tempo(75.0);
+        clock_internal_restart();
+        clock_internal_test_tick_once();
+        CHECK(clock_internal_get_beat() == doctest::Approx(0.0));
+        CHECK(clock_internal_get_tempo() == doctest::Approx(75.0));
+    }
+
+    // --- threaded tests ---
+    // these tests run the real background thread and must be managed carefully
+    // to avoid leaking threads or interfering with other tests.
+
+    SUBCASE("loop rebases after long time jump") {
+        // simulate a JACK stall—nanosleep does not advance time; enable strict validation for invalid sleeps
+        tests_set_now(0.0);
+        tests_set_nanosleep_advances_time(false);
+        tests_set_nanosleep_strict_validation(true);
+
+        // enable threading for this subcase only
+        clock_internal_test_enable_threadless(false);
+        clock_internal_test_reset_published_ticks();
+        clock_internal_init();
+
+        // wait for at least one publish to initialize pacing
+        unsigned long long p0 = clock_internal_test_get_published_ticks();
+        for (int i = 0; i < 200000 && clock_internal_test_get_published_ticks() == p0; ++i) {
+            ;
+        }
+
+        // jump time forward by hours so next_tick_time is far behind current_time
+        tests_set_now(6.0 * 3600.0);
+
+        // the rebase logic should skip catchup ticks and quickly produce non-negative sleep
+        bool became_non_negative = false;
+        for (int i = 0; i < 50; ++i) {
+            // wait for next publish
+            unsigned long long before = clock_internal_test_get_published_ticks();
+            for (int s = 0; s < 10000 && clock_internal_test_get_published_ticks() == before; ++s) {
+                ;
+            }
+            double last_sleep = clock_internal_test_get_last_sleep_s();
+            if (last_sleep >= 0.0) {
+                became_non_negative = true;
+                break;
+            }
+        }
+        CHECK(became_non_negative == true);
+
+        // cleanup: stop the thread and restore nanosleep behavior
+        clock_internal_test_stop_thread();
+        tests_set_nanosleep_advances_time(true);
+        tests_set_nanosleep_strict_validation(false);
+        clock_internal_test_enable_threadless(true);
+    }
+
+    SUBCASE("threaded loop survives long time jump and publishes tempo changes") {
+        // run the real clock thread; nanosleep is stubbed to advance virtual time
+        tests_set_now(0.0);
+        clock_internal_test_reset_published_ticks();
+        clock_internal_test_enable_threadless(false);
+        clock_internal_init();
+
+        // wait for the first publish
+        unsigned long long pub = clock_internal_test_get_published_ticks();
+        for (int i = 0; i < 200000 && clock_internal_test_get_published_ticks() == pub; ++i) {
+            ;
+        }
+        REQUIRE(clock_internal_get_tempo() == doctest::Approx(120.0));
+
+        // change tempo to 90; it should update on next publish only
+        CHECK(clock_internal_get_tempo() == doctest::Approx(120.0));
+        pub = clock_internal_test_get_published_ticks();
+        clock_internal_set_tempo(90.0);
+
+        for (int i = 0; i < 200000 && clock_internal_test_get_published_ticks() == pub; ++i) {
+            ;
+        }
+        CHECK(clock_internal_get_tempo() == doctest::Approx(90.0));
+
+        // jump time forward by hours; tempo change still publishes on the next tick
+        tests_set_now(6.0 * 3600.0);
+        pub = clock_internal_test_get_published_ticks();
+        clock_internal_set_tempo(60.0);
+        for (int i = 0; i < 400000 && clock_internal_test_get_published_ticks() == pub; ++i) {
+            ;
+        }
+        CHECK(clock_internal_get_tempo() == doctest::Approx(60.0));
+
+        // stop the background thread to avoid affecting other tests
+        clock_internal_test_stop_thread();
+        clock_internal_test_enable_threadless(true);
+    }
+}

--- a/tests/matron/clocks/clock_link/test_clock_link.cpp
+++ b/tests/matron/clocks/clock_link/test_clock_link.cpp
@@ -1,0 +1,176 @@
+// tests for matron/src/clocks/clock_link.c behavior
+// covers abl_link integration and helpers
+
+#include <doctest/doctest.h>
+
+extern "C" {
+#include "abl_link.h"
+#include "clocks/clock_link.h"
+#include "helpers.h"
+}
+
+// declare test-only seam (not in public header)
+extern "C" void clock_link_run_once(void);
+
+// override helpers.c stubs to return fixed values for link tests
+extern "C" double clock_get_reference_beat(clock_reference_t *) {
+    return 42.0;
+}
+extern "C" double clock_get_reference_tempo(clock_reference_t *) {
+    return 96.0;
+}
+
+// access stub globals from abl_link_stubs.c
+extern "C" volatile uint64_t g_stub_num_peers;
+extern "C" volatile int g_stub_created_count;
+extern "C" volatile double g_stub_last_quantum;
+extern "C" volatile double g_stub_requested_tempo;
+extern "C" volatile double g_stub_beat;
+extern "C" volatile double g_stub_tempo;
+extern "C" volatile int64_t g_stub_micros;
+extern "C" volatile bool g_stub_is_playing;
+extern "C" volatile bool g_stub_enabled;
+extern "C" volatile bool g_stub_sync_enabled;
+extern "C" volatile int g_stub_set_tempo_call_count;
+
+// capture start/stop requests from clock_link when start/stop sync reacts
+static int g_link_start_calls = 0;
+static int g_link_stop_calls = 0;
+
+extern "C" void clock_start_from_source(clock_source_t source) {
+    if (source == CLOCK_SOURCE_LINK) {
+        g_link_start_calls++;
+    }
+}
+extern "C" void clock_stop_from_source(clock_source_t source) {
+    if (source == CLOCK_SOURCE_LINK) {
+        g_link_stop_calls++;
+    }
+}
+
+TEST_CASE("link: init constructs abl_link instance") {
+    g_stub_created_count = 0;
+    clock_link_init();
+    CHECK(g_stub_created_count == 1);
+}
+
+TEST_CASE("link: number_of_peers proxies to abl_link") {
+    g_stub_num_peers = 7;
+    CHECK(clock_link_number_of_peers() == 7u);
+}
+
+TEST_CASE("link: getters call reference helpers") {
+    clock_link_init();
+    CHECK(clock_link_get_beat() == doctest::Approx(42.0));
+    CHECK(clock_link_get_tempo() == doctest::Approx(96.0));
+}
+
+TEST_CASE("link: clock_link_run_once seam steps one iteration with updated quantum") {
+    // initialize without starting background thread.
+    clock_link_init();
+
+    // set stub state and change quantum.
+    // single iteration should pass it through.
+    g_stub_last_quantum = -1.0;
+    g_stub_beat = 1.0;
+    g_stub_tempo = 120.0;
+    g_stub_micros = 0;
+    clock_link_set_quantum(8.0);
+
+    clock_link_run_once();
+    CHECK(g_stub_last_quantum == doctest::Approx(8.0));
+}
+
+TEST_CASE("link: set_tempo publishes requested tempo to stub on next iteration") {
+    clock_link_init();
+
+    g_stub_requested_tempo = 0.0;
+    g_stub_micros = 0;
+    g_stub_tempo = 120.0;
+    g_stub_beat = 0.0;
+
+    clock_link_set_tempo(135.0);
+    CHECK(g_stub_requested_tempo == doctest::Approx(0.0));
+
+    // value is applied when the loop runs once
+    clock_link_run_once();
+    CHECK(g_stub_requested_tempo == doctest::Approx(135.0));
+}
+
+TEST_CASE("link: start/stop sync triggers clock start/stop from LINK source") {
+    clock_link_init();
+
+    // reset counters and stub state
+    g_link_start_calls = 0;
+    g_link_stop_calls = 0;
+    g_stub_is_playing = false; // link initially not playing
+
+    // enable sync, transition from not playing -> playing -> not playing
+    clock_link_set_start_stop_sync(true);
+
+    // Start: link begins playing
+    g_stub_is_playing = true;
+    clock_link_run_once();
+    CHECK(g_link_start_calls == 1);
+    CHECK(g_link_stop_calls == 0);
+
+    // Stop: link stops playing
+    g_stub_is_playing = false;
+    clock_link_run_once();
+    CHECK(g_link_start_calls == 1);
+    CHECK(g_link_stop_calls == 1);
+}
+
+TEST_CASE("link: join/leave session toggles abl_link enable state") {
+    clock_link_init();
+    // ensure known baseline
+    g_stub_enabled = false;
+
+    // join should enable link on next step
+    clock_link_join_session();
+    clock_link_run_once();
+    CHECK(g_stub_enabled == true);
+
+    // leave should disable link on next step
+    clock_link_leave_session();
+    clock_link_run_once();
+    CHECK(g_stub_enabled == false);
+}
+
+TEST_CASE("link: start/stop sync flag forwarded to abl_link") {
+    clock_link_init();
+    g_stub_sync_enabled = false;
+
+    clock_link_set_start_stop_sync(true);
+    clock_link_run_once();
+    CHECK(g_stub_sync_enabled == true);
+
+    clock_link_set_start_stop_sync(false);
+    clock_link_run_once();
+    CHECK(g_stub_sync_enabled == false);
+}
+
+TEST_CASE("link: transport start/stop directly set playing state") {
+    clock_link_init();
+    g_stub_is_playing = false;
+
+    clock_link_set_transport_start();
+    clock_link_run_once();
+    CHECK(g_stub_is_playing == true);
+
+    clock_link_set_transport_stop();
+    clock_link_run_once();
+    CHECK(g_stub_is_playing == false);
+}
+
+TEST_CASE("link: set_tempo applies once and clears request") {
+    clock_link_init();
+    g_stub_set_tempo_call_count = 0;
+
+    clock_link_set_tempo(111.0);
+    // first step applies
+    clock_link_run_once();
+    // second step should not reapply
+    clock_link_run_once();
+    CHECK(g_stub_set_tempo_call_count == 1);
+}

--- a/tests/matron/clocks/clock_midi/test_clock_midi.cpp
+++ b/tests/matron/clocks/clock_midi/test_clock_midi.cpp
@@ -1,0 +1,245 @@
+// tests for matron/src/clocks/clock_midi.c behavior
+// covers start/stop, tick timing, and tempo smoothing
+
+#include <cmath>
+#include <doctest/doctest.h>
+
+extern "C" {
+#include "clocks/clock_midi.h"
+#include "helpers.h"
+}
+
+TEST_CASE("midi: start + ticks update beat and converge tempo to 120") {
+    double time = 200.0;
+    tests_set_now(time);
+    clock_midi_init();
+
+    // send START (counter -> -1)
+    clock_midi_handle_message(0xfa);
+
+    // first tick only sets last_tick_time
+    time = 200.010; // arbitrary
+    tests_set_now(time);
+    clock_midi_handle_message(0xf8);
+
+    // feed a number of ticks at 120 BPM (0.5s per beat -> ~0.0208333s per tick)
+    double dt = (0.5 / 24.0);
+    // 48 iterations = 2x the duration buffer size (24) to warm up smoothing buffer
+    for (int i = 0; i < 48; ++i) {
+        time += dt;
+        tests_set_now(time);
+        clock_midi_handle_message(0xf8);
+    }
+    double tempo1 = clock_midi_get_tempo();
+    CHECK(tempo1 > 0.0);
+
+    // after warm-up, beat near zero (allow small drift)
+    time = 200.030;
+    tests_set_now(time);
+
+    double near_zero = clock_midi_get_beat();
+    CHECK(near_zero > -0.1);
+    CHECK(near_zero < 0.1);
+
+    // speed up clock: halve dt (simulate 240 BPM), warm up, then compare ratios
+    double beat_before = clock_midi_get_beat();
+    double dt2 = dt / 2.0;
+    // 72 iterations = 3x the duration buffer size (24) to reach new steady state
+    for (int i = 0; i < 72; ++i) {
+        time += dt2;
+        tests_set_now(time);
+        clock_midi_handle_message(0xf8);
+    }
+    double tempo2 = clock_midi_get_tempo();
+    CHECK(tempo2 > tempo1);
+    CHECK(tempo2 / tempo1 == doctest::Approx(2.0).epsilon(0.25));
+
+    // beat should increase further
+    for (int i = 0; i < 12; ++i) {
+        time += dt;
+        tests_set_now(time);
+        clock_midi_handle_message(0xf8);
+    }
+    double beat_after = clock_midi_get_beat();
+    CHECK(beat_after > beat_before);
+}
+
+TEST_CASE("midi: stop message handled") {
+    // just exercise stop pathway, no observable state here
+    clock_midi_init();
+    clock_midi_handle_message(0xfc);
+    CHECK(true);
+}
+
+TEST_CASE("midi: beat counter persists across stop") {
+    // this test verifies that the beat counter is not reset by a STOP message.
+    // when ticks resume, the counter continues from its previous position.
+    // note: norns does not formally handle MIDI CONTINUE (0xfb). this
+    // behavior is a side-effect.
+    double time = 100.0;
+    tests_set_now(time);
+    clock_midi_init();
+
+    // send START (counter -> -1)
+    clock_midi_handle_message(0xfa);
+
+    // send first tick to establish timing
+    time += 0.010;
+    tests_set_now(time);
+    clock_midi_handle_message(0xf8);
+
+    // warm up the duration buffer with steady 120 BPM ticks
+    double dt = (0.5 / 24.0); // 120 BPM: 0.5s per beat, 24 ticks per beat
+    // 48 iterations = 2x the duration buffer size (24) to warm up smoothing buffer
+    for (int i = 0; i < 48; ++i) {
+        time += dt;
+        tests_set_now(time);
+        clock_midi_handle_message(0xf8);
+    }
+
+    // capture beat count before stopping
+    double beat_before_stop = clock_midi_get_beat();
+    CHECK(beat_before_stop > 0.0);
+
+    // send STOP (0xfc)
+    clock_midi_handle_message(0xfc);
+
+    // advance time significantly (simulate pause)
+    time += 2.0;
+    tests_set_now(time);
+
+    // send a few more ticks after the pause.
+    // since the counter was not reset, they should increment from the stopped position.
+    for (int i = 0; i < 12; ++i) {
+        time += dt;
+        tests_set_now(time);
+        clock_midi_handle_message(0xf8);
+    }
+
+    // beat should have increased from where it stopped, not reset to zero.
+    double beat_after_resume = clock_midi_get_beat();
+    CHECK(beat_after_resume > beat_before_stop);
+}
+
+TEST_CASE("midi: tempo remains finite with very high frequency ticks") {
+    double time = 100.0;
+    tests_set_now(time);
+    clock_midi_init();
+
+    // send START
+    clock_midi_handle_message(0xfa);
+
+    // first tick to establish timing
+    time += 0.001;
+    tests_set_now(time);
+    clock_midi_handle_message(0xf8);
+
+    // simulate extremely fast MIDI clock: dt approaching zero (thousands of BPM)
+    double dt = 0.0001; // 0.1ms between ticks
+    // 48 iterations = 2x the duration buffer size (24) to warm up smoothing buffer
+    for (int i = 0; i < 48; ++i) {
+        time += dt;
+        tests_set_now(time);
+        clock_midi_handle_message(0xf8);
+    }
+
+    double tempo = clock_midi_get_tempo();
+    // verify no inf or NaN (smoothing may produce unusual values with extreme timing)
+    CHECK(std::isfinite(tempo));
+    CHECK(!std::isnan(tempo));
+}
+
+TEST_CASE("midi: tempo remains finite with very low frequency ticks") {
+    double time = 100.0;
+    tests_set_now(time);
+    clock_midi_init();
+
+    // send START
+    clock_midi_handle_message(0xfa);
+
+    // first tick to establish timing
+    time += 0.010;
+    tests_set_now(time);
+    clock_midi_handle_message(0xf8);
+
+    // simulate very slow MIDI clock near the 4-second "clock stopped" threshold
+    double dt = 3.5 / 24.0; // 3.5s per beat divided by 24 ticks (just under 4s threshold)
+    // 48 iterations = 2x the duration buffer size (24) to warm up smoothing buffer
+    for (int i = 0; i < 48; ++i) {
+        time += dt;
+        tests_set_now(time);
+        clock_midi_handle_message(0xf8);
+    }
+
+    double tempo = clock_midi_get_tempo();
+    // tempo should be very low and finite
+    CHECK(tempo > 0.0);
+    CHECK(tempo < 20.0); // sanity check: should be very slow tempo
+    CHECK(std::isfinite(tempo));
+    CHECK(!std::isnan(tempo));
+}
+
+TEST_CASE("midi: zero dt ticks do not produce inf or NaN") {
+    double time = 100.0;
+    tests_set_now(time);
+    clock_midi_init();
+
+    // send START
+    clock_midi_handle_message(0xfa);
+
+    // first tick to establish timing
+    time += 0.010;
+    tests_set_now(time);
+    clock_midi_handle_message(0xf8);
+
+    // warm up with normal tempo
+    double dt = (0.5 / 24.0); // 120 BPM
+    for (int i = 0; i < 24; ++i) {
+        time += dt;
+        tests_set_now(time);
+        clock_midi_handle_message(0xf8);
+    }
+
+    // send tick with exact same timestamp (dt = 0)
+    clock_midi_handle_message(0xf8);
+
+    double tempo = clock_midi_get_tempo();
+    // verify no inf or NaN despite zero dt
+    CHECK(std::isfinite(tempo));
+    CHECK(!std::isnan(tempo));
+}
+
+TEST_CASE("midi: ticks beyond 4s threshold are treated as clock stopped") {
+    double time = 100.0;
+    tests_set_now(time);
+    clock_midi_init();
+
+    // send START
+    clock_midi_handle_message(0xfa);
+
+    // first tick to establish timing
+    time += 0.010;
+    tests_set_now(time);
+    clock_midi_handle_message(0xf8);
+
+    // warm up with normal tempo
+    double dt = (0.5 / 24.0); // 120 BPM
+    // 48 iterations = 2x the duration buffer size (24) to warm up smoothing buffer
+    for (int i = 0; i < 48; ++i) {
+        time += dt;
+        tests_set_now(time);
+        clock_midi_handle_message(0xf8);
+    }
+    double tempo_before = clock_midi_get_tempo();
+    CHECK(tempo_before > 0.0);
+
+    // send tick beyond 4s threshold (clock stopped condition)
+    time += 5.0;
+    tests_set_now(time);
+    clock_midi_handle_message(0xf8);
+
+    // tempo should still be finite
+    double tempo_after = clock_midi_get_tempo();
+    CHECK(std::isfinite(tempo_after));
+    CHECK(!std::isnan(tempo_after));
+}

--- a/tests/matron/clocks/clock_scheduler/test_clock_scheduler.cpp
+++ b/tests/matron/clocks/clock_scheduler/test_clock_scheduler.cpp
@@ -1,0 +1,281 @@
+// tests for matron/src/clocks/clock_scheduler.c behavior
+// covers scheduling, capacity, and thread safety
+
+#include <doctest/doctest.h>
+
+#include <atomic>
+#include <cfloat>
+#include <chrono>
+#include <mutex>
+#include <thread>
+#include <vector>
+
+extern "C" {
+#include "clocks/clock_scheduler.h"
+#include "event_types.h"
+}
+
+// scheduler runs on background thread. use atomic time control.
+static std::atomic<double> g_now{0.0};
+static std::atomic<double> g_beats{0.0};
+
+struct PostedEvent {
+    event_t type;
+    uint32_t thread_id;
+    double value;
+};
+
+static std::mutex g_ev_mtx;
+static std::vector<PostedEvent> g_posted;
+
+// override time stubs with atomic versions for scheduler thread.
+extern "C" double jack_client_get_current_time() {
+    return g_now.load();
+}
+extern "C" double clock_get_system_time() {
+    return g_now.load();
+}
+extern "C" double clock_get_beats() {
+    return g_beats.load();
+}
+
+// override event stubs to capture posted events.
+extern "C" union event_data *event_data_new(event_t evcode) {
+    auto *ev = (union event_data *)malloc(sizeof(union event_data));
+    ev->type = evcode;
+    return ev;
+}
+
+extern "C" void event_post(union event_data *ev) {
+    std::lock_guard<std::mutex> lk(g_ev_mtx);
+    if (ev->type == EVENT_CLOCK_RESUME) {
+        PostedEvent rec;
+        rec.type = static_cast<event_t>(ev->type);
+        rec.thread_id = ev->clock_resume.thread_id;
+        rec.value = ev->clock_resume.value;
+        g_posted.push_back(rec);
+    } else {
+        PostedEvent rec;
+        rec.type = static_cast<event_t>(ev->type);
+        rec.thread_id = 0u;
+        rec.value = 0.0;
+        g_posted.push_back(rec);
+    }
+    free(ev);
+}
+
+static void wait_ms(int ms) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(ms));
+}
+
+TEST_CASE("scheduler") {
+    // setup and teardown for all test cases in this suite
+    // start and stop the scheduler thread only once
+    clock_scheduler_init();
+
+    SUBCASE("capacity and clear") {
+        g_posted.clear();
+        clock_scheduler_clear_all();
+
+        bool ok = true;
+        for (int i = 0; i < NUM_CLOCK_SCHEDULER_EVENTS; ++i) {
+            ok &= clock_scheduler_schedule_sync(i, 1.0, 0.0);
+        }
+        CHECK(ok == true);
+
+        // scheduler is full. next schedule fails.
+        CHECK(clock_scheduler_schedule_sync(9999, 1.0, 0.0) == false);
+
+        clock_scheduler_clear_all();
+        CHECK(clock_scheduler_schedule_sync(9999, 1.0, 0.0) == true);
+    }
+
+    SUBCASE("sleep posts resume after time elapses") {
+        g_posted.clear();
+        g_now = 0.0;
+        clock_scheduler_clear_all();
+
+        CHECK(clock_scheduler_schedule_sleep(7, 0.05) == true);
+
+        // advance time beyond 50ms and wait for background thread to process.
+        g_now = 0.06;
+        wait_ms(20);
+
+        std::lock_guard<std::mutex> lk(g_ev_mtx);
+        bool seen = false;
+        for (const auto &e : g_posted) {
+            if (e.type == EVENT_CLOCK_RESUME && e.thread_id == 7) {
+                seen = true;
+            }
+        }
+        CHECK(seen == true);
+    }
+
+    SUBCASE("sync posts resume after passing next grid beat") {
+        g_posted.clear();
+        g_now = 0.0;
+        g_beats = 0.0;
+        clock_scheduler_clear_all();
+
+        CHECK(clock_scheduler_schedule_sync(5, 4.0, 0.0) == true);
+
+        // advance beats past 4.0 and wait for processing.
+        g_beats = 4.1;
+        wait_ms(20);
+
+        std::lock_guard<std::mutex> lk(g_ev_mtx);
+        bool seen = false;
+        for (const auto &e : g_posted) {
+            if (e.type == EVENT_CLOCK_RESUME && e.thread_id == 5) {
+                seen = true;
+            }
+        }
+        CHECK(seen == true);
+    }
+
+    SUBCASE("clear all is thread-safe with active background thread") {
+        g_posted.clear();
+        g_now = 0.0;
+        clock_scheduler_clear_all();
+
+        // schedule multiple sleep events with short durations
+        CHECK(clock_scheduler_schedule_sleep(1, 0.010) == true);
+        CHECK(clock_scheduler_schedule_sleep(2, 0.015) == true);
+        CHECK(clock_scheduler_schedule_sleep(3, 0.020) == true);
+
+        // clear all events and wait for background thread to observe cleared state.
+        clock_scheduler_clear_all();
+        wait_ms(5);
+
+        // advance time beyond all scheduled events and wait for background thread.
+        g_now = 0.030;
+        wait_ms(50);
+
+        // confirm no events posted after clear_all.
+        std::lock_guard<std::mutex> lk(g_ev_mtx);
+        CHECK(g_posted.empty());
+    }
+
+    SUBCASE("reschedule uses current clock beat") {
+        g_posted.clear();
+        g_now = 0.0;
+        g_beats = 0.0;
+        clock_scheduler_clear_all();
+
+        // initial schedule at 4.0 beats
+        REQUIRE(clock_scheduler_schedule_sync(10, 4.0, 0.0) == true);
+
+        // move clock to boundary and reschedule. target advances to 8.0.
+        g_beats = 4.0;
+        clock_scheduler_reschedule_sync_events();
+
+        // advance past 4.0. event does not post due to reschedule.
+        g_beats = 4.1;
+        wait_ms(20);
+        {
+            std::lock_guard<std::mutex> lk(g_ev_mtx);
+            bool seen = false;
+            for (const auto &e : g_posted) {
+                if (e.type == EVENT_CLOCK_RESUME && e.thread_id == 10) {
+                    seen = true;
+                }
+            }
+            CHECK(seen == false);
+        }
+
+        // advance past 8.0. event posts.
+        g_beats = 8.1;
+        wait_ms(30);
+        {
+            std::lock_guard<std::mutex> lk(g_ev_mtx);
+            bool seen = false;
+            for (const auto &e : g_posted) {
+                if (e.type == EVENT_CLOCK_RESUME && e.thread_id == 10) {
+                    seen = true;
+                }
+            }
+            CHECK(seen == true);
+        }
+    }
+
+    SUBCASE("reset sets sync_clock_beat to 0 for ready sync events") {
+        g_posted.clear();
+        g_now = 0.0;
+        g_beats = 0.5; // > 0 to trigger immediate eligibility on reset
+        clock_scheduler_clear_all();
+
+        REQUIRE(clock_scheduler_schedule_sync(11, 4.0, 0.0) == true);
+
+        // reset sets stored target to 0, causing immediate post on next tick.
+        clock_scheduler_reset_sync_events();
+        wait_ms(20);
+
+        std::lock_guard<std::mutex> lk(g_ev_mtx);
+        bool seen = false;
+        for (const auto &e : g_posted) {
+            if (e.type == EVENT_CLOCK_RESUME && e.thread_id == 11) {
+                seen = true;
+            }
+        }
+        CHECK(seen == true);
+    }
+
+    SUBCASE("rescheduling same thread counts from stored sync beat") {
+        g_posted.clear();
+        g_now = 0.0;
+        g_beats = 0.0;
+        clock_scheduler_clear_all();
+
+        // schedule at 4.0 and reschedule same thread. target becomes 8.0.
+        REQUIRE(clock_scheduler_schedule_sync(12, 4.0, 0.0) == true);
+        REQUIRE(clock_scheduler_schedule_sync(12, 4.0, 0.0) == true);
+
+        // crossing 4.0 does not post. counts from stored next beat.
+        g_beats = 4.1;
+        wait_ms(20);
+        {
+            std::lock_guard<std::mutex> lk(g_ev_mtx);
+            bool seen = false;
+            for (const auto &e : g_posted) {
+                if (e.type == EVENT_CLOCK_RESUME && e.thread_id == 12) {
+                    seen = true;
+                }
+            }
+            CHECK(seen == false);
+        }
+
+        // crossing 8.0 posts event.
+        g_beats = 8.1;
+        wait_ms(30);
+        {
+            std::lock_guard<std::mutex> lk(g_ev_mtx);
+            bool seen = false;
+            for (const auto &e : g_posted) {
+                if (e.type == EVENT_CLOCK_RESUME && e.thread_id == 12) {
+                    seen = true;
+                }
+            }
+            CHECK(seen == true);
+        }
+    }
+
+    SUBCASE("next-beat boundary math (epsilon/ceil)") {
+        // on boundary advances to next grid (4.0 → 8.0 for 4-beat grid).
+        CHECK(clock_scheduler_test_next_clock_beat(4.0, 4.0, 0.0) == doctest::Approx(8.0));
+
+        // within epsilon of boundary advances to next grid.
+        double near = 4.0 - (FLT_EPSILON * 0.5);
+        CHECK(clock_scheduler_test_next_clock_beat(near, 4.0, 0.0) == doctest::Approx(8.0));
+
+        // beyond epsilon rounds to current grid (4.0).
+        double below = 4.0 - (FLT_EPSILON * 10.0);
+        CHECK(clock_scheduler_test_next_clock_beat(below, 4.0, 0.0) == doctest::Approx(4.0));
+
+        // offset applied correctly (0 → 1.5 with 4.0 beat + 1.5 offset).
+        CHECK(clock_scheduler_test_next_clock_beat(0.0, 4.0, 1.5) == doctest::Approx(5.5));
+    }
+
+    // teardown
+    clock_scheduler_stop();
+    clock_scheduler_join();
+}

--- a/tests/matron/clocks/common/abl_link.h
+++ b/tests/matron/clocks/common/abl_link.h
@@ -1,0 +1,51 @@
+// stub header for ableton link C API used by clock_link.c
+// this stub satisfies the compiler without pulling in the entire link library.
+
+#pragma once
+#include <stdbool.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct abl_link {
+    void *impl;
+} abl_link;
+typedef struct abl_link_session_state {
+    void *impl;
+} abl_link_session_state;
+
+abl_link abl_link_create(double bpm);
+void abl_link_destroy(abl_link link);
+bool abl_link_is_enabled(abl_link link);
+void abl_link_enable(abl_link link, bool enable);
+bool abl_link_is_start_stop_sync_enabled(abl_link link);
+void abl_link_enable_start_stop_sync(abl_link link, bool enabled);
+uint64_t abl_link_num_peers(abl_link link);
+
+typedef void (*abl_link_num_peers_callback)(uint64_t num_peers, void *context);
+void abl_link_set_num_peers_callback(abl_link link, abl_link_num_peers_callback callback, void *context);
+
+typedef void (*abl_link_tempo_callback)(double tempo, void *context);
+void abl_link_set_tempo_callback(abl_link link, abl_link_tempo_callback callback, void *context);
+
+typedef void (*abl_link_start_stop_callback)(bool is_playing, void *context);
+void abl_link_set_start_stop_callback(abl_link link, abl_link_start_stop_callback callback, void *context);
+
+int64_t abl_link_clock_micros(abl_link link);
+
+abl_link_session_state abl_link_create_session_state(void);
+void abl_link_destroy_session_state(abl_link_session_state state);
+void abl_link_capture_app_session_state(abl_link link, abl_link_session_state state);
+void abl_link_commit_app_session_state(abl_link link, abl_link_session_state state);
+double abl_link_tempo(abl_link_session_state state);
+void abl_link_set_tempo(abl_link_session_state state, double bpm, int64_t at_time);
+double abl_link_beat_at_time(abl_link_session_state state, int64_t micros, double quantum);
+bool abl_link_is_playing(abl_link_session_state state);
+void abl_link_set_is_playing(abl_link_session_state state, bool is_playing, int64_t at_time);
+void abl_link_request_beat_at_start_playing_time(abl_link_session_state state, double beat, double quantum);
+
+#ifdef __cplusplus
+}
+#endif

--- a/tests/matron/clocks/common/abl_link_stubs.c
+++ b/tests/matron/clocks/common/abl_link_stubs.c
@@ -1,0 +1,114 @@
+// stub implementations for ableton link C API used by clock_link.c
+
+#include "abl_link.h"
+
+volatile int64_t g_stub_micros = 0;
+volatile double g_stub_tempo = 120.0;
+volatile double g_stub_beat = 0.0;
+volatile uint64_t g_stub_num_peers = 0;
+volatile double g_stub_requested_tempo = 0.0;
+volatile int g_stub_created_count = 0;
+volatile bool g_stub_is_playing = false;
+volatile double g_stub_last_quantum = 0.0;
+volatile bool g_stub_enabled = false;
+volatile bool g_stub_sync_enabled = false;
+volatile int g_stub_set_tempo_call_count = 0;
+
+abl_link abl_link_create(double bpm) {
+    (void)bpm;
+    ++g_stub_created_count;
+    abl_link l;
+    l.impl = (void *)0x1;
+    return l;
+}
+void abl_link_destroy(abl_link link) {
+    (void)link;
+}
+bool abl_link_is_enabled(abl_link link) {
+    (void)link;
+    return true;
+}
+void abl_link_enable(abl_link link, bool enable) {
+    (void)link;
+    g_stub_enabled = enable;
+}
+bool abl_link_is_start_stop_sync_enabled(abl_link link) {
+    (void)link;
+    return false;
+}
+void abl_link_enable_start_stop_sync(abl_link link, bool enabled) {
+    (void)link;
+    g_stub_sync_enabled = enabled;
+}
+uint64_t abl_link_num_peers(abl_link link) {
+    (void)link;
+    return g_stub_num_peers;
+}
+
+void abl_link_set_num_peers_callback(abl_link link, abl_link_num_peers_callback cb, void *ctx) {
+    (void)link;
+    (void)cb;
+    (void)ctx;
+}
+void abl_link_set_tempo_callback(abl_link link, abl_link_tempo_callback cb, void *ctx) {
+    (void)link;
+    (void)cb;
+    (void)ctx;
+}
+void abl_link_set_start_stop_callback(abl_link link, abl_link_start_stop_callback cb, void *ctx) {
+    (void)link;
+    (void)cb;
+    (void)ctx;
+}
+
+int64_t abl_link_clock_micros(abl_link link) {
+    (void)link;
+    return g_stub_micros;
+}
+
+abl_link_session_state abl_link_create_session_state(void) {
+    abl_link_session_state s;
+    s.impl = (void *)0x2;
+    return s;
+}
+void abl_link_destroy_session_state(abl_link_session_state state) {
+    (void)state;
+}
+void abl_link_capture_app_session_state(abl_link link, abl_link_session_state state) {
+    (void)link;
+    (void)state;
+}
+void abl_link_commit_app_session_state(abl_link link, abl_link_session_state state) {
+    (void)link;
+    (void)state;
+}
+double abl_link_tempo(abl_link_session_state state) {
+    (void)state;
+    return g_stub_tempo;
+}
+void abl_link_set_tempo(abl_link_session_state state, double bpm, int64_t at_time) {
+    (void)state;
+    (void)at_time;
+    g_stub_requested_tempo = bpm;
+    g_stub_set_tempo_call_count++;
+}
+double abl_link_beat_at_time(abl_link_session_state state, int64_t micros, double quantum) {
+    (void)state;
+    (void)micros;
+    g_stub_last_quantum = quantum;
+    return g_stub_beat;
+}
+bool abl_link_is_playing(abl_link_session_state state) {
+    (void)state;
+    return g_stub_is_playing;
+}
+void abl_link_set_is_playing(abl_link_session_state state, bool is_playing, int64_t at_time) {
+    (void)state;
+    g_stub_is_playing = is_playing;
+    (void)at_time;
+}
+void abl_link_request_beat_at_start_playing_time(abl_link_session_state state, double beat, double quantum) {
+    (void)state;
+    (void)beat;
+    (void)quantum;
+}

--- a/tests/matron/clocks/common/helpers.c
+++ b/tests/matron/clocks/common/helpers.c
@@ -1,0 +1,163 @@
+#include "helpers.h"
+#include "events.h"
+
+#include <errno.h>
+#include <stdlib.h>
+#include <time.h>
+
+static double g_now = 0.0;
+static double g_beats = 0.0;
+static bool g_nanosleep_advances_time = true;
+static bool g_nanosleep_strict_validation = false;
+
+// -----------------------------------------------------------------------------
+// test control functions - allow tests to manipulate time and beats
+// -----------------------------------------------------------------------------
+
+double tests_set_now(double v) {
+    g_now = v;
+    return g_now;
+}
+
+double tests_set_beats(double v) {
+    g_beats = v;
+    return g_beats;
+}
+
+void tests_set_nanosleep_advances_time(bool v) {
+    g_nanosleep_advances_time = v;
+}
+void tests_set_nanosleep_strict_validation(bool v) {
+    g_nanosleep_strict_validation = v;
+}
+
+// -----------------------------------------------------------------------------
+// time stubs - provide controllable time to system code
+// weak symbols allow test_clock_scheduler to override with atomic versions
+// -----------------------------------------------------------------------------
+
+__attribute__((weak)) double jack_client_get_current_time(void) {
+    return g_now;
+}
+
+__attribute__((weak)) double clock_get_system_time(void) {
+    return g_now;
+}
+
+__attribute__((weak)) double clock_get_beats(void) {
+    return g_beats;
+}
+
+// -----------------------------------------------------------------------------
+// clock reference stubs - shared by clock_internal, clock_crow, clock_midi, clock_link
+// -----------------------------------------------------------------------------
+
+void clock_reference_init(clock_reference_t *reference) {
+    pthread_mutex_init(&(reference->lock), NULL);
+    reference->beat = 0.0;
+    reference->beat_duration = 0.5; // default 120 bpm
+    reference->last_beat_time = g_now;
+}
+
+void clock_update_source_reference(clock_reference_t *reference, double beat, double beat_duration) {
+    reference->beat = beat;
+    reference->beat_duration = beat_duration;
+    reference->last_beat_time = g_now;
+}
+
+// weak symbols allow tests to override with custom implementations
+__attribute__((weak)) double clock_get_reference_beat(clock_reference_t *reference) {
+    return reference->beat + ((g_now - reference->last_beat_time) / reference->beat_duration);
+}
+
+__attribute__((weak)) double clock_get_reference_tempo(clock_reference_t *reference) {
+    return 60.0 / reference->beat_duration;
+}
+
+// -----------------------------------------------------------------------------
+// clock control stubs - used by clock implementations to signal state changes
+// -----------------------------------------------------------------------------
+
+__attribute__((weak)) void clock_start_from_source(clock_source_t source) {
+    (void)source;
+}
+
+__attribute__((weak)) void clock_stop_from_source(clock_source_t source) {
+    (void)source;
+}
+
+// weak symbol allows test_clock_crow to override and track reschedule calls
+__attribute__((weak)) void clock_reschedule_sync_events_from_source(clock_source_t source) {
+    (void)source;
+}
+
+// -----------------------------------------------------------------------------
+// pthread mutex stubs - no-ops for deterministic testing
+// -----------------------------------------------------------------------------
+
+int pthread_mutex_lock(pthread_mutex_t *mutex) {
+    (void)mutex;
+    return 0;
+}
+
+int pthread_mutex_unlock(pthread_mutex_t *mutex) {
+    (void)mutex;
+    return 0;
+}
+
+int pthread_mutex_init(pthread_mutex_t *mutex, const pthread_mutexattr_t *attr) {
+    (void)mutex;
+    (void)attr;
+    return 0;
+}
+
+int pthread_mutex_trylock(pthread_mutex_t *mutex) {
+    (void)mutex;
+    return 0; // success
+}
+
+// -----------------------------------------------------------------------------
+// time sleeping stub - advance virtual time instead of real sleeping
+// -----------------------------------------------------------------------------
+
+int clock_nanosleep(clockid_t clock_id, int flags, const struct timespec *request, struct timespec *remain) {
+    (void)clock_id;
+    (void)flags;
+    (void)remain;
+
+    // guard against NULL or invalid timespec
+    if (request == NULL) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    // malformed values: either simulate OS error or no-op per test mode
+    if (request->tv_sec < 0 || request->tv_nsec < 0 || request->tv_nsec >= 1000000000L) {
+        if (g_nanosleep_strict_validation) {
+            errno = EINVAL;
+            return -1;
+        }
+        return 0; // ignore invalid and do not advance time
+    }
+
+    if (g_nanosleep_advances_time) {
+        double seconds = (double)request->tv_sec + (double)request->tv_nsec / 1000000000.0;
+        g_now += seconds;
+    }
+    return 0;
+}
+
+// -----------------------------------------------------------------------------
+// event system stubs - minimal implementation for tests that don't examine events
+// weak symbols allow test_clock_scheduler to override and capture posted events
+// -----------------------------------------------------------------------------
+
+__attribute__((weak)) union event_data *event_data_new(event_t t) {
+    union event_data *ev = (union event_data *)malloc(sizeof(union event_data));
+    ev->type = t;
+    return ev;
+}
+
+__attribute__((weak)) void event_post(union event_data *ev) {
+    free(ev);
+}

--- a/tests/matron/clocks/common/helpers.h
+++ b/tests/matron/clocks/common/helpers.h
@@ -1,0 +1,45 @@
+// shared test stubs for matron clocks
+// provides controllable time, events, and clock reference helpers
+
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <pthread.h>
+#include <stdbool.h>
+
+#include "clock.h"
+
+// test-controlled time and beat values
+double tests_set_now(double v);
+double tests_set_beats(double v);
+void tests_set_nanosleep_advances_time(bool v);
+void tests_set_nanosleep_strict_validation(bool v);
+
+// time stubs used by all clock implementations
+double jack_client_get_current_time(void);
+double clock_get_system_time(void);
+double clock_get_beats(void);
+
+// clock reference stubs used by clock_internal, clock_crow, clock_midi, clock_link
+void clock_reference_init(clock_reference_t *reference);
+void clock_update_source_reference(clock_reference_t *reference, double beat, double beat_duration);
+double clock_get_reference_beat(clock_reference_t *reference);
+double clock_get_reference_tempo(clock_reference_t *reference);
+
+// clock control stubs used by clock_crow, clock_internal, clock_midi, clock_link
+void clock_start_from_source(clock_source_t source);
+void clock_stop_from_source(clock_source_t source);
+void clock_reschedule_sync_events_from_source(clock_source_t source);
+
+// pthread mutex stubs for deterministic testing
+int pthread_mutex_lock(pthread_mutex_t *mutex);
+int pthread_mutex_unlock(pthread_mutex_t *mutex);
+int pthread_mutex_init(pthread_mutex_t *mutex, const pthread_mutexattr_t *attr);
+int pthread_mutex_trylock(pthread_mutex_t *mutex);
+
+#ifdef __cplusplus
+}
+#endif

--- a/tests/matron/jack_client/common/jack/jack.h
+++ b/tests/matron/jack_client/common/jack/jack.h
@@ -1,0 +1,46 @@
+// minimal jack header shim for unit tests.
+// this stub satisfies the compiler without pulling in the real jack dependency.
+
+#pragma once
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef uint32_t jack_nframes_t;
+
+typedef struct _jack_client jack_client_t;
+typedef struct _jack_port jack_port_t;
+
+// client open flags
+enum { JackNoStartServer = 0 };
+
+// port flags used in queries
+enum { JackPortIsInput = 1,
+       JackPortIsOutput = 2 };
+
+// function pointer types (simplified)
+typedef int (*JackXRunCallback)(void *arg);
+
+// minimal prototypes referenced by jack_client.c
+jack_client_t *jack_client_open(const char *client_name, int options, void *status);
+int jack_set_xrun_callback(jack_client_t *client, JackXRunCallback callback, void *arg);
+int jack_activate(jack_client_t *client);
+void jack_client_close(jack_client_t *client);
+float jack_cpu_load(jack_client_t *client);
+jack_nframes_t jack_get_sample_rate(jack_client_t *client);
+const char **jack_get_ports(jack_client_t *client, const char *port_name_pattern, const char *type_name_pattern, unsigned long flags);
+const jack_port_t *jack_port_by_name(jack_client_t *client, const char *port_name);
+const char **jack_port_get_all_connections(jack_client_t *client, const jack_port_t *port);
+int jack_connect(jack_client_t *client, const char *source_port, const char *destination_port);
+int jack_disconnect(jack_client_t *client, const char *source_port, const char *destination_port);
+void jack_free(void *ptr);
+
+// current frame time, defined in the test file
+jack_nframes_t jack_frame_time(jack_client_t *client);
+
+#ifdef __cplusplus
+}
+#endif

--- a/tests/matron/jack_client/jack_stubs.c
+++ b/tests/matron/jack_client/jack_stubs.c
@@ -1,0 +1,79 @@
+#include <stdint.h>
+#include <stdlib.h>
+
+#include "jack/jack.h"
+
+struct _jack_client {};
+struct _jack_port {};
+
+jack_client_t *jack_client_open(const char *client_name, int options, void *status) {
+    (void)client_name;
+    (void)options;
+    (void)status;
+    static struct _jack_client dummy;
+    return &dummy;
+}
+
+int jack_set_xrun_callback(jack_client_t *client, JackXRunCallback callback, void *arg) {
+    (void)client;
+    (void)callback;
+    (void)arg;
+    return 0;
+}
+
+int jack_activate(jack_client_t *client) {
+    (void)client;
+    return 0;
+}
+
+void jack_client_close(jack_client_t *client) {
+    (void)client;
+}
+
+float jack_cpu_load(jack_client_t *client) {
+    (void)client;
+    return 0.0f;
+}
+
+jack_nframes_t jack_get_sample_rate(jack_client_t *client) {
+    (void)client;
+    return (jack_nframes_t)48000u;
+}
+
+const char **jack_get_ports(jack_client_t *client, const char *port_name_pattern, const char *type_name_pattern, unsigned long flags) {
+    (void)client;
+    (void)port_name_pattern;
+    (void)type_name_pattern;
+    (void)flags;
+    return NULL;
+}
+
+const jack_port_t *jack_port_by_name(jack_client_t *client, const char *port_name) {
+    (void)client;
+    (void)port_name;
+    return NULL;
+}
+
+const char **jack_port_get_all_connections(jack_client_t *client, const jack_port_t *port) {
+    (void)client;
+    (void)port;
+    return NULL;
+}
+
+int jack_connect(jack_client_t *client, const char *source_port, const char *destination_port) {
+    (void)client;
+    (void)source_port;
+    (void)destination_port;
+    return 0;
+}
+
+int jack_disconnect(jack_client_t *client, const char *source_port, const char *destination_port) {
+    (void)client;
+    (void)source_port;
+    (void)destination_port;
+    return 0;
+}
+
+void jack_free(void *ptr) {
+    (void)ptr;
+}

--- a/tests/matron/jack_client/test_jack_client.cpp
+++ b/tests/matron/jack_client/test_jack_client.cpp
@@ -1,0 +1,117 @@
+// tests for matron/src/jack_client.c 64-bit time wrap tracking
+
+#include <atomic>
+#include <cstdint>
+#include <doctest/doctest.h>
+#include <thread>
+
+extern "C" {
+#include "jack_client.h"
+// test-only seam added under NORNS_TEST
+void jack_client_test_set_time_state(uint64_t frames);
+void jack_client_test_reset_time_state(void);
+// global from jack_client.c
+extern double jack_sample_rate;
+}
+
+// stub JACK frame time source controlled by tests
+static std::atomic<uint32_t> g_stub_frames{0u};
+
+extern "C" {
+#include "jack/jack.h"
+
+jack_nframes_t jack_frame_time(jack_client_t *) {
+    return static_cast<jack_nframes_t>(g_stub_frames.load());
+}
+}
+
+static void set_sr(double sr) {
+    jack_sample_rate = sr;
+}
+
+TEST_CASE("jack_client: time progresses forward without wrap") {
+    jack_client_test_reset_time_state();
+    set_sr(48000.0);
+
+    g_stub_frames = 100u;
+    double t1 = jack_client_get_current_time();
+    CHECK(t1 == doctest::Approx(100.0 / 48000.0));
+
+    g_stub_frames = 100000u;
+    double t2 = jack_client_get_current_time();
+    CHECK(t2 == doctest::Approx(100000.0 / 48000.0));
+    CHECK(t2 >= t1);
+}
+
+TEST_CASE("jack_client: time wrap produces correct 64-bit time") {
+    // seed jack client state to pre-wrap value so signed delta sees a small change
+    jack_client_test_set_time_state(0xFFFFFFF0u); // 2^32 - 16
+    set_sr(48000.0);
+
+    // drive close to 2^32 - 16, then wrap to 32
+    g_stub_frames = 0xFFFFFFF0u; // 2^32 - 16
+    double t_pre = jack_client_get_current_time();
+    CHECK(t_pre == doctest::Approx(4294967280.0 / 48000.0));
+
+    g_stub_frames = 0x00000020u; // 32
+    double t_post = jack_client_get_current_time();
+
+    // expected: (2^32 + 32) / sr
+    const double expected = (4294967296.0 + 32.0) / 48000.0;
+    CHECK(t_post == doctest::Approx(expected));
+    CHECK(t_post >= t_pre);
+}
+
+TEST_CASE("jack_client: time is monotonic with out-of-order frames") {
+    jack_client_test_reset_time_state();
+    set_sr(48000.0);
+
+    g_stub_frames = 1000u;
+    double t1 = jack_client_get_current_time();
+    CHECK(t1 == doctest::Approx(1000.0 / 48000.0));
+
+    // smaller value but not a real wrap pattern (far from range ends)
+    g_stub_frames = 900u;
+    double t2 = jack_client_get_current_time();
+    // monotonic: should not decrease and should not jump by ~2^32 frames
+    CHECK(t2 >= t1);
+    CHECK(t2 == doctest::Approx(t1));
+}
+
+TEST_CASE("jack_client: time is monotonic across threads during wrap") {
+    jack_client_test_reset_time_state();
+    set_sr(48000.0);
+
+    // prepare to cross wrap boundary while multiple readers observe time
+    g_stub_frames = 0xFFFFFF00u; // near top
+
+    // reader samples
+    std::atomic<double> r1_last{0.0}, r2_last{0.0};
+    std::atomic<int> r1_bad{0}, r2_bad{0};
+
+    auto read_loop = [](std::atomic<double> &last, std::atomic<int> &bad) {
+        for (int i = 0; i < 1000; ++i) {
+            double t = jack_client_get_current_time();
+            double prev = last.load();
+            if (t + 1e-12 < prev) {
+                ++bad; // detected regression
+            } else {
+                last.store(t);
+            }
+        }
+    };
+
+    std::thread r1(read_loop, std::ref(r1_last), std::ref(r1_bad));
+    std::thread r2(read_loop, std::ref(r2_last), std::ref(r2_bad));
+
+    // advance past wrap while readers are running
+    for (uint32_t f = 0xFFFFFF00u; f != 0x00000100u; ++f) {
+        g_stub_frames = f;
+    }
+
+    r1.join();
+    r2.join();
+
+    CHECK(r1_bad.load() == 0);
+    CHECK(r2_bad.load() == 0);
+}

--- a/tests/matron/test_args.cpp
+++ b/tests/matron/test_args.cpp
@@ -1,0 +1,187 @@
+// tests for matron/src/args.c behavior
+// covers argument parsing, defaults, overrides, and error handling
+
+#include <doctest/doctest.h>
+
+#include <string>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+#include <vector>
+
+extern "C" {
+#include "args.h"
+}
+
+// -----------------------------------------------------------------------------
+// test helpers
+
+static void reset_args_to_defaults() {
+    char program[] = "matron";
+    char opt_l[] = "-l";
+    char val_l[] = "8888";
+    char opt_e[] = "-e";
+    char val_e[] = "57120";
+    char opt_o[] = "-o";
+    char val_o[] = "10111";
+    char opt_c[] = "-c";
+    char val_c[] = "9999";
+    char opt_f[] = "-f";
+    char val_f[] = "/dev/fb0";
+
+    char *argv[] = {program, opt_l, val_l, opt_e, val_e, opt_o, val_o, opt_c, val_c, opt_f, val_f, nullptr};
+    int argc = static_cast<int>((sizeof(argv) / sizeof(argv[0])) - 1);
+
+    optind = 1;
+    args_parse(argc, argv);
+}
+
+// -----------------------------------------------------------------------------
+// default values
+
+TEST_CASE("args_parse returns default ports and framebuffer") {
+    reset_args_to_defaults();
+
+    CHECK(std::string(args_local_port()) == "8888");
+    CHECK(std::string(args_ext_port()) == "57120");
+    CHECK(std::string(args_crone_port()) == "9999");
+    CHECK(std::string(args_remote_port()) == "10111");
+    CHECK(std::string(args_framebuffer_path()) == "/dev/fb0");
+}
+
+// -----------------------------------------------------------------------------
+// override behavior
+
+TEST_CASE("args_parse overrides all ports and framebuffer") {
+    reset_args_to_defaults();
+
+    char program[] = "matron";
+    char opt_l[] = "-l";
+    char val_l[] = "12000";
+    char opt_e[] = "-e";
+    char val_e[] = "42000";
+    char opt_o[] = "-o";
+    char val_o[] = "33333";
+    char opt_c[] = "-c";
+    char val_c[] = "44444";
+    char opt_f[] = "-f";
+    char val_f[] = "/dev/fb1";
+    char *argv[] = {program, opt_l, val_l, opt_e, val_e, opt_o, val_o, opt_c, val_c, opt_f, val_f, nullptr};
+    int argc = static_cast<int>((sizeof(argv) / sizeof(argv[0])) - 1);
+    optind = 1;
+
+    args_parse(argc, argv);
+
+    CHECK(std::string(args_local_port()) == "12000");
+    CHECK(std::string(args_ext_port()) == "42000");
+    CHECK(std::string(args_remote_port()) == "33333");
+    CHECK(std::string(args_crone_port()) == "44444");
+    CHECK(std::string(args_framebuffer_path()) == "/dev/fb1");
+}
+
+TEST_CASE("args_parse preserves defaults when partially overridden") {
+    reset_args_to_defaults();
+
+    char program[] = "matron";
+    char opt_l[] = "-l";
+    char val_l[] = "12345";
+    char *argv[] = {program, opt_l, val_l, nullptr};
+    int argc = static_cast<int>((sizeof(argv) / sizeof(argv[0])) - 1);
+    optind = 1;
+
+    args_parse(argc, argv);
+
+    CHECK(std::string(args_local_port()) == "12345");
+    CHECK(std::string(args_ext_port()) == "57120");
+    CHECK(std::string(args_remote_port()) == "10111");
+    CHECK(std::string(args_crone_port()) == "9999");
+    CHECK(std::string(args_framebuffer_path()) == "/dev/fb0");
+}
+
+// -----------------------------------------------------------------------------
+// boundary conditions
+
+TEST_CASE("args_parse truncates values longer than 63 characters") {
+    reset_args_to_defaults();
+
+    char program[] = "matron";
+    char opt_l[] = "-l";
+    std::string long_port(80, '7');
+    std::vector<char> long_buf(long_port.begin(), long_port.end());
+    long_buf.push_back('\0');
+    char *argv[] = {program, opt_l, long_buf.data(), nullptr};
+    int argc = static_cast<int>((sizeof(argv) / sizeof(argv[0])) - 1);
+    optind = 1;
+
+    int rc = args_parse(argc, argv);
+
+    CHECK(rc == 0);
+    std::string parsed = args_local_port();
+    CHECK(parsed.size() <= 63);
+    CHECK(parsed == long_port.substr(0, parsed.size()));
+}
+
+TEST_CASE("args_parse accepts values at 63 character boundary") {
+    reset_args_to_defaults();
+
+    char program[] = "matron";
+    char opt_l[] = "-l";
+    std::string boundary_port(63, '9');
+    std::vector<char> boundary_buf(boundary_port.begin(), boundary_port.end());
+    boundary_buf.push_back('\0');
+    char *argv[] = {program, opt_l, boundary_buf.data(), nullptr};
+    int argc = static_cast<int>((sizeof(argv) / sizeof(argv[0])) - 1);
+    optind = 1;
+
+    int rc = args_parse(argc, argv);
+
+    CHECK(rc == 0);
+    std::string parsed = args_local_port();
+    CHECK(parsed.size() == 63);
+    CHECK(parsed == boundary_port);
+}
+
+// -----------------------------------------------------------------------------
+// error handling
+
+TEST_CASE("args_parse exits with status 1 on help flag") {
+    pid_t pid = fork();
+    REQUIRE(pid >= 0);
+
+    if (pid == 0) {
+        char program[] = "matron";
+        char opt_h[] = "-h";
+        char *argv[] = {program, opt_h, nullptr};
+        int argc = static_cast<int>((sizeof(argv) / sizeof(argv[0])) - 1);
+        optind = 1;
+        args_parse(argc, argv);
+        _exit(0);
+    }
+
+    int status = 0;
+    waitpid(pid, &status, 0);
+
+    CHECK(WIFEXITED(status));
+    CHECK(WEXITSTATUS(status) == 1);
+}
+
+TEST_CASE("args_parse exits with status 1 on unknown option") {
+    pid_t pid = fork();
+    REQUIRE(pid >= 0);
+
+    if (pid == 0) {
+        char program[] = "matron";
+        char opt_z[] = "-z";
+        char *argv[] = {program, opt_z, nullptr};
+        int argc = static_cast<int>((sizeof(argv) / sizeof(argv[0])) - 1);
+        optind = 1;
+        args_parse(argc, argv);
+        _exit(0);
+    }
+
+    int status = 0;
+    waitpid(pid, &status, 0);
+
+    CHECK(WIFEXITED(status));
+    CHECK(WEXITSTATUS(status) == 1);
+}

--- a/tests/wscript
+++ b/tests/wscript
@@ -1,0 +1,736 @@
+"""tests/wscript - test runner for C/C++ units.
+
+discovers `test_*.cpp` files under `tests/` and builds one test binary per
+test_*/directory. mirrors test locations to source files in `<module>/src/` using
+simple name mapping rules. supports a dry-run to print discovery results without
+building and a self-test that validates core logic.
+
+notes:
+- enables `NORNS_TEST` seams during tests.
+- accepts extra defines via `NORNS_TEST_DEFINES` env var (comma/semicolon list).
+- recognizes camelcase and underscore variants when mapping to system sources.
+"""
+
+top = ".."
+
+import os
+import sys
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+from typing import Any, Dict, List, Set, Tuple
+from waflib import Logs
+from waflib.Build import BuildContext
+
+Node = Any  # waflib.Node.Node at runtime
+
+
+@dataclass
+class TestRunnerConfig:
+    """compiler configuration shared across all tests.
+
+    holds include paths, compiler flags, and preprocessor defines.
+
+    Args:
+        includes: list of include directory paths.
+        cflags: list of C compiler flags.
+        cxxflags: list of C++ compiler flags.
+        defines: list of preprocessor defines.
+    """
+
+    includes: List[str]
+    cflags: List[str]
+    cxxflags: List[str]
+    defines: List[str]
+
+
+@dataclass
+class TestSources:
+    """source files collected for a single test unit.
+
+    holds test files, helper sources, system sources, and includes.
+
+    Args:
+        test_files: set of test file nodes.
+        unit_helpers: list of unit-specific helper source nodes.
+        common_helpers: list of common helper source nodes.
+        system_sources: list of system source nodes to compile.
+        system_headers: list of system header-only nodes (not compiled).
+        common_includes: list of common include directory paths.
+        unit_dir: waf node for the test unit directory.
+    """
+
+    test_files: Set[Node]
+    unit_helpers: List[Node]
+    common_helpers: List[Node]
+    system_sources: List[Node]
+    system_headers: List[Node]
+    common_includes: List[str]
+    unit_dir: Node
+
+    def has_c_sources(self) -> bool:
+        """check if any sources are C files."""
+        return (
+            any(h.abspath().endswith(".c") for h in self.unit_helpers)
+            or any(h.abspath().endswith(".c") for h in self.common_helpers)
+            or any(n.abspath().endswith(".c") for n in self.system_sources)
+        )
+
+    def assemble_for_build(self, tests_root: Node) -> List[str]:
+        """convert nodes to relative paths for waf.
+
+        includes `common/test_main.cpp`, all test files, helper sources, and
+        system sources that are compileable. header-only mappings are not
+        returned because they are not compiled.
+
+        Args:
+            tests_root: root node of the tests tree.
+
+        Returns:
+            list of source file paths relative to tests root.
+        """
+        main_source = ["common/test_main.cpp"]
+        test_sources = sorted([f.path_from(tests_root) for f in self.test_files])
+        unit_helpers = [h.path_from(tests_root) for h in self.unit_helpers]
+        common_helpers = [h.path_from(tests_root) for h in self.common_helpers]
+        # only compilable sources are passed to waf; headers are tracked separately
+        system_sources = [n.path_from(tests_root) for n in self.system_sources]
+        return (
+            main_source + test_sources + unit_helpers + common_helpers + system_sources
+        )
+
+
+@dataclass
+class TestUnit:
+    """metadata for a single test binary target.
+
+    Args:
+        test_dir: directory path relative to tests root.
+        target: waf target name for this test binary.
+        sources: TestSources collected for this test unit.
+
+    """
+
+    test_dir: str
+    target: str
+    sources: TestSources
+
+    def system_source_count(self) -> int:
+        """count of system sources mapped for this test.
+
+        counts both compiled sources and header-only mappings.
+        """
+        return len(self.sources.system_sources) + len(self.sources.system_headers)
+
+    def test_source_count(
+        self,
+        tests_root: Node,
+    ) -> int:
+        """count of test sources (total minus compiled system sources).
+
+        only compiled system sources appear in the assembled list; headers do not.
+
+        Args:
+            tests_root: root node of the tests tree.
+
+        Returns:
+            count of test source files for this unit.
+        """
+        total = len(self.sources.assemble_for_build(tests_root))
+        compiled_system = len(self.sources.system_sources)
+        return total - compiled_system
+
+    def source_paths(
+        self,
+        tests_root: Node,
+    ) -> List[str]:
+        """get all source paths for waf build (relative to tests root).
+
+        Args:
+            tests_root: root node of the tests tree.
+
+        Returns:
+            list of source file paths for this test unit.
+        """
+        return self.sources.assemble_for_build(tests_root)
+
+
+def _abs(
+    path: str,
+    bld: BuildContext,
+) -> str:
+    """resolve a relative path to an absolute filesystem path using waf nodes.
+
+    Args:
+        path: relative path to resolve.
+        bld: waf build context - provides `path.make_node`.
+
+    Returns:
+        absolute path string corresponding to `path`.
+    """
+    node = bld.path.make_node(path)
+    return node.abspath()
+
+
+def _setup_includes_and_flags(bld: BuildContext) -> TestRunnerConfig:
+    """collect shared include paths and compiler flags for all tests.
+
+    Args:
+        bld: waf build context - contains env variables such as CFLAGS, DEFINES.
+
+    Returns:
+        TestRunnerConfig with includes, cflags, cxxflags, and defines.
+    """
+    # common include paths available to all tests
+    includes = [
+        _abs("../third-party/doctest", bld),
+        _abs("../third-party/trompeloeil/include", bld),
+        _abs("../tests/common", bld),
+        _abs("../matron/src", bld),
+        _abs("../crone/src", bld),
+        _abs("../ws-wrapper/src", bld),
+        _abs("../maiden-repl/src", bld),
+    ]
+
+    cflags = list(getattr(bld.env, "CFLAGS", []) or [])
+    cxxflags = list(getattr(bld.env, "CXXFLAGS", []) or [])
+    defines = list(getattr(bld.env, "DEFINES", []) or [])
+
+    # enable test seams
+    if "NORNS_TEST" not in defines:
+        defines.append("NORNS_TEST")
+    if "-Wno-psabi" not in cxxflags:
+        cxxflags.append("-Wno-psabi")
+
+    # allow extra preprocessor defines from environment for toggling fixes, etc.
+    # usage: NORNS_TEST_DEFINES="FOO=1,BAR" ./test.sh
+    extra_defines = os.environ.get("NORNS_TEST_DEFINES")
+    if extra_defines:
+        for d in [
+            s.strip() for s in extra_defines.replace(";", ",").split(",") if s.strip()
+        ]:
+            if d not in defines:
+                defines.append(d)
+
+    return TestRunnerConfig(
+        includes=includes, cflags=cflags, cxxflags=cxxflags, defines=defines
+    )
+
+
+def _discover_test_dirs(bld: BuildContext) -> Tuple[Node, Dict[str, Set[Node]]]:
+    """find all `test_*.cpp` files and group them by directory.
+
+    Args:
+        bld: waf build context - `bld.path` is the tests root node.
+
+    Returns:
+        tuple of (tests_root_node, mapping of test_dir path → set of file nodes).
+
+    Raises:
+        fatal error if no test files are discovered.
+    """
+    # find all test_*.cpp files and group by directory (one binary per directory)
+    tests_root = bld.path
+    all_test_files = tests_root.ant_glob("**/test_*.cpp", excl=["common/test_main.cpp"])
+
+    if not all_test_files:
+        Logs.error("no test_*.cpp files found in tests/ directory")
+        Logs.error("expected pattern: tests/<project>/test_*.cpp")
+        Logs.error("example: tests/crone/test_window.cpp")
+        bld.fatal("test discovery failed - no test files found")
+
+    test_dirs = {}
+    for test_file in all_test_files:
+        test_dir = test_file.parent.path_from(tests_root)
+        test_dirs.setdefault(test_dir, set()).add(test_file)
+    return tests_root, test_dirs
+
+
+def _collect_test_sources(
+    bld: BuildContext,
+    tests_root: Node,
+    test_dir: str,
+    test_source_files: Set[Node],
+) -> TestSources:
+    """collect all sources needed for a test unit: test files, helpers, and system sources.
+
+    Args:
+        bld: waf build context - used to locate project source roots.
+        tests_root: root node of the tests tree.
+        test_dir: directory path relative to tests root.
+        test_source_files: set of test file nodes in this directory.
+
+    Returns:
+        TestSources with all collected source nodes and includes.
+    """
+    # collect unit directory and local helper sources
+    unit_dir = tests_root.make_node(test_dir)
+    unit_helpers = []
+    unit_helpers += unit_dir.ant_glob("*.c")
+    unit_helpers += unit_dir.ant_glob("*.cpp", excl=["test_*.cpp"])
+
+    # collect common helpers and includes from directory hierarchy
+    common_helpers = []
+    common_includes = []
+
+    scan_node = unit_dir
+    seen_common = set()
+    while True:
+        common_dir = scan_node.make_node("common")
+        if common_dir.exists() and common_dir.isdir():
+            common_abs = common_dir.abspath()
+            if common_abs not in seen_common:
+                seen_common.add(common_abs)
+                common_includes.append(common_abs)
+                common_helpers += common_dir.ant_glob("*.c")
+                # exclude typical non-shared or duplicate-entry files
+                common_helpers += common_dir.ant_glob(
+                    "*.cpp", excl=["test_*.cpp", "test_main.cpp"]
+                )
+        if scan_node == tests_root:
+            break
+        if not getattr(scan_node, "parent", None):
+            break
+        scan_node = scan_node.parent
+
+    # mirror map system sources
+    system_sources, system_headers = _mirror_map_system_sources(
+        bld, test_dir, test_source_files
+    )
+
+    return TestSources(
+        test_files=test_source_files,
+        unit_helpers=unit_helpers,
+        common_helpers=common_helpers,
+        system_sources=system_sources,
+        system_headers=system_headers,
+        common_includes=common_includes,
+        unit_dir=unit_dir,
+    )
+
+
+def _dedupe_nodes_case_insensitive(nodes: Iterable[Node]) -> List[Node]:
+    """deduplicate waf nodes by absolute path, case-insensitively.
+
+    Args:
+        nodes: iterable of waf nodes representing filesystem entries.
+
+    Returns:
+        list of nodes with duplicates removed using case-insensitive path keys.
+    """
+    seen: Set[str] = set()
+    dedup: List[Any] = []
+    for node in nodes:
+        normalized_path = os.path.normpath(node.abspath()).lower()
+        if normalized_path not in seen:
+            seen.add(normalized_path)
+            dedup.append(node)
+    return dedup
+
+
+def _mirror_map_system_sources(
+    bld: BuildContext,
+    test_dir: str,
+    test_source_files: Set[Node],
+) -> Tuple[List[Node], List[Node]]:
+    """resolve a test directory to candidate system sources via naming conventions.
+
+    implements a mirror mapping strategy to locate system source files
+    corresponding to a given test directory.
+
+    for nested test dirs, try `<proj>/src/<unit>.{c,cpp}` and then
+    `<proj>/src/<unit>/*.{c,cpp}`. for project-root tests, derive a unit name
+    from filenames and try multiple case/style variants, including header-only
+    units (`.h`, `.hpp`).
+
+    Args:
+        bld: waf build context - used to locate project source roots.
+        test_dir: directory path relative to the tests root.
+        test_source_files: set of test file nodes in this directory.
+
+    Returns:
+        tuple of (compilable system sources, header-only system nodes), both
+        deduplicated by case-insensitive absolute path.
+    """
+    # map test directory to system sources (by path) via mirror mapping
+    parts = test_dir.split("/")
+    if len(parts) < 1:
+        proj = None
+        unit_path = None
+    elif len(parts) == 1:
+        # project root: tests/<proj>/ - derive units from test filenames
+        proj = parts[0]
+        unit_path = None
+    else:
+        # nested: tests/<proj>/<unit>/...
+        proj = parts[0]
+        unit_path = "/".join(parts[1:])
+
+    system_source_nodes: List[Any] = []
+    system_header_nodes: List[Any] = []
+
+    if proj and unit_path:
+        # nested path mapping: tests/<proj>/<unit>/ → <proj>/src/<unit>.*
+        src_root = bld.path.make_node("../%s/src" % proj)
+        mapped_file_c = src_root.make_node(unit_path + ".c")
+        mapped_file_cpp = src_root.make_node(unit_path + ".cpp")
+        mapped_file_h = src_root.make_node(unit_path + ".h")
+        mapped_file_hpp = src_root.make_node(unit_path + ".hpp")
+        mapped_dir = src_root.make_node(unit_path)
+
+        # try exact file match first (unit_path.c or unit_path.cpp)
+        has_exact_impl = False
+        if mapped_file_c.exists():
+            system_source_nodes.append(mapped_file_c)
+            has_exact_impl = True
+        if mapped_file_cpp.exists():
+            system_source_nodes.append(mapped_file_cpp)
+            has_exact_impl = True
+
+        # recognize header-only units (unit_path.h/.hpp) — track but do not compile
+        if mapped_file_h.exists():
+            system_header_nodes.append(mapped_file_h)
+        if mapped_file_hpp.exists():
+            system_header_nodes.append(mapped_file_hpp)
+
+        # if no exact file, try directory (all .c/.cpp in unit_path/, non-recursive)
+        if not has_exact_impl and mapped_dir.exists() and mapped_dir.isdir():
+            system_source_nodes += mapped_dir.ant_glob("*.c")
+            system_source_nodes += mapped_dir.ant_glob("*.cpp")
+
+        # if still nothing mapped, try case/style variants of the last path segment
+        # this helps units like tests/crone/peak_meter → crone/src/PeakMeter.h
+        if not system_source_nodes and not system_header_nodes:
+            unit_name = unit_path.split("/")[-1]
+            underscored = unit_name
+            no_underscore = unit_name.replace("_", "")
+            camel_from_underscores = "".join(
+                p.capitalize() for p in unit_name.split("_")
+            )
+            variants = [
+                underscored,
+                underscored.capitalize(),
+                underscored.title(),
+                no_underscore,
+                camel_from_underscores,
+            ]
+            for variant in variants:
+                for ext in [".c", ".cpp", ".h", ".hpp"]:
+                    cand = src_root.make_node(variant + ext)
+                    if cand.exists():
+                        if ext in (".h", ".hpp"):
+                            system_header_nodes.append(cand)
+                        else:
+                            system_source_nodes.append(cand)
+
+    elif proj:
+        # project root mapping: derive unit from test filename, try case variants
+        src_root = bld.path.make_node("../%s/src" % proj)
+        for test_file in test_source_files:
+            filename = test_file.name
+            if filename.startswith("test_") and filename.endswith(".cpp"):
+                # extract unit name: test_window.cpp → window
+                unit_name = filename[5:-4]
+                # generate filename variants
+                underscored = unit_name
+                no_underscore = unit_name.replace("_", "")
+                camel_from_underscores = "".join(
+                    p.capitalize() for p in unit_name.split("_")
+                )
+                variants = [
+                    underscored,
+                    underscored.capitalize(),
+                    underscored.title(),
+                    no_underscore,
+                    camel_from_underscores,
+                ]
+                # try both .c and .cpp for each variant
+                for variant in variants:
+                    mapped_file_c = src_root.make_node(variant + ".c")
+                    mapped_file_cpp = src_root.make_node(variant + ".cpp")
+                    if mapped_file_c.exists():
+                        system_source_nodes.append(mapped_file_c)
+                    if mapped_file_cpp.exists():
+                        system_source_nodes.append(mapped_file_cpp)
+
+    return (
+        _dedupe_nodes_case_insensitive(system_source_nodes),
+        _dedupe_nodes_case_insensitive(system_header_nodes),
+    )
+
+
+def _target_name_for(test_dir: str) -> str:
+    """generate a stable waf target name for a test directory.
+
+    converts directory paths to target names by prefixing with 'test_' and
+    replacing slashes with underscores.
+
+    examples: crone → test_crone, matron/args → test_matron_args
+
+    Args:
+        test_dir: directory path relative to tests root.
+
+    Returns:
+        target string in the form 'test_<dir-with-slashes-replaced-by-underscores>'.
+    """
+    return "test_" + test_dir.replace("/", "_")
+
+
+def _report_test_discovery(
+    test_units: List[TestUnit],
+    tests_root: Node,
+    dry_run: bool = False,
+):
+    """report discovered test units with their configuration and status.
+
+    this function logs a summary of test discovery results, displaying
+    information about each test unit including the number of tests, associated
+    system sources, and header mappings.
+
+    Args:
+        test_units: list of discovered test units.
+        tests_root: root node of the tests tree.
+        dry_run: if True, print detailed source list for each test.
+    """
+    if not test_units:
+        return
+
+    Logs.info("---")
+    Logs.info(f"found {len(test_units)} test unit(s):")
+
+    for unit in test_units:
+        compiled_system = len(unit.sources.system_sources)
+        header_only = len(unit.sources.system_headers)
+        test_count = unit.test_source_count(tests_root)
+
+        parts = [f"{test_count} test"]
+        if compiled_system > 0:
+            parts.append(f"{compiled_system} system source(s)")
+        if header_only > 0:
+            parts.append(f"{header_only} header mapping(s)")
+        if compiled_system == 0 and header_only == 0:
+            status = f"{test_count} test source(s) [no system code mapped]"
+        else:
+            status = " + ".join(parts)
+
+        Logs.info(f"  \033[36m{unit.target}\033[0m: {status}")
+
+        if dry_run:
+            for src in unit.source_paths(tests_root):
+                Logs.info(f"    - {src}")
+
+
+def _self_test(bld: BuildContext):
+    """
+    validate test runner logic before discovering actual tests.
+
+    tests core functionality of discovery, mapping, and assembly functions.
+    fails fast if any assumptions are violated.
+
+    Args:
+        bld: waf build context - for accessing test directory structure.
+    """
+    Logs.info("\033[3mvalidating test runner - running self-tests:\033[0m")
+    Logs.info("---")
+
+    # test 1: target naming conventions
+    try:
+        assert _target_name_for("crone") == "test_crone"
+        assert _target_name_for("matron/clock") == "test_matron_clock"
+        assert (
+            _target_name_for("matron/clocks/clock_crow")
+            == "test_matron_clocks_clock_crow"
+        )
+        Logs.info("  ✓ can name test binaries")
+    except AssertionError as e:
+        Logs.error("test runner self-test failed: target naming")
+        Logs.error("the test runner cannot validate its own functionality")
+        Logs.error("this suggests an issue with test discovery or core logic")
+        bld.fatal("self-test failed - check test runner implementation")
+
+    # test 2: verify test infrastructure files exist
+    tests_root = bld.path
+    test_main = tests_root.find_node("common/test_main.cpp")
+    if test_main is None:
+        Logs.error("test runner self-test failed: test infrastructure missing")
+        Logs.error("common/test_main.cpp not found")
+        bld.fatal("self-test failed - check tests/ directory structure")
+    Logs.info("  ✓ common test files present")
+
+    # test 3: verify absolute path resolution
+    abs_path = _abs("common/test_main.cpp", bld)
+    if not os.path.isabs(abs_path) or not abs_path.endswith("common/test_main.cpp"):
+        Logs.error("test runner self-test failed: path resolution")
+        bld.fatal("self-test failed - path resolution logic broken")
+    Logs.info("  ✓ file paths resolve correctly")
+
+    # test 4: verify test discovery pattern matching
+    test_files = tests_root.ant_glob("**/test_*.cpp", excl=["common/test_main.cpp"])
+    if len(test_files) == 0:
+        Logs.error("test runner self-test failed: test discovery pattern")
+        Logs.error("no test_*.cpp files found")
+        bld.fatal("self-test failed - add test files to tests/ subdirectories")
+    Logs.info(f"  ✓ found test files ({len(test_files)} total)")
+
+    # test 5: verify source collection and dataclass structure
+    if tests_root.find_node("crone"):
+        test_file_set = {tests_root.find_node("crone/test_window.cpp")}
+        if test_file_set and None not in test_file_set:
+            try:
+                sources = _collect_test_sources(bld, tests_root, "crone", test_file_set)
+                if not isinstance(sources, TestSources):
+                    Logs.error("test runner self-test failed: source collection")
+                    bld.fatal("self-test failed - _collect_test_sources broken")
+                if sources.unit_dir is None:
+                    Logs.error("test runner self-test failed: unit_dir not set")
+                    bld.fatal("self-test failed - TestSources.unit_dir broken")
+                Logs.info("  ✓ test sources collect")
+            except Exception as e:
+                Logs.error(f"test runner self-test failed: {e}")
+                bld.fatal("self-test failed - check source collection logic")
+
+    # test 6: verify TestSources methods
+    try:
+        # create a minimal TestSources for validation
+        test_sources = TestSources(
+            test_files=set(),
+            unit_helpers=[],
+            common_helpers=[],
+            system_sources=[],
+            system_headers=[],
+            common_includes=[],
+            unit_dir=tests_root,
+        )
+        if test_sources.has_c_sources() is not False:
+            Logs.error("test runner self-test failed: has_c_sources with no sources")
+            bld.fatal("self-test failed - TestSources.has_c_sources broken")
+        source_list = test_sources.assemble_for_build(tests_root)
+        if not isinstance(source_list, list):
+            Logs.error("test runner self-test failed: assemble_for_build return type")
+            bld.fatal("self-test failed - TestSources.assemble_for_build broken")
+        Logs.info("  ✓ source methods work")
+    except Exception as e:
+        Logs.error(f"test runner self-test failed: {e}")
+        bld.fatal("self-test failed - check TestSources methods")
+
+    Logs.info("\033[32mtest runner self-tests passed\033[0m")
+
+
+def _validate_test_discovery(bld: BuildContext):
+    """
+    pre-build validation: verify test discovery found valid tests and sources.
+
+    checks that test discovery succeeded and warns about missing system sources.
+    fails fast if no tests were discovered or critical configuration issues exist.
+
+    Args:
+        bld: waf build context - for accessing discovered test units.
+    """
+    test_units = getattr(bld, "norns_test_units", [])
+    tests_root = getattr(bld, "norns_tests_root", None)
+
+    # check that we discovered at least one test
+    if not test_units:
+        Logs.error("no tests discovered after build configuration")
+        Logs.error("verify tests/ directory contains test_*.cpp files")
+        bld.fatal("test validation failed - no test units")
+
+    # validate each test unit - collect warnings to show after report
+    tests_without_system = []
+    for unit in test_units:
+        source_paths = unit.source_paths(tests_root)
+
+        # check for empty source list (should never happen if test files exist)
+        if not source_paths:
+            Logs.error(f"{unit.target}: source assembly failed")
+            Logs.error(f"test directory: tests/{unit.test_dir}")
+            bld.fatal(f"{unit.target}: no sources found")
+
+        # track tests without system sources
+        if unit.system_source_count() == 0:
+            tests_without_system.append(unit)
+
+    # report discovery results
+    dry_run = getattr(bld.options, "test_dry_run", False)
+    _report_test_discovery(test_units, tests_root, dry_run=dry_run)
+
+    if tests_without_system:
+        Logs.info("")
+        Logs.warn(f"{len(tests_without_system)} test(s) without system code…")
+        Logs.warn("these tests will run without system code under test:")
+        for unit in tests_without_system:
+            Logs.warn(f"  {unit.target} (tests/{unit.test_dir})")
+
+    # exit after reporting if dry-run
+    if dry_run:
+        Logs.info("")
+        Logs.info("dry-run complete - no tests built or executed")
+        sys.exit(0)
+
+
+def test(bld: BuildContext):
+    """waf entry: discover tests and build one binary per test directory.
+
+    uses waf_unit_test feature to execute tests with parallel support.
+    validates test discovery before building via pre-build hook.
+
+    Args:
+        bld: waf build context - used to configure and create targets.
+    """
+    # self-test: validate test runner logic before proceeding
+    if not getattr(bld.options, "skip_self_test", False):
+        _self_test(bld)
+        Logs.info("")
+
+    # setup: includes and compiler flags
+    build_config = _setup_includes_and_flags(bld)
+
+    # discover: group test files by directory
+    tests_root, test_dirs = _discover_test_dirs(bld)
+
+    # common libs many tests require
+    link_libs = ["pthread"]
+
+    # collect test units
+    test_units: List[TestUnit] = []
+    for test_dir, test_source_files in sorted(test_dirs.items()):
+        test_sources = _collect_test_sources(
+            bld, tests_root, test_dir, test_source_files
+        )
+        target_name = _target_name_for(test_dir)
+        test_unit = TestUnit(
+            test_dir=test_dir, target=target_name, sources=test_sources
+        )
+        test_units.append(test_unit)
+
+        # determine features based on source types
+        features = "cxx cxxprogram test"
+        if test_sources.has_c_sources():
+            features = "c cxx cxxprogram test"
+
+        includes = (
+            build_config.includes
+            + [test_sources.unit_dir.abspath()]
+            + test_sources.common_includes
+        )
+
+        source = test_sources.assemble_for_build(tests_root)
+
+        # build test binary with waf_unit_test feature
+        bld.program(
+            target=target_name,
+            features=features,
+            source=source,
+            includes=includes,
+            cflags=build_config.cflags,
+            cxxflags=build_config.cxxflags,
+            defines=build_config.defines,
+            lib=link_libs,
+        )
+
+    # store test units for validation hook
+    bld.norns_test_units = test_units
+    bld.norns_tests_root = tests_root
+
+    # register pre-build validation hook to verify test discovery
+    bld.add_pre_fun(_validate_test_discovery)


### PR DESCRIPTION
_what_

adds c/c++ testing infrastructure with [doctest](https://github.com/doctest/doctest) and [trompeloeil](https://github.com/rollbear/trompeloeil) frameworks, automatic test discovery in `tests/wscript`, c/c++ test workflow to github actions, documentation and contribution notes, and the beginnings of test coverage across matron and crone components.

the unit tests included in this pr showcase multiple approaches of test coverage (mocks, stubs, test seams, etc.) and exercising code to ensure the expected behavior. these initial tests establish testing patterns and providing a nice reference along with the documentation.

also included in this pr are various important fixes for clock time tracking (see details below), as well as minor threading, and args parsing issues discovered during test development.

fixes #1863

_how_

see included `tests/README.md` for detailed documentation on how the testing infrastructure works.

**testing infrastructure**
- add doctest (assertions/runner) and trompeloeil (c++ mocking) as submodules
- implement automatic test discovery in `tests/wscript` that mirrors test paths to source tree
- add `test.sh` wrapper script to build and run tests
- integrate c/c++ tests into github actions workflow
- add tests path to `clang_format.sh`

**included coverage**
- crone: window lookup table, peakmeter rise/decay, vu meter taper, jack client time tracking, utilities
- matron: args parsing, clock implementations (internal/midi/crow/link/scheduler)
- often using `NORNS_TEST` preprocessor seams for exposing private interfaces during tests without changes to the core code

**documentation**
- add `tests/README.md` with detailed examples and patterns
- update `CONTRIBUTING.md` with testing guidelines

_improvements discovered during initial test coverage implementation_

_**clock internal**_

**issue**
clock loop enters catchup spiral when experiencing lag (potentially scheduler delays, JACK stalls, system suspend, NTP adjustments), causing timing jitter for minor lag, burst publishing for moderate lag, or complete CPU lockup for severe lag. when time jumps forward, `next_tick_time - current_time` becomes large and negative, producing invalid timespec values, stalled thread sleeps, and frozen tempo updates.

mentioned here #1865.

**fix**
clamp negative sleep values to zero before timespec conversion. rebase `next_tick_time` forward when schedule falls more than one tick behind.

**test**
stub `clock_nanosleep` for virtual time control, jump forward by hours, verify valid sleep calculations and continued tempo publishing.

_**jack_client**_

**issue**
JACK's 32-bit frame counter wraps after ~25 hours (48kHz), causing time to jump backward 25 hours and breaking all tempo/scheduling. out-of-order reads between calls can also cause time to decrease slightly.

a simple repro for this is to load up the `firstlight` script, let it run for ~25 hours, and watch the animation hang.

related to clock internal above and also mentioned here #1865.

**fix**
maintain 64-bit monotonic frame counter tracking high/low 32 bits separately. detect wraps when low bits cross from high to low range and increment high bits. enforce monotonicity with mutex-protected read-modify-write operations.

**test**
stub JACK frame values, simulate wraparound (`0xFFFFFFF0` → `0x00000020`), verify monotonic time across boundary and consistent multi-threaded reads.

_**additional improvements**_
- `args`: switch to `snprintf` for safe truncation, wire up `-f` framebuffer flag which wasn't connected previously
- `event_types.h`: decouple heavy includes, add opaque `lo_message` type

---

_notes_
- mocking requires c++14 standard (updated in main `wscript`), this is a safe change.
- tested changes on device, functional on aluminum norns cm3 and pi3 shield.
- this is a pretty big pr! consider this as foundational work. more components can be tested using this infrastructure. i think the pr makes sense together, but if it's preferred as smaller changes we can always break it up a bit. i also keep combing through the details of the changes to ensure that it's sound... at this point i would like to get this large pr into review so that the work can be built on top of as a follow up.