### PR TITLE
Removing duplicate snd_rawmidi_open call

### DIFF
--- a/matron/src/device/device_midi.c
+++ b/matron/src/device/device_midi.c
@@ -118,10 +118,6 @@ int dev_midi_virtual_init(void *self) {
         fprintf(stderr, "failed to open alsa virtual device.\n");
         return -1;
     }
-    if (snd_rawmidi_open(&midi->handle_in, &midi->handle_out, "virtual", 0) < 0) {
-        fprintf(stderr, "failed to open alsa virtual device.\n");
-        return -1;
-    }
 
     // trigger reading
     snd_rawmidi_read(midi->handle_in, NULL, 0);


### PR DESCRIPTION
There are two calls to snd_rawmidi_open in a row with the same parameters. I might be missing something, but this is not recommended and leads to some memory leakage. 