### PR TITLE
Fix `Grid.rotation` bug seen in #1888

### DIFF
--- a/lua/core/grid.lua
+++ b/lua/core/grid.lua
@@ -92,11 +92,7 @@ function Grid:rotation(val)
   local cols = _norns.grid_cols(self.dev)
   self.rows = rows
   self.cols = cols
-
-  if self.port then
-    Grid.vports[self.port].rows = rows
-    Grid.vports[self.port].cols = cols
-  end
+  Grid.update_devices()
 end
 
 --- enable/disable grid tilt.

--- a/lua/core/grid.lua
+++ b/lua/core/grid.lua
@@ -88,8 +88,16 @@ function Grid.remove(dev) end
 -- @tparam integer val : rotation 0,90,180,270 as [0, 3]
 function Grid:rotation(val)
   _norns.grid_set_rotation(self.dev, val)
-end
+  local rows = _norns.grid_rows(self.dev)
+  local cols = _norns.grid_cols(self.dev)
+  self.rows = rows
+  self.cols = cols
 
+  if self.port then
+    Grid.vports[self.port].rows = rows
+    Grid.vports[self.port].cols = cols
+  end
+end
 
 --- enable/disable grid tilt.
 -- @tparam integer id : sensor

--- a/lua/core/grid.lua
+++ b/lua/core/grid.lua
@@ -88,10 +88,8 @@ function Grid.remove(dev) end
 -- @tparam integer val : rotation 0,90,180,270 as [0, 3]
 function Grid:rotation(val)
   _norns.grid_set_rotation(self.dev, val)
-  local rows = _norns.grid_rows(self.dev)
-  local cols = _norns.grid_cols(self.dev)
-  self.rows = rows
-  self.cols = cols
+  self.rows = _norns.grid_rows(self.dev)
+  self.cols = _norns.grid_cols(self.dev)
   Grid.update_devices()
 end
 

--- a/matron/src/device/device_monome.c
+++ b/matron/src/device/device_monome.c
@@ -95,9 +95,9 @@ int dev_monome_init(void *self) {
 
 // calculate quadrant number given x/y
 static inline uint8_t dev_monome_quad_idx(struct dev_monome *md, uint8_t x, uint8_t y) {
-   // are we a 16x8 grid AND rotated 90 or 270 degrees?
+    // are we a 16x8 grid AND rotated 90 or 270 degrees?
     if (md->quads == 2 && md->quad_yoff[1] == 8)
-      return ((x > 7) << 1) | (y > 7);
+        return ((x > 7) << 1) | (y > 7);
     return ((y > 7) << 1) | (x > 7);
 }
 // calcalate offset into quad data given x/y

--- a/matron/src/device/device_monome.c
+++ b/matron/src/device/device_monome.c
@@ -98,7 +98,6 @@ static inline uint8_t dev_monome_quad_idx(struct dev_monome *md, uint8_t x, uint
    // are we a 16x8 grid AND rotated 90 or 270 degrees?
     if (md->quads == 2 && md->quad_yoff[1] == 8)
       return ((x > 7) << 1) | (y > 7);
-        return ((x > 7) << 1) | (y > 7);
     return ((y > 7) << 1) | (x > 7);
 }
 // calcalate offset into quad data given x/y

--- a/matron/src/device/device_monome.c
+++ b/matron/src/device/device_monome.c
@@ -95,6 +95,9 @@ int dev_monome_init(void *self) {
 
 // calculate quadrant number given x/y
 static inline uint8_t dev_monome_quad_idx(uint8_t x, uint8_t y) {
+    monome_rotate_t = monome_get_rotation(md->m);
+    if (r == MONOME_ROTATE_90 || r == MONOME_ROTATE_270)
+        return ((x > 7) << 1) | (y > 7);
     return ((y > 7) << 1) | (x > 7);
 }
 // calcalate offset into quad data given x/y

--- a/matron/src/device/device_monome.c
+++ b/matron/src/device/device_monome.c
@@ -94,7 +94,7 @@ int dev_monome_init(void *self) {
 }
 
 // calculate quadrant number given x/y
-static inline uint8_t dev_monome_quad_idx(uint8_t x, uint8_t y) {
+static inline uint8_t dev_monome_quad_idx(struct dev_monome *md, uint8_t x, uint8_t y) {
     monome_rotate_t r = monome_get_rotation(md->m);
     if (r == MONOME_ROTATE_90 || r == MONOME_ROTATE_270)
         return ((x > 7) << 1) | (y > 7);
@@ -130,7 +130,7 @@ void dev_monome_tilt_disable(struct dev_monome *md, uint8_t sensor) {
 
 // set a given LED value
 void dev_monome_grid_set_led(struct dev_monome *md, uint8_t x, uint8_t y, int8_t val, bool rel) {
-    uint8_t q = dev_monome_quad_idx(x, y);
+    uint8_t q = dev_monome_quad_idx(md, x, y);
     if (rel) {
         md->data[q][dev_monome_quad_offset(x, y)] =
             clamp_range(md->data[q][dev_monome_quad_offset(x, y)] + val, 0, 15);

--- a/matron/src/device/device_monome.c
+++ b/matron/src/device/device_monome.c
@@ -95,8 +95,9 @@ int dev_monome_init(void *self) {
 
 // calculate quadrant number given x/y
 static inline uint8_t dev_monome_quad_idx(struct dev_monome *md, uint8_t x, uint8_t y) {
-    monome_rotate_t r = monome_get_rotation(md->m);
-    if (r == MONOME_ROTATE_90 || r == MONOME_ROTATE_270)
+   // are we a 16x8 grid AND rotated 90 or 270 degrees?
+    if (md->quads == 2 && md->quad_yoff[1] == 8)
+      return ((x > 7) << 1) | (y > 7);
         return ((x > 7) << 1) | (y > 7);
     return ((y > 7) << 1) | (x > 7);
 }

--- a/matron/src/device/device_monome.c
+++ b/matron/src/device/device_monome.c
@@ -95,7 +95,7 @@ int dev_monome_init(void *self) {
 
 // calculate quadrant number given x/y
 static inline uint8_t dev_monome_quad_idx(uint8_t x, uint8_t y) {
-    monome_rotate_t = monome_get_rotation(md->m);
+    monome_rotate_t r = monome_get_rotation(md->m);
     if (r == MONOME_ROTATE_90 || r == MONOME_ROTATE_270)
         return ((x > 7) << 1) | (y > 7);
     return ((y > 7) << 1) | (x > 7);


### PR DESCRIPTION
I believe this will fix the issue #1888.

There are two bugs that I found.

First, is that the `dev_monome_quad_idx` wasn't returning the correct quadrant index. This resulted in led's not turning on when set past row 8. I had to update this function signature to accept a reference to the monome device so we could get the current rotation value for the device. This felt like the cleanest solution.

Second, the rows and cols properties weren't being reset after a rotation. I probably took the easy way out here and did this in grid.lua. It's possible it could be done in `dev_monom_set_rotation`, but I couldn't figure it out.

I compiled and ran this all on my norns and it fixes the issue I was having with my modified version of the metrix script (using rotation vs manually rotating by overriding `Grid.led`).

I would love feedback if this isn't the correct solution. If there is time in just giving me a nudge in the correct direction, I would definitely prefer that as I'd like the chance to update the PR and try to fix what I've done. If there's no time, I get it!