### PR TITLE
connect the audio.vu callback

### DIFF
--- a/lua/core/menu/mix.lua
+++ b/lua/core/menu/mix.lua
@@ -123,6 +123,7 @@ m.redraw = function()
 end
 
 m.init = function()
+  m.saved_vu = _norns.vu
   _norns.vu = m.vu
   m.in1 = 0
   m.in2 = 0
@@ -138,10 +139,11 @@ m.deinit = function()
   norns.encoders.set_accel(2,false)
   norns.encoders.set_sens(2,2)
   norns.encoders.set_sens(3,2)
-  _norns.vu = norns.none
+  _norns.vu = m.saved_vu
 end
 
 m.vu = function(in1,in2,out1,out2)
+  m.saved_vu(in1,in2,out1,out2)
   m.in1 = in1
   m.in2 = in2
   m.out1 = out1

--- a/lua/core/norns.lua
+++ b/lua/core/norns.lua
@@ -83,7 +83,9 @@ _norns.poll = function(id, value)
 end
 
 -- i/o level callback.
-_norns.vu = function(in1, in2, out1, out2) end
+_norns.vu = function(in1, in2, out1, out2)
+  audio.vu(in1, in2, out1, out2)
+end
 -- softcut phase
 _norns.softcut_phase = function(id, value) end
 


### PR DESCRIPTION
This fixes #1864.

audio.vu is supposed to be a user-definable callback, but it was never actually called. The system vu callback is _norns.vu. The only wrinkle is that mix.lua redefines _norns.vu when in the mix menu, to display the VU meter. The approach I took was to have _norns.vu call audio.vu, and mix.lua saves the existing _norns.vu callback, calls it in addition to doing its own VU handling, and then restores it on deinitialization.

I couldn't find a good example of something similar in the lua core (callback is both user-definable and used by menu system, but the user callback should still work while in the menu), so I'm not sure if y'all like this approach. Let me know if you want a different approach.