### PR TITLE
converged sidecar fixes

### DIFF
--- a/lua/core/menu/settings.lua
+++ b/lua/core/menu/settings.lua
@@ -68,8 +68,15 @@ end
 m.passdone = function(txt)
   if txt ~= nil then
     if string.len(txt) >= 8 and string.len(txt) < 64 then
-      local chpasswd_status = os.execute("echo 'we:"..txt.."' | sudo chpasswd")
-      local smbpasswd_status = os.execute("printf '"..txt.."\n"..txt.."\n' | sudo smbpasswd -a we")
+      local q = txt:gsub("'", "'\\''")
+      norns.system_cmd("printf '%s\\n' 'we:"..q.."' | sudo chpasswd && echo __ok__", function(out)
+        if out:match("__ok__") then print("ssh password changed")
+        else print("!! ssh password change failed !!") end
+      end)
+      norns.system_cmd("printf '%s\\n' '"..q.."' '"..q.."' | sudo smbpasswd -a we && echo __ok__", function(out)
+        if out:match("__ok__") then print("samba password changed")
+        else print("!! samba password change failed !!") end
+      end)
       local hotspotpasswd_status;
       local fd = io.open("home/we/norns/.system.hotspot_password", "w+")
       if fd then
@@ -78,8 +85,6 @@ m.passdone = function(txt)
         io.close(fd)
         hotspotpasswd_status = true
       end
-      if chpasswd_status then print("ssh password changed") end
-      if smbpasswd_status then print("samba password changed") end
       if hotspotpasswd_status then print("hotspot password changed, toggle WIFI off/on to take effect") end
     elseif string.len(txt) <= 8 then
       print("!! password must be at least 8 characters !!")

--- a/lua/core/menu/tape.lua
+++ b/lua/core/menu/tape.lua
@@ -106,7 +106,7 @@ local function file_tape_exists(index)
 end
 
 local function file_read_tape_index()
-  os.execute("mkdir -p " .. _path.tape)
+  util.make_dir(_path.tape)
   local tape = util.os_capture("ls " .. _path.tape, true)
   local t = {}
   for f in tape:gmatch("([^\n]+)") do

--- a/lua/core/norns.lua
+++ b/lua/core/norns.lua
@@ -263,5 +263,5 @@ end
 
 -- expand the filesystem after a fresh installation
 norns.expand_filesystem = function()
-  os.execute('sudo raspi-config --expand-rootfs')
+  norns.system_cmd('sudo raspi-config --expand-rootfs')
 end

--- a/lua/test/core/menu/tape_test.lua
+++ b/lua/test/core/menu/tape_test.lua
@@ -74,6 +74,11 @@ local function setup_tape_env(opts)
     return util_stub._os_capture_output or ""
   end
 
+  util_stub._made_dirs = {}
+  function util_stub.make_dir(path)
+    table.insert(util_stub._made_dirs, path)
+  end
+
   function util_stub.file_exists(path)
     local map = util_stub._existing_files or {}
     return map[path] == true
@@ -119,10 +124,6 @@ local function setup_tape_env(opts)
   package.loaded['textentry'] = textentry_stub
   package.loaded['listselect'] = listselect_stub
 
-  -- stub os.execute invoked by read_tape_index
-  local original_os_execute = os.execute
-  os.execute = function(_) return true end -- luacheck: ignore
-
   -- ensure fresh load
   package.loaded['core/menu/tape'] = nil
   local tape = require('core/menu/tape')
@@ -135,7 +136,7 @@ local function setup_tape_env(opts)
   -- by default, initialize the tape menu to subscribe to state updates
   if tape and tape.init then tape.init() end
 
-  -- convenience: expose restore to clean up package.loaded and os
+  -- expose restore to clean up package.loaded
   local function restore()
     -- ensure we unsubscribe to avoid cross-test observers
     if tape and tape.deinit then pcall(tape.deinit) end
@@ -144,7 +145,6 @@ local function setup_tape_env(opts)
     package.loaded['fileselect'] = nil
     package.loaded['textentry'] = nil
     package.loaded['listselect'] = nil
-    os.execute = original_os_execute -- luacheck: ignore
   end
 
   return {

--- a/matron/src/hardware/stat.cc
+++ b/matron/src/hardware/stat.cc
@@ -4,30 +4,30 @@
  * hardware status monitoring
  */
 
-#include <errno.h>
-#include <fcntl.h>
 #include <pthread.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sys/epoll.h>
+#include <sys/statvfs.h>
 #include <unistd.h>
 
 #include "events.h"
-#include "sidecar.h"
 
 #define STAT_INTERVAL 2
 
+// SoC temperature sensor, value in millidegrees Celsius
+#define TEMP_PATH "/sys/class/thermal/thermal_zone0/temp"
+
 static pthread_t p;
-static bool have_vcgencmd;
+static bool have_temp;
 
 void *stat_check(void *);
 
 void stat_init() {
-    if (!(have_vcgencmd = system("which vcgencmd > /dev/null 2>&1") == 0)) {
-        fprintf(stderr, "Unable to check temperature: vcgencmd not in path\n");
+    if (!(have_temp = access(TEMP_PATH, R_OK) == 0)) {
+        fprintf(stderr, "Unable to check temperature: " TEMP_PATH " not readable\n");
     }
 
     if (pthread_create(&p, NULL, stat_check, 0)) {
@@ -47,8 +47,6 @@ void *stat_check(void *x) {
     int temp = 0;
     int cpu[5] = {0, 0, 0, 0, 0};
 
-    char bufsub[8];
-
     uint32_t user, nice, system, idle, iowait, irq, softirq, steal;
     uint32_t sumidle = 0, sumnonidle = 0, total = 0;
     uint32_t prevsumidle[5] = {0, 0, 0, 0, 0};
@@ -62,70 +60,55 @@ void *stat_check(void *x) {
 
         // check disk every 5 sleeps
         if (number == 0) {
-            size_t size = 0;
-            char *buff = NULL;
-            sidecar_client_cmd("df -l --output=avail / | tail -1 | awk '{ print $1 }'", &buff, &size);
-            if (size == 0) {
-                fprintf(stderr, "Error: disk free read\n");
+            struct statvfs vfs;
+            if (statvfs("/", &vfs) == 0) {
+                disk = (int)((uint64_t)vfs.f_bavail * vfs.f_frsize / 1024000); // MB, legacy df scale
             } else {
-                disk = atoi(buff) / 1000; // convert to MB
+                fprintf(stderr, "Error: disk free read\n");
             }
-            free(buff);
         }
 
         // check temp every 5
-        if (have_vcgencmd && number == 0) {
-            size_t size = 0;
-            char *buff = NULL;
-            sidecar_client_cmd("vcgencmd measure_temp", &buff, &size);
-            if (size == 0) {
+        if (have_temp && number == 0) {
+            FILE *tf = fopen(TEMP_PATH, "r");
+            if (tf == NULL) {
                 fprintf(stderr, "Error: temp read\n");
             } else {
-                bufsub[0] = buff[5];
-                bufsub[1] = buff[6];
-                bufsub[2] = 0;
-                temp = atoi(bufsub);
+                int milli;
+                if (fscanf(tf, "%d", &milli) == 1) {
+                    temp = milli / 1000;
+                } else {
+                    fprintf(stderr, "Error: temp read\n");
+                }
+                fclose(tf);
             }
-            free(buff);
         }
 
         // check cpu
-        size_t size = 0;
-        char *buff = NULL;
-        sidecar_client_cmd("cat /proc/stat", &buff, &size);
-
-        if (size == 0) {
+        FILE *f = fopen("/proc/stat", "r");
+        if (f == NULL) {
             fprintf(stderr, "Error: cpu read\n");
         } else {
-            int i = 0;
-            strtok(buff, " ");
-            while (i < 4) {
-                user = atoi(strtok(NULL, " "));
-                nice = atoi(strtok(NULL, " "));
-                system = atoi(strtok(NULL, " "));
-                idle = atoi(strtok(NULL, " "));
-                iowait = atoi(strtok(NULL, " "));
-                irq = atoi(strtok(NULL, " "));
-                softirq = atoi(strtok(NULL, " "));
-                steal = atoi(strtok(NULL, " "));
-                // fprintf(stderr, "> %d %d %d %d %d %d %d %d\n", user, nice, system, idle, iowait, irq, softirq, steal);
+            char label[16];
+            for (int i = 0; i < 5; i++) {
+                if (fscanf(f, "%15s %u %u %u %u %u %u %u %u", label, &user, &nice, &system, &idle, &iowait, &irq, &softirq, &steal) != 9 || strncmp(label, "cpu", 3) != 0) {
+                    break;
+                }
+                int ch;
+                while ((ch = fgetc(f)) != EOF && ch != '\n') {
+                }
 
                 sumidle = idle + iowait;
                 sumnonidle = user + nice + system + irq + softirq + steal;
                 total = sumnonidle + sumidle;
                 totald = total - prevtotal[i];
                 idled = sumidle - prevsumidle[i];
-                cpu[i] = 100 * (totald - idled) / totald;
+                cpu[i] = totald > 0 ? 100 * (totald - idled) / totald : 0;
                 prevsumidle[i] = sumidle;
                 prevtotal[i] = total;
-
-                // fprintf(stderr,"%d --> %d\n", i, cpu);
-                strtok(NULL, "\n");
-                strtok(NULL, " ");
-                i++;
             }
+            fclose(f);
         }
-        free(buff);
 
         // just send every tick
         union event_data *ev = event_data_new(EVENT_STAT);

--- a/matron/src/system_cmd.cc
+++ b/matron/src/system_cmd.cc
@@ -11,8 +11,11 @@ static void post_command_capture(const char *cmd, void *ctx, const char *respons
     int cb_ref = (int)ctx;
 
     if (response_size == 0) {
+        // FIXME the settings password change passes a plaintext password
+        // through here, and stderr reaches the journal and maiden.
         fprintf(stderr, "system_cmd: command (%s) failed\n", cmd);
-        return;
+        response_buff = "";
+        response_size = 1;
     }
 
     // response buffer is only valid during the callback so it is copied so that

--- a/matron/src/weaver.cc
+++ b/matron/src/weaver.cc
@@ -3492,7 +3492,7 @@ int _system_glob(lua_State *l) {
 }
 
 static void _execute_completion(const char *cmd, void *ctx, const char *buf, size_t size) {
-    lua_pushstring((lua_State *)ctx, buf);
+    lua_pushstring((lua_State *)ctx, buf != NULL ? buf : "");
 }
 
 int _execute(lua_State *l) {

--- a/norns/sidecar.cpp
+++ b/norns/sidecar.cpp
@@ -10,7 +10,7 @@
 #include <nng/protocol/reqrep0/req.h>
 #include <nng/transport/ipc/ipc.h>
 
-#include "readerwriterqueue.h"
+#include "blockingconcurrentqueue.h"
 #include "sidecar.h"
 
 //---------------------------------
@@ -47,7 +47,7 @@ union request {
     struct request_run_cmd run_cmd;
 };
 
-static moodycamel::BlockingReaderWriterQueue<union request *> requests(32);
+static moodycamel::BlockingConcurrentQueue<union request *> requests(32);
 
 static union request *request_new(request_type type) {
     union request *req = (request *)calloc(1, sizeof(union request));
@@ -195,7 +195,7 @@ struct client_state {
 
 static pthread_t client_thread;
 static struct client_state cs;
-static pthread_mutex_t run_cmd_lock;
+static pthread_mutex_t run_cmd_lock = PTHREAD_MUTEX_INITIALIZER;
 
 static void handle_run_cmd(const char *cmd, void *ctx, client_cmd_completion_t completion) {
     static char empty_result[1] = {'\0'};


### PR DESCRIPTION
sidecar: client concurrency, transport failures reported to lua, and the last in-process forks removed

_why_

the sidecar exists so the converged norns binary never `fork()`s while holding the JACK real-time thread. some paths still forked in-process, or shelled out for data the process can read itself. also, the sidecar client had a couple of threading bugs.

_what_

this PR brings in changes related to ongoing work on norns binary <-> sidecar communication.

this PR _does not_ fix SYSTEM > UPDATE just yet. a follow-up PR will include sidecar/norns restructuring to resolve the update.sh regression and the unreliable restart issues in the converged norns binary.

- fix: the request queue was single-producer (`BlockingReaderWriterQueue`) with two producers, `system_cmd` from the matron lua thread and `sidecar_client_cleanup`'s `REQUEST_QUIT` from the main thread. now `BlockingConcurrentQueue`. `run_cmd_lock` was never initialized, working only by static zero-init.
- fix: a regression in when system command outputs nothing. the lua callback never ran and its registry ref leaked. failures now carry an empty string so the callback always fires, restoring pre-converged scripting contract, etc.
- fix: `stat` shelled out to `df`, `vcgencmd`, and `cat /proc/stat` every 2 seconds. now `statvfs()`, `/sys/class/thermal/thermal_zone0/temp`, and `/proc/stat` read directly, dropping the `vcgencmd` dependency.
- fix: the old cpu loop stopped after the aggregate line and cores 0 through 2, so `norns.cpu[4]` was never written and the home screen's fourth cpu figure has been reading a constant `0.`. it now reports core 3.
- fix: settings password change, the tape dir, and `expand_filesystem` were the last in-process `os.execute` sites, now `norns.system_cmd` / `util.make_dir`.

_verified_

- tests passing.
- tested on hardware: password change, tape menu, stat readouts match `df` / `vcgencmd`, `norns.cpu[4]` goes live under load. stats work correctly on norns and norns shield.

_note_

the settings password change path historically has passed a plaintext password through to logs upon error. this PR _does not_ fix this. i've intentionally left that alone for the moment.