### PR TITLE
fix: guard ARM-specific code behind NORNS_DESKTOP for x86 desktop builds

### DIFF
--- a/matron/src/hardware/input/inputs.h
+++ b/matron/src/hardware/input/inputs.h
@@ -2,6 +2,9 @@
 
 #include "hardware/io.h"
 
+#ifndef NORNS_DESKTOP
 extern input_ops_t key_gpio_ops;
 extern input_ops_t enc_gpio_ops;
+#else
 extern input_ops_t input_sdl_ops;
+#endif

--- a/matron/src/hardware/io.c
+++ b/matron/src/hardware/io.c
@@ -8,12 +8,12 @@
 #include "hardware/screen/screens.h"
 
 io_ops_t *io_types[] = {
-    (io_ops_t *)&enc_gpio_ops,
-    (io_ops_t *)&key_gpio_ops,
-
 #ifdef NORNS_DESKTOP
     (io_ops_t *)&screen_sdl_ops,
     (io_ops_t *)&input_sdl_ops,
+#else
+    (io_ops_t *)&enc_gpio_ops,
+    (io_ops_t *)&key_gpio_ops,
 #endif
     (io_ops_t *)NULL,
 };

--- a/matron/src/hardware/screen.c
+++ b/matron/src/hardware/screen.c
@@ -21,7 +21,9 @@
 #include "events.h"
 #include "hardware/io.h"
 #include "hardware/screen.h"
+#ifndef NORNS_DESKTOP
 #include "hardware/screen/ssd1322.h"
+#endif
 #include "screen.h"
 #include "screen_results.h"
 
@@ -297,11 +299,10 @@ void screen_update(void) {
         screen_ops_t *fb_ops = (screen_ops_t *)io->ops;
         fb_ops->paint(fb);
     }
-    return;
-#endif
-
+#else
     cairo_surface_flush(surface);
     ssd1322_update(surface, surface_may_have_color);
+#endif
 }
 
 void screen_save(void) {
@@ -348,7 +349,9 @@ void screen_brightness(int v) {
     // is limited and offset.
     v += 16;
 
+#ifndef NORNS_DESKTOP
     ssd1322_set_brightness((uint8_t)v);
+#endif
 }
 
 void screen_contrast(int c) {
@@ -358,7 +361,9 @@ void screen_contrast(int c) {
     if (c > 255) {
         c = 255;
     }
+#ifndef NORNS_DESKTOP
     ssd1322_set_contrast((uint8_t)c);
+#endif
 }
 
 void screen_gamma(double g) {
@@ -366,11 +371,17 @@ void screen_gamma(double g) {
         g = 0;
     }
 
+#ifndef NORNS_DESKTOP
     ssd1322_set_gamma(g);
+#endif
 }
 
 void screen_invert(int inverted) {
+#ifndef NORNS_DESKTOP
     ssd1322_set_display_mode((inverted != 0) ? SSD1322_DISPLAY_MODE_INVERT : SSD1322_DISPLAY_MODE_NORMAL);
+#else
+    (void)inverted;
+#endif
 }
 
 void screen_level(int z) {

--- a/matron/src/main.c
+++ b/matron/src/main.c
@@ -21,7 +21,9 @@
 #include "device_monitor.h"
 #include "device_monome.h"
 #include "events.h"
+#ifndef NORNS_DESKTOP
 #include "hardware/screen/ssd1322.h"
+#endif
 #include "hello.h"
 #include "i2c.h"
 #include "input.h"
@@ -50,7 +52,9 @@ void cleanup(void) {
     battery_deinit();
     stat_deinit();
     jack_client_deinit();
+#ifndef NORNS_DESKTOP
     ssd1322_deinit();
+#endif
     screen_results_deinit();
     fprintf(stderr, "matron shutdown complete\n");
     exit(0);
@@ -74,14 +78,18 @@ int main(int argc, char **argv) {
     battery_init();
     stat_init();
     osc_init();
+#ifndef NORNS_DESKTOP
     ssd1322_init();
+#endif
     if (jack_client_init()) {
         screen_clear();
         screen_level(15);
         screen_move(10, 40);
         screen_text("audio system fail.");
         screen_update();
+#ifndef NORNS_DESKTOP
         ssd1322_refresh();
+#endif
         return -1;
     }
     clock_init();

--- a/matron/wscript
+++ b/matron/wscript
@@ -19,8 +19,6 @@ def build(bld):
         'src/hardware/platform.c',
         'src/hardware/screen.c',
         'src/hardware/stat.c',
-        'src/hardware/screen/ssd1322.c',
-        'src/hardware/input/gpio.c',
         'src/args.c',
         'src/events.c',
         'src/hello.c',
@@ -47,6 +45,11 @@ def build(bld):
         matron_sources += [
             'src/hardware/screen/sdl.c',
             'src/hardware/input/sdl.c',
+        ]
+    else:
+        matron_sources += [
+            'src/hardware/screen/ssd1322.c',
+            'src/hardware/input/gpio.c',
         ]
 
     matron_includes = [
@@ -86,7 +89,10 @@ def build(bld):
         matron_libs += ['stdc++']
         matron_use += ['LIBLINK_C']
 
-    matron_cflags=['-O3', '-Wall', '-std=c11', '-mfpu=neon']
+    matron_cflags=['-O3', '-Wall', '-std=c11']
+
+    if not bld.env.NORNS_DESKTOP:
+        matron_cflags += ['-mfpu=neon']
 
     if bld.env.NORNS_RELEASE:
         matron_cflags += [

--- a/readme-setup.md
+++ b/readme-setup.md
@@ -56,6 +56,8 @@ git submodule update --init --recursive
 ./waf
 ```
 
+(NB: `waf` assumes `build` as the default command, which is why we can omit it above.
+
 this should build several executables under `norns/build/<name>/`:
 
 - `matron`: the main norns system application: runs scripts, interfaces with controllers and screens
@@ -80,12 +82,9 @@ popd
 for building on desktop, add the `--desktop` option to both `waf` steps (configure and build):
 
 ```
-./waf configure --desktop
+CC=gcc CXX=g++ ./waf configure --desktop
 ./waf build --desktop
 ```
-
-(NB: `waf` assumes `build` as the default command, which is why we can omit it above.)
-
 
 ## launching components
 


### PR DESCRIPTION
The --desktop build mode was incomplete: ssd1322.c (NEON intrinsics), gpio.c, and -mfpu=neon were always compiled, breaking x86_64 builds. Properly exclude ARM hardware drivers and flags when building for desktop.