### PR TITLE
Converged fixes

### DIFF
--- a/crone/src/crone_param_dispatch.cpp
+++ b/crone/src/crone_param_dispatch.cpp
@@ -35,7 +35,9 @@ std::map<const std::string, std::function<void(int, float)>> cut_param_fn_map =
      {"level_slew_time", crone_set_param_cut_level_slew_time},
      {"pan_slew_time", crone_set_param_cut_pan_slew_time},
      {"recpre_slew_time", crone_set_param_cut_recpre_slew_time},
-     {"rate_slew_time", crone_set_param_cut_rate_slew_time}};
+     {"rate_slew_time", crone_set_param_cut_rate_slew_time},
+     {"phase_quant", crone_set_param_cut_phase_quant},
+     {"phase_offset", crone_set_param_cut_phase_offset}};
 
 std::map<const std::string, std::function<void(int, int)>> cut_param_fn_map_ii =
     {

--- a/matron/src/oracle.cc
+++ b/matron/src/oracle.cc
@@ -763,8 +763,8 @@ void o_poll_callback_softcut_render(int idx, float sec_per_sample, float start, 
     ev->softcut_render.sec_per_sample = sec_per_sample;
     ev->softcut_render.start = start;
     ev->softcut_render.size = size;
-    ev->softcut_render.data = (float *)calloc(1, size);
-    memcpy(ev->softcut_render.data, data, size);
+    ev->softcut_render.data = (float *)calloc(size, sizeof(float));
+    memcpy(ev->softcut_render.data, data, size * sizeof(float));
     event_post(ev);
 }
 


### PR DESCRIPTION
A couple of softcut fixes for the converged changes:
- wires the `phase_quant` and `phase_offset` cut params into crone's param dispatch map
- fixes the `softcut_render` buffer in oracle to allocate and copy by float count (`size * sizeof(float)`) rather than byte count.

Tested on hardware and seems to resolve the issues mentioned here https://github.com/monome/norns/pull/1893