### PR TITLE
fix: add default encoder sensitivity and acceleration

### DIFF
--- a/lua/core/encoders.lua
+++ b/lua/core/encoders.lua
@@ -11,14 +11,22 @@ local util = require 'util'
 
 local now = util.time()
 
+local function default_accel_and_sens()
+  local default_sens = {2,2,2}
+  local default_accel = {true,true,true}
+
+  return default_accel, default_sens
+end
+
+
 encoders.tick = {0,0,0}
-encoders.accel = {true,true,true}
-encoders.sens = {1,1,1}
+encoders.accel, encoders.sens = default_accel_and_sens()
 encoders.time = {now,now,now}
 encoders.callback = norns.none
 
 --- set acceleration
 encoders.set_accel = function(n,z)
+  print("Modifying encs in [norns.encoders.set_accel]: n="..n..", z="..tostring(z))
   if n == 0 then
     for k=1,3 do
       encoders.accel[k] = z
@@ -32,6 +40,7 @@ end
 
 --- set sensitivity
 encoders.set_sens = function(n,s)
+  print("Modifying encs in [norns.encoders.set_sens]: n="..n..", s="..s)
   if n == 0 then
     for k=1,3 do
       encoders.sens[k] = util.clamp(s,1,16)
@@ -82,14 +91,19 @@ encoders.process_with_accel = function(n,d)
 end
 
 
+encoders.print_state = function()
+  for k=1,3 do
+    print("encoders | sens="..encoders.sens[k]..", accel="..tostring(encoders.accel[k]))
+  end
+end
+
 
 -- script state
-
-local accel = {true,true,true}
-local sens = {2,2,2}
+local accel, sens = default_accel_and_sens()
 
 norns.enc = {}
 norns.enc.accel = function(n,z)
+  print("Modifying encs in [norns.enc.accel]: n="..n..", z="..tostring(z))
   if n == 0 then
     for k=1,3 do
       accel[k] = z
@@ -101,6 +115,7 @@ norns.enc.accel = function(n,z)
 end
 
 norns.enc.sens = function(n,s)
+  print("Modifying encs in [norns.enc.sens]: n="..n..", s="..s)
   if n == 0 then
     for k=1,3 do
       sens[k] = util.clamp(s,1,16)
@@ -112,10 +127,22 @@ norns.enc.sens = function(n,s)
 end
 
 norns.enc.resume = function()
+  print("Resuming...")
   for n=1,3 do
     norns.encoders.set_accel(n,accel[n])
     norns.encoders.set_sens(n,sens[n])
   end
+end
+
+norns.enc.print_state = function()
+  for k=1,3 do
+    print("enc | sens="..sens[k]..", accel="..tostring(accel[k]))
+  end
+end
+
+norns.enc.reset = function()
+  print("Resetting script accel and sens")
+  accel, sens = default_accel_and_sens()
 end
 
 

--- a/lua/core/encoders.lua
+++ b/lua/core/encoders.lua
@@ -26,7 +26,6 @@ encoders.callback = norns.none
 
 --- set acceleration
 encoders.set_accel = function(n,z)
-  print("Modifying encs in [norns.encoders.set_accel]: n="..n..", z="..tostring(z))
   if n == 0 then
     for k=1,3 do
       encoders.accel[k] = z
@@ -40,7 +39,6 @@ end
 
 --- set sensitivity
 encoders.set_sens = function(n,s)
-  print("Modifying encs in [norns.encoders.set_sens]: n="..n..", s="..s)
   if n == 0 then
     for k=1,3 do
       encoders.sens[k] = util.clamp(s,1,16)
@@ -103,7 +101,6 @@ local accel, sens = default_accel_and_sens()
 
 norns.enc = {}
 norns.enc.accel = function(n,z)
-  print("Modifying encs in [norns.enc.accel]: n="..n..", z="..tostring(z))
   if n == 0 then
     for k=1,3 do
       accel[k] = z
@@ -115,7 +112,6 @@ norns.enc.accel = function(n,z)
 end
 
 norns.enc.sens = function(n,s)
-  print("Modifying encs in [norns.enc.sens]: n="..n..", s="..s)
   if n == 0 then
     for k=1,3 do
       sens[k] = util.clamp(s,1,16)
@@ -127,7 +123,6 @@ norns.enc.sens = function(n,s)
 end
 
 norns.enc.resume = function()
-  print("Resuming...")
   for n=1,3 do
     norns.encoders.set_accel(n,accel[n])
     norns.encoders.set_sens(n,sens[n])
@@ -141,7 +136,6 @@ norns.enc.print_state = function()
 end
 
 norns.enc.reset = function()
-  print("Resetting script accel and sens")
   accel, sens = default_accel_and_sens()
 end
 

--- a/lua/core/script.lua
+++ b/lua/core/script.lua
@@ -63,8 +63,7 @@ Script.clear = function()
   enc = norns.none
 
   -- reset encoders
-  norns.enc.accel(0,true)
-  norns.enc.sens(0,2)
+  norns.enc.reset()
 
   -- clear, redirect, and reset devices
   grid.cleanup()


### PR DESCRIPTION
Hi all. Here's a small fix to allow users to define the default knob sensitivity.

Details:
My Norns Shield has "jumpy" encoders, and on Lines I found a few threads that discussed ways of changing the knob sensitivity and acceleration, e.g [this thread](https://llllllll.co/t/norns-shield-jumpy-encoders/44292/2). Changing the values didn't seem to make any difference, so I dug into the code and saw that those initial values aren't being used as defaults because they are overwritten in other parts of the code.

The main issue is that the enc.accel and enc.sens script state values are being set in the [Script.clear() function](https://github.com/monome/norns/blob/main/lua/core/script.lua#L66), which is called whenever a script is loaded. Values in encoders.sens and encoders.accel are modified in menu.lua and mix.lua, so they can't be used as default values.

With the fix, I'm basically just adding explicit default values and setting the script state to use these values when Script.clear() is called.