### PR TITLE
sidecar: typed streaming transport + detached exec, and a fail-safe SYSTEM>UPDATE

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,3 +53,10 @@ jobs:
           sudo apt-get install -y lua5.3
       - name: run lua tests
         run: ./test-lua.sh
+
+  test-update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: run update.sh dry-run tests
+        run: bash update/test-update.sh

--- a/lua/core/menu/system.lua
+++ b/lua/core/menu/system.lua
@@ -39,13 +39,4 @@ end
 m.init = norns.none
 m.deinit = norns.none
 
-m.passdone = function(txt)
-  if txt ~= nil then
-    local status = _norns.execute("echo 'we:"..txt.."' | sudo chpasswd")
-    if status then print("password changed") end
-  end
-  _menu.set_page("SYSTEM")
-end
-
-
 return m

--- a/lua/core/menu/update.lua
+++ b/lua/core/menu/update.lua
@@ -1,136 +1,273 @@
 local m = {
   alt = false,
-  install = "stable"
+  install = "stable",
+  dots = 0,
+  -- polls with no new progress, cleared by progress and by each check
+  stall_ticks = 0,
+  status_path = "/tmp/norns-update-status",
+  progress_path = "/tmp/norns-update-progress",
+  -- named in system_cmd.cc
+  update_unit = "norns-update",
+  -- override, settable from the maiden repl for testing
+  releases_url = nil,
+  -- 0.5s ticks without installer progress before probing the unit (10 min)
+  install_timeout_ticks = 1200,
+  -- bumped on leaving the page, so a stale callback can be told from a live one
+  visit_id = 0,
+  constants = {
+    CHECKING = "checking",
+    MESSAGE = "message",
+    CONFIRM = "confirm",
+    UPDATE = "update",
+    CANCEL = "cancel",
+    INSTALLING = "installing",
+    INSTALL_FAILED = "install failed",
+  },
 }
 
 releases = {}
-local VER = { "stable", "beta" }
 
-local function checked() print("what??") end
-local function get_update_2() end
+local UPDATER = _path.home .. "/norns/update/update.sh"
+
+-- async callbacks, defined below their callers
+local compare_releases
+local handoff_update
+
+-- the menu timer is shared, so a callback from a previous visit must not stop it
+local function if_same_visit(fn)
+  local visit = m.visit_id
+  return function(...)
+    if m.visit_id ~= visit then return end
+    return fn(...)
+  end
+end
+
+-- the shared menu timer, cycling the dots until the page settles
+local function start_tick_timer()
+  _menu.timer.time = 0.5
+  _menu.timer.count = -1
+  _menu.timer.event = function()
+    m.dots = (m.dots % 3) + 1
+    _menu.redraw()
+  end
+  _menu.timer:start()
+end
 
 local function check_newest()
   print("checking for update")
   if m.alt then print("stable and beta") end
-  norns.system_cmd( [[curl -s \
-      https://raw.githubusercontent.com/monome/norns/main/releases.txt \
-      ]],
-      checked)
+  local url = m.releases_url or "https://raw.githubusercontent.com/monome/norns/main/releases.txt"
+  norns.system_cmd("curl -s " .. url, if_same_visit(compare_releases))
 end
 
-checked = function(result)
-  print(result)
-  load(result)()
+local function valid_release(r)
+  return type(r) == "table" and tonumber(r.version) ~= nil
+end
 
+compare_releases = function(result)
+  print(result)
+  releases = {}
+  local manifest = load(result or "")
+  -- an http error body arrives as an ordinary callback, so it must fail here
+  -- rather than error mid-callback
+  if not (manifest and pcall(manifest) and valid_release(releases.stable) and valid_release(releases.beta)) then
+    print("update: could not read the releases list")
+    _menu.timer:stop()
+    m.message = "check failed. try again."
+    m.stage = m.constants.MESSAGE
+    _menu.redraw()
+    return
+  end
+
+  _menu.timer:stop()
   if m.alt==false and tonumber(norns.version.update) >= tonumber(releases.stable.version) then
     m.message = "up to date."
+    m.stage = m.constants.MESSAGE
   else
-    m.stage = "confirm"
+    m.stage = m.constants.CONFIRM
   end
   _menu.redraw()
 end
 
 
 local function get_update()
-  m.message = "preparing..."
   _menu.redraw()
   pcall(cleanup) -- shut down script
   norns.script.clear()
   _menu.locked = true
   print("shutting down audio...")
-  --_norns.execute("sudo systemctl stop norns-jack.service") -- disable audio
   for i=1,6 do _norns.cut_enable(i,0) end -- disable softcut
   _norns.execute("sudo systemctl stop norns-sclang.service") -- disable audio
-  print("clearing old updates...")
-  _norns.execute("sudo rm -rf /home/we/update/*") -- clear old updates
-  m.message = "downloading..."
+  m.dots = 0
   _menu.redraw()
   print("starting download...")
-  local cmd = "wget -T 180 -q -P /home/we/update/ " .. releases[m.install].url .. " " .. releases[m.install].sha
+  local release = releases[m.install]
+  local cmd = table.concat({
+    "/bin/bash", UPDATER, "download", release.url, release.sha
+  }, " ")
   print("> "..cmd)
-  m.initial_disk = norns.disk
-  norns.system_cmd(cmd, get_update_2) --download
-  _menu.timer.time = 0.5
-  _menu.timer.count = -1
-  _menu.timer.event = function()
-    m.blink = m.blink == false
-    m.message = "downloading: " .. m.initial_disk-norns.disk
-    _menu.redraw()
-  end
-  _menu.timer:start()
+  norns.system_cmd(cmd, if_same_visit(handoff_update))
+  start_tick_timer()
 end
 
-get_update_2 = function()
+local function read_failed_step()
+  local f = io.open(m.status_path, "r")
+  if not f then return nil end
+  local line = f:read("l")
+  f:close()
+  return line and line:match("^failed:(.+)$") or nil
+end
+
+local function clear_failed_step()
+  os.remove(m.status_path)
+end
+
+local function enter_install_failed(step)
   _menu.timer:stop()
-  m.message = "unpacking update..."
+  m.failed_step = step
+  m.stage = m.constants.INSTALL_FAILED
   _menu.redraw()
-  print("checksum validation...")
-  m.message = "checksum validation..."
-  local checksum = util.os_capture("cd /home/we/update; sha256sum -c /home/we/update/*.sha256 | grep OK")
-  if checksum:match("OK") then
-    print("unpacking...")
-    _norns.execute("tar xzvf /home/we/update/*.tgz -C /home/we/update/")
-    m.message = "running update..."
-    _menu.redraw()
-    print("running update...")
-    _norns.execute("/home/we/update/"..releases[m.install].version.."/update.sh")
-    m.message = "done. any key to shut down."
-    _menu.redraw()
-    print("update complete.")
-  else
-    print("update failed.")
-    m.message = "update failed."
-    _menu.redraw()
+end
+
+local function read_install_progress()
+  local f = io.open(m.progress_path, "r")
+  if not f then return nil end
+  local text = f:read("l")
+  local beat = f:read("l")
+  f:close()
+  if not text or text == "" then return nil end
+  return text, text .. "\n" .. (beat or "")
+end
+
+local ALIVE_STATES = {
+  active = true, activating = true, reloading = true, deactivating = true,
+}
+
+local function check_updater_alive(on_result)
+  norns.system_cmd("systemctl is-active " .. m.update_unit, function(out)
+    -- a transport failure gives "", which reads as not alive
+    local state = tostring(out or ""):match("^%s*([%a-]+)")
+    on_result(state ~= nil and ALIVE_STATES[state] == true)
+  end)
+end
+
+local function give_up_unless_alive(alive)
+  if m.stage ~= m.constants.INSTALLING then return end
+  if alive then return end
+  enter_install_failed("timeout")
+end
+
+local function check_install_status()
+  -- success reboots out from under this poll, so it sees progress or failure
+  local step = read_failed_step()
+  if step then
+    enter_install_failed(step)
+    return
   end
-  m.stage = "done"
+  local text, mark = read_install_progress()
+  if mark and mark ~= m.last_progress then
+    m.last_progress = mark
+    m.message = text
+    m.stall_ticks = 0
+  else
+    m.stall_ticks = m.stall_ticks + 1
+    if m.stall_ticks >= m.install_timeout_ticks then
+      -- a running updater reboots when it is done
+      m.stall_ticks = 0
+      check_updater_alive(if_same_visit(give_up_unless_alive))
+    end
+  end
+  m.dots = (m.dots % 3) + 1
+  _menu.redraw()
+end
+
+handoff_update = function(result)
+  _menu.timer:stop()
+  local status
+  for line in tostring(result or ""):gmatch("[^\n]+") do
+    status = line:match("^download: (.+)$") or status
+  end
+  if status ~= "ok" then
+    local reason = (status and status:match("checksum")) and "checksum" or "download"
+    print("update failed: " .. reason .. " (" .. (status or "no download output") .. ")")
+    enter_install_failed(reason)
+    return
+  end
+
+  print("handing off to updater ("..UPDATER..")...")
+  clear_failed_step()
+  m.last_progress = nil
+  m.stall_ticks = 0
+  norns.system_update(function()
+    enter_install_failed("launch")
+  end)
+  m.message = "updating"
+  m.stage = m.constants.INSTALLING
+
+  _menu.timer.time = 0.5
+  _menu.timer.count = -1
+  _menu.timer.event = check_install_status
+  _menu.timer:start()
+  _menu.redraw()
 end
 
 
 m.key = function(n,z)
-  if m.stage=="init" and z==1 then
+  if (m.stage==m.constants.CHECKING or m.stage==m.constants.MESSAGE) and z==1 then
     _menu.set_page("SYSTEM")
     _menu.redraw()
-  elseif m.stage=="confirm" then
+  elseif m.stage==m.constants.CONFIRM then
     if n==2 and z==1 then
       _menu.set_page("SYSTEM")
       _menu.redraw()
     elseif n==3 and z==1 then
-      m.stage="update"
+      m.stage=m.constants.UPDATE
       get_update()
     end
-  elseif m.stage=="update" then
+  elseif m.stage==m.constants.UPDATE then
     if n==2 and z==1 then
-      m.stage="cancel"
+      m.stage=m.constants.CANCEL
       _menu.redraw()
     end
-  elseif m.stage=="cancel" then
+  elseif m.stage==m.constants.CANCEL then
     if n==2 and z==1 then
-      m.stage="update"
+      m.stage=m.constants.UPDATE
       _menu.redraw()
     elseif n==3 and z==1 then
       _norns.reset()
     end
-  elseif m.stage=="done" and z==1 then
-    m.stage = "shutdown"
-    print("shutting down.")
+  elseif m.stage==m.constants.INSTALL_FAILED and z==1 then
+    -- any key returns to SYSTEM, the previous install is still in place
+    _menu.timer:stop()
+    clear_failed_step()
+    -- bring back sclang (stopped by get_update)
+    _norns.execute("sudo systemctl start norns-sclang.service")
+    _menu.locked = false
+    _menu.set_page("SYSTEM")
     _menu.redraw()
-    _norns.execute("sleep 0.5; sudo shutdown now")
   end
 end
 
 
 m.enc = function(n,delta)
   if n==2 and delta<0 then m.install = "stable" else m.install = "beta" end
-  if m.stage == "confirm" then
+  if m.stage == m.constants.CONFIRM then
     _menu.redraw()
   end
+end
+
+-- measure the full-width string so cycling dots do not shift the line
+local function draw_dots(text)
+  local x = 64 - screen.text_extents(text .. "...") / 2
+  screen.move(x,40)
+  screen.text(text .. string.rep(".", m.dots))
 end
 
 m.redraw = function()
   screen.clear()
   screen.level(15)
   screen.move(64,40)
-  if m.stage == "confirm" then
+  if m.stage == m.constants.CONFIRM then
     if m.alt==false then
       screen.text_center("update found: "..releases.stable.version)
       screen.move(64,50)
@@ -143,20 +280,32 @@ m.redraw = function()
       screen.level(m.install=="beta" and 15 or 1)
       screen.text("beta-"..releases.beta.version)
     end
-  elseif m.stage == "update" then
-    screen.level(m.blink == true and 15 or 3)
-    screen.text_center(m.message)
-  elseif m.stage == "cancel" then
+  elseif m.stage == m.constants.UPDATE then
+    draw_dots("downloading")
+  elseif m.stage == m.constants.CANCEL then
     screen.text_center("cancel?")
-  elseif m.stage == "shutdown" then
-    screen.text_center("shutting down.")
-    if norns.is_shield then
-      screen.move(64,50)
-      screen.text_center("disconnect power when the")
-      screen.move(64,60)
-      screen.text_center("not-red light stops blinking.")
-    end
-  else
+  elseif m.stage == m.constants.INSTALLING then
+    draw_dots(m.message)
+    screen.level(5)
+    screen.move(64,50)
+    screen.text_center("please do not power off")
+  elseif m.stage == m.constants.INSTALL_FAILED then
+    screen.move(64,30)
+    screen.text_center("update failed")
+    local pre, step = "error:", m.failed_step or "unknown"
+    local x = 64 - (screen.text_extents(pre) + 4 + screen.text_extents(step)) / 2
+    screen.level(10)
+    screen.move(x,40)
+    screen.text(pre)
+    screen.level(15)
+    screen.move(x + screen.text_extents(pre) + 4,40)
+    screen.text(step)
+    screen.level(4)
+    screen.move(64,50)
+    screen.text_center("press any key")
+  elseif m.stage == m.constants.CHECKING then
+    draw_dots("checking for update")
+  elseif m.stage == m.constants.MESSAGE then
     screen.text_center(m.message)
   end
   screen.update()
@@ -166,20 +315,39 @@ m.init = function()
   m.install = "stable"
   m.alt = _menu.alt
 
-  m.stage = "init"
-  m.message = "checking for update..."
+  local leftover = read_failed_step()
+  if leftover then
+    enter_install_failed(leftover)
+    return
+  end
+
+  m.stage = m.constants.CHECKING
+  m.dots = 0
   _menu.redraw()
+  start_tick_timer()
 
   local ping = util.os_capture("ping -c 1 github.com | grep failure")
 
-  if not ping == ''  then
+  if ping ~= '' then
+    _menu.timer:stop()
     m.message = "need internet."
+    m.stage = m.constants.MESSAGE
+    _menu.redraw()
   elseif norns.disk < 400 then
+    _menu.timer:stop()
     m.message = "disk full. need 400M."
+    m.stage = m.constants.MESSAGE
+    _menu.redraw()
   else check_newest() end
 end
 
-m.deinit = function() end
+m.deinit = function()
+  m.visit_id = m.visit_id + 1
+  _menu.timer:stop()
+end
+
+-- exposed for lua/test/core/menu/update_test.lua
+m._check_install_status = check_install_status
+m._handoff_update = handoff_update
 
 return m
-

--- a/lua/core/norns.lua
+++ b/lua/core/norns.lua
@@ -182,6 +182,16 @@ else
   norns.version.update = "000000"
 end
 
+local function report_launch_failure(what, on_fail)
+  return function(ok, err)
+    if not ok then
+      print(what .. ": launch failed")
+      if err then print(err) end
+      if on_fail then on_fail(err or "") end
+    end
+  end
+end
+
 --- shutdown
 norns.shutdown = function()
   hook.system_pre_shutdown()
@@ -192,7 +202,7 @@ norns.shutdown = function()
   pcall(cleanup)
   audio.level_dac(0)
   audio.headphone_gain(0)
-  _norns.execute("sleep 0.5; sudo shutdown now")
+  _norns.system_action("shutdown", report_launch_failure("shutdown"))
 end
 
 --- platform detection
@@ -217,19 +227,21 @@ norns.system_cmd = function(cmd, callback)
   return _norns.system_cmd(cmd, callback or print)
 end
 
+--- launch the system updater, detached so it survives norns replacing itself
+-- @tparam[opt] func on_fail called with the error if the launch fails
+norns.system_update = function(on_fail)
+  return _norns.system_action("update", report_launch_failure("update", on_fail))
+end
+
 --- find pathnames matching a pattern
 -- @function system_glob
 -- @tparam string pattern
 -- @treturn {string,...} a table of matching pathnames
 norns.system_glob = _norns.system_glob
 
--- system reset (restart sclang + self-terminate for systemd relaunch)
+-- system reset (restart sclang + main as one detached system command)
 _norns.reset = function()
-  -- restart sclang first (synchronous via sidecar, completes before we die)
-  _norns.execute("sudo systemctl restart norns-sclang.service")
-  -- self-terminate
-  -- systemd Restart=always relaunches the binary
-  _norns.terminate()
+  _norns.system_action("reset", report_launch_failure("reset"))
 end
 
 -- restart device

--- a/lua/test/core/menu/update_test.lua
+++ b/lua/test/core/menu/update_test.lua
@@ -1,0 +1,651 @@
+-- lua/test/core/menu/update_test.lua
+-- unit tests for the SYSTEM>UPDATE menu.
+
+local luaunit = require('lib/test/luaunit')
+local mock = require('lib/test/mock')
+
+local update
+local STAGE
+local saved
+local status_path
+local progress_path
+
+local function write_status(text)
+  local f = assert(io.open(status_path, "w"))
+  f:write(text)
+  f:close()
+end
+
+local function write_progress(text)
+  local f = assert(io.open(progress_path, "w"))
+  f:write(text)
+  f:close()
+end
+
+local function stall_until_systemd_is_asked()
+  local before = norns.system_cmd.call_count()
+  for _ = 1, update.install_timeout_ticks do update._check_install_status() end
+  luaunit.assertEquals(norns.system_cmd.call_count(), before + 1)
+  local call = norns.system_cmd.args(before + 1)
+  luaunit.assertStrContains(call[1], "is-active norns-update")
+  return call[2]
+end
+
+local function stall_until_systemd_replies(reply)
+  stall_until_systemd_is_asked()(reply)
+end
+
+local function drawn_text()
+  local out = {}
+  for i = 1, screen.text.call_count() do out[#out + 1] = screen.text.args(i)[1] end
+  for i = 1, screen.text_center.call_count() do out[#out + 1] = screen.text_center.args(i)[1] end
+  return table.concat(out, "|")
+end
+
+local function status_exists()
+  local f = io.open(status_path, "r")
+  if f then
+    f:close()
+    return true
+  end
+  return false
+end
+
+TestUpdate = {}
+
+function TestUpdate.setUp()
+  saved = {
+    _menu = _menu,
+    screen = screen,
+    norns = norns,
+    _norns = _norns,
+    util = util,
+    releases = releases,
+    _path = _path
+  }
+
+  _menu = {
+    redraw = mock.spy(),
+    set_page = mock.spy(),
+    locked = false,
+    alt = false,
+    timer = {
+      start = mock.spy(),
+      stop = mock.spy(),
+      time = 0,
+      count = 0,
+      event = nil,
+    },
+  }
+
+  screen = {
+    clear = function() end,
+    level = function() end,
+    move = function() end,
+    text = mock.spy(),
+    text_center = mock.spy(),
+    text_extents = function(s) return #s * 4 end,
+    update = mock.spy(),
+  }
+
+  norns = {
+    disk = 1000,
+    version = { update = "260000" },
+    system_update = mock.spy(),
+    system_cmd = mock.spy(),
+    script = { clear = mock.spy() }
+  }
+  _norns = { execute = mock.spy(), cut_enable = mock.spy() }
+  util = { os_capture = function() return "" end }
+  _path = { home = "/nonexistent" }
+
+  status_path = os.tmpname()
+  os.remove(status_path)
+  progress_path = os.tmpname()
+  os.remove(progress_path)
+
+  package.loaded['core/menu/update'] = nil
+  update = require('core/menu/update')
+  STAGE = update.constants
+  update.status_path = status_path
+  update.progress_path = progress_path
+end
+
+function TestUpdate.tearDown()
+  if status_path then os.remove(status_path) end
+  if progress_path then os.remove(progress_path) end
+  package.loaded['core/menu/update'] = nil
+  if saved then
+    _menu, screen, norns = saved._menu, saved.screen, saved.norns
+    _norns, util, releases, _path = saved._norns, saved.util, saved.releases, saved._path
+  end
+  update, STAGE, saved, status_path, progress_path = nil, nil, nil, nil, nil
+end
+
+function TestUpdate.test_poll_transitions_to_failure_on_failed_status()
+  update.stage = STAGE.INSTALLING
+
+  write_status("failed:binary-swap")
+  update._check_install_status()
+
+  luaunit.assertEquals(update.stage, STAGE.INSTALL_FAILED)
+  luaunit.assertEquals(update.failed_step, "binary-swap")
+  luaunit.assertTrue(_menu.timer.stop.called())
+end
+
+function TestUpdate.test_poll_noop_without_status()
+  update.stage = STAGE.INSTALLING
+
+  update._check_install_status()
+
+  luaunit.assertEquals(update.stage, STAGE.INSTALLING)
+  luaunit.assertFalse(_menu.timer.stop.called())
+end
+
+function TestUpdate.test_poll_noop_on_empty_status_file()
+  update.stage = STAGE.INSTALLING
+
+  write_status("")
+  update._check_install_status()
+
+  luaunit.assertEquals(update.stage, STAGE.INSTALLING)
+  luaunit.assertFalse(_menu.timer.stop.called())
+end
+
+function TestUpdate.test_poll_ignores_non_failure_status()
+  update.stage = STAGE.INSTALLING
+
+  write_status("ok")
+  update._check_install_status()
+
+  luaunit.assertEquals(update.stage, STAGE.INSTALLING)
+end
+
+function TestUpdate.test_poll_shows_installer_progress()
+  update.stage = STAGE.INSTALLING
+
+  write_progress("updating norns\n")
+  update._check_install_status()
+
+  luaunit.assertEquals(update.stage, STAGE.INSTALLING)
+  luaunit.assertEquals(update.message, "updating norns")
+  luaunit.assertTrue(_menu.redraw.called())
+end
+
+function TestUpdate.test_poll_failure_outranks_progress()
+  update.stage = STAGE.INSTALLING
+
+  write_progress("updating norns\n")
+  write_status("failed:units")
+  update._check_install_status()
+
+  luaunit.assertEquals(update.stage, STAGE.INSTALL_FAILED)
+  luaunit.assertEquals(update.failed_step, "units")
+end
+
+function TestUpdate.test_failed_download_lands_on_the_failure_screen()
+  update.stage = STAGE.UPDATE
+
+  update._handoff_update("wget: unable to resolve host address 'example.com'\ndownload: failed\n")
+
+  luaunit.assertEquals(update.stage, STAGE.INSTALL_FAILED)
+  luaunit.assertEquals(update.failed_step, "download")
+  luaunit.assertFalse(norns.system_update.called())
+end
+
+function TestUpdate.test_checksum_download_failure_names_the_reason()
+  update.stage = STAGE.UPDATE
+
+  update._handoff_update("saved 'bundle.tgz'\ndownload: failed checksum verification\n")
+
+  luaunit.assertEquals(update.stage, STAGE.INSTALL_FAILED)
+  luaunit.assertEquals(update.failed_step, "checksum")
+  luaunit.assertFalse(norns.system_update.called())
+end
+
+function TestUpdate.test_transport_failure_reads_as_download_failure()
+  update.stage = STAGE.UPDATE
+
+  update._handoff_update("")
+
+  luaunit.assertEquals(update.stage, STAGE.INSTALL_FAILED)
+  luaunit.assertEquals(update.failed_step, "download")
+  luaunit.assertFalse(norns.system_update.called())
+end
+
+function TestUpdate.test_completed_download_hands_off_detached()
+  update.stage = STAGE.UPDATE
+
+  update._handoff_update("saved 'bundle.tgz'\ndownload: ok\n")
+
+  luaunit.assertEquals(update.stage, STAGE.INSTALLING)
+  luaunit.assertTrue(norns.system_update.called())
+end
+
+function TestUpdate.test_failed_launch_lands_on_the_failure_screen()
+  local captured_on_fail
+  norns.system_update = function(on_fail)
+    captured_on_fail = on_fail
+  end
+  update.stage = STAGE.UPDATE
+
+  update._handoff_update("download: ok\n")
+  luaunit.assertEquals(update.stage, STAGE.INSTALLING)
+
+  captured_on_fail("__detach_failed__")
+
+  luaunit.assertEquals(update.stage, STAGE.INSTALL_FAILED)
+  luaunit.assertEquals(update.failed_step, "launch")
+end
+
+function TestUpdate.test_stalled_install_asks_systemd_before_giving_up()
+  update.stage = STAGE.INSTALLING
+  update.install_timeout_ticks = 4
+
+  for _ = 1, 3 do update._check_install_status() end
+  luaunit.assertEquals(update.stage, STAGE.INSTALLING)
+  luaunit.assertFalse(norns.system_cmd.called())
+
+  update._check_install_status()
+
+  luaunit.assertEquals(update.stage, STAGE.INSTALLING)
+  luaunit.assertTrue(norns.system_cmd.called())
+  luaunit.assertStrContains(norns.system_cmd.args(1)[1], "is-active norns-update")
+
+  norns.system_cmd.args(1)[2]("inactive\n")
+
+  luaunit.assertEquals(update.stage, STAGE.INSTALL_FAILED)
+  luaunit.assertEquals(update.failed_step, "timeout")
+  luaunit.assertTrue(_menu.timer.stop.called())
+end
+
+function TestUpdate.test_running_updater_is_never_declared_timed_out()
+  update.stage = STAGE.INSTALLING
+  update.install_timeout_ticks = 2
+
+  stall_until_systemd_replies("activating\n")
+
+  luaunit.assertEquals(update.stage, STAGE.INSTALLING)
+  luaunit.assertNotEquals(update.failed_step, "timeout")
+
+  update._check_install_status()
+  luaunit.assertEquals(norns.system_cmd.call_count(), 1)
+end
+
+function TestUpdate.test_an_inactive_unit_is_not_mistaken_for_activating()
+  update.stage = STAGE.INSTALLING
+  update.install_timeout_ticks = 2
+
+  stall_until_systemd_replies("inactive\n")
+
+  luaunit.assertEquals(update.stage, STAGE.INSTALL_FAILED)
+  luaunit.assertEquals(update.failed_step, "timeout")
+end
+
+function TestUpdate.test_a_failed_unit_reads_as_gone()
+  update.stage = STAGE.INSTALLING
+  update.install_timeout_ticks = 2
+
+  stall_until_systemd_replies("failed\n")
+
+  luaunit.assertEquals(update.stage, STAGE.INSTALL_FAILED)
+  luaunit.assertEquals(update.failed_step, "timeout")
+end
+
+function TestUpdate.test_an_unknown_unit_reads_as_gone()
+  update.stage = STAGE.INSTALLING
+  update.install_timeout_ticks = 2
+
+  stall_until_systemd_replies("unknown\n")
+
+  luaunit.assertEquals(update.stage, STAGE.INSTALL_FAILED)
+  luaunit.assertEquals(update.failed_step, "timeout")
+end
+
+function TestUpdate.test_an_empty_systemd_reply_reads_as_gone()
+  update.stage = STAGE.INSTALLING
+  update.install_timeout_ticks = 2
+
+  stall_until_systemd_replies("")
+
+  luaunit.assertEquals(update.stage, STAGE.INSTALL_FAILED)
+  luaunit.assertEquals(update.failed_step, "timeout")
+end
+
+function TestUpdate.test_progress_resets_the_install_timeout()
+  update.stage = STAGE.INSTALLING
+  update.install_timeout_ticks = 3
+
+  write_progress("unpacking\n")
+  update._check_install_status()
+  update._check_install_status()
+  update._check_install_status()
+  luaunit.assertEquals(update.stage, STAGE.INSTALLING)
+
+  write_progress("updating norns\n")
+  update._check_install_status()
+  update._check_install_status()
+  update._check_install_status()
+  luaunit.assertEquals(update.stage, STAGE.INSTALLING)
+
+  update._check_install_status()
+  luaunit.assertTrue(norns.system_cmd.called())
+  norns.system_cmd.args(1)[2]("inactive\n")
+
+  luaunit.assertEquals(update.stage, STAGE.INSTALL_FAILED)
+  luaunit.assertEquals(update.failed_step, "timeout")
+end
+
+function TestUpdate.test_a_zero_byte_progress_file_is_not_progress()
+  update.stage = STAGE.INSTALLING
+  update.install_timeout_ticks = 2
+
+  write_progress("")
+  stall_until_systemd_replies("inactive\n")
+
+  luaunit.assertEquals(update.stage, STAGE.INSTALL_FAILED)
+  luaunit.assertEquals(update.failed_step, "timeout")
+end
+
+function TestUpdate.test_a_blank_progress_line_is_not_progress()
+  update.stage = STAGE.INSTALLING
+  update.install_timeout_ticks = 2
+
+  write_progress("\n")
+  stall_until_systemd_replies("inactive\n")
+
+  luaunit.assertEquals(update.stage, STAGE.INSTALL_FAILED)
+  luaunit.assertEquals(update.failed_step, "timeout")
+end
+
+function TestUpdate.test_a_marked_step_counts_as_progress_without_renaming()
+  update.stage = STAGE.INSTALLING
+  update.install_timeout_ticks = 2
+
+  write_progress("installing packages\n0\n")
+  update._check_install_status()
+  update._check_install_status()
+
+  write_progress("installing packages\n1\n")
+  update._check_install_status()
+  update._check_install_status()
+
+  luaunit.assertEquals(update.stage, STAGE.INSTALLING)
+  luaunit.assertEquals(update.message, "installing packages")
+  luaunit.assertFalse(norns.system_cmd.called())
+end
+
+function TestUpdate.test_dismiss_clears_status_and_returns_to_system()
+  write_status("failed:libnng")
+  update.stage = STAGE.INSTALL_FAILED
+  _menu.locked = true
+
+  update.key(3, 1)
+
+  luaunit.assertFalse(status_exists())
+  luaunit.assertFalse(_menu.locked)
+  luaunit.assertTrue(_menu.set_page.called())
+  luaunit.assertEquals(_menu.set_page.args(1)[1], "SYSTEM")
+  luaunit.assertTrue(_menu.timer.stop.called())
+  luaunit.assertTrue(_norns.execute.called())
+  luaunit.assertEquals(_norns.execute.args(1)[1], "sudo systemctl start norns-sclang.service")
+end
+
+function TestUpdate.test_checking_screen_dismisses_to_system()
+  update.stage = STAGE.CHECKING
+
+  update.key(2, 1)
+
+  luaunit.assertTrue(_menu.set_page.called())
+  luaunit.assertEquals(_menu.set_page.args(1)[1], "SYSTEM")
+end
+
+function TestUpdate.test_settled_message_dismisses_to_system()
+  update.stage = STAGE.MESSAGE
+
+  update.key(3, 1)
+
+  luaunit.assertTrue(_menu.set_page.called())
+  luaunit.assertEquals(_menu.set_page.args(1)[1], "SYSTEM")
+end
+
+function TestUpdate.test_key_release_does_not_commit()
+  write_status("failed:units")
+  update.stage = STAGE.INSTALL_FAILED
+  _menu.locked = true
+
+  update.key(3, 0)
+
+  luaunit.assertTrue(status_exists())
+  luaunit.assertTrue(_menu.locked)
+  luaunit.assertFalse(_menu.set_page.called())
+end
+
+function TestUpdate.test_stale_status_surfaced_on_init()
+  write_status("failed:postcheck")
+
+  update.init()
+
+  luaunit.assertEquals(update.stage, STAGE.INSTALL_FAILED)
+  luaunit.assertEquals(update.failed_step, "postcheck")
+  luaunit.assertFalse(_menu.timer.start.called())
+  luaunit.assertFalse(norns.system_cmd.called())
+end
+
+function TestUpdate.test_no_internet_settles_on_the_message_screen()
+  util.os_capture = function() return "ping: github.com: Temporary failure in name resolution" end
+
+  update.init()
+
+  luaunit.assertEquals(update.stage, STAGE.MESSAGE)
+  luaunit.assertEquals(update.message, "need internet.")
+  luaunit.assertFalse(norns.system_cmd.called())
+  luaunit.assertTrue(_menu.timer.stop.called())
+end
+
+function TestUpdate.test_full_disk_settles_on_the_message_screen()
+  norns.disk = 399
+
+  update.init()
+
+  luaunit.assertEquals(update.stage, STAGE.MESSAGE)
+  luaunit.assertEquals(update.message, "disk full. need 400M.")
+  luaunit.assertFalse(norns.system_cmd.called())
+  luaunit.assertTrue(_menu.timer.stop.called())
+end
+
+function TestUpdate.test_manifest_reply_settles_the_stage()
+  update.init()
+  luaunit.assertEquals(update.stage, STAGE.CHECKING)
+  luaunit.assertTrue(_menu.timer.start.called())
+
+  local reply = norns.system_cmd.args(1)[2]
+  reply("releases = { stable = { version = '260616' }, beta = { version = '260616' } }")
+
+  luaunit.assertEquals(update.stage, STAGE.CONFIRM)
+  luaunit.assertTrue(_menu.timer.stop.called())
+end
+
+function TestUpdate.test_an_up_to_date_norns_is_offered_nothing()
+  norns.version.update = "260616"
+  update.init()
+
+  norns.system_cmd.args(1)[2]("releases = { stable = { version = '260616' }, beta = { version = '260616' } }")
+
+  luaunit.assertEquals(update.stage, STAGE.MESSAGE)
+  luaunit.assertEquals(update.message, "up to date.")
+  luaunit.assertTrue(_menu.timer.stop.called())
+end
+
+function TestUpdate.test_alt_offers_a_channel_choice_even_when_up_to_date()
+  _menu.alt = true
+  norns.version.update = "260616"
+  update.init()
+
+  norns.system_cmd.args(1)[2]("releases = { stable = { version = '260616' }, beta = { version = '260617' } }")
+
+  luaunit.assertEquals(update.stage, STAGE.CONFIRM)
+end
+
+function TestUpdate.test_a_manifest_that_is_not_lua_settles_on_the_message_screen()
+  update.init()
+
+  norns.system_cmd.args(1)[2]("404: Not Found")
+
+  luaunit.assertEquals(update.stage, STAGE.MESSAGE)
+  luaunit.assertEquals(update.message, "check failed. try again.")
+  luaunit.assertTrue(_menu.timer.stop.called())
+end
+
+function TestUpdate.test_a_manifest_that_errors_when_run_settles_on_the_message_screen()
+  update.init()
+
+  norns.system_cmd.args(1)[2]("error('rate limited')")
+
+  luaunit.assertEquals(update.stage, STAGE.MESSAGE)
+  luaunit.assertEquals(update.message, "check failed. try again.")
+end
+
+function TestUpdate.test_an_empty_manifest_reply_settles_on_the_message_screen()
+  update.init()
+
+  norns.system_cmd.args(1)[2]("")
+
+  luaunit.assertEquals(update.stage, STAGE.MESSAGE)
+  luaunit.assertEquals(update.message, "check failed. try again.")
+end
+
+function TestUpdate.test_a_manifest_missing_a_channel_settles_on_the_message_screen()
+  update.init()
+
+  norns.system_cmd.args(1)[2]("releases = { stable = { version = '260616' } }")
+
+  luaunit.assertEquals(update.stage, STAGE.MESSAGE)
+  luaunit.assertEquals(update.message, "check failed. try again.")
+end
+
+function TestUpdate.test_a_bad_manifest_does_not_resurrect_an_earlier_one()
+  update.init()
+  norns.system_cmd.args(1)[2]("releases = { stable = { version = '260616' }, beta = { version = '260616' } }")
+  luaunit.assertEquals(update.stage, STAGE.CONFIRM)
+
+  update.deinit()
+  update.init()
+  norns.system_cmd.args(2)[2]("local x = 1")
+
+  luaunit.assertEquals(update.stage, STAGE.MESSAGE)
+  luaunit.assertEquals(update.message, "check failed. try again.")
+end
+
+function TestUpdate.test_confirm_shuts_down_audio_and_asks_update_sh_to_download()
+  releases = {
+    stable = { version = "260616", url = "http://example.com/bundle.tgz", sha = "http://example.com/bundle.sha256" },
+  }
+  update.install = "stable"
+  update.stage = STAGE.CONFIRM
+
+  update.key(3, 1)
+
+  luaunit.assertEquals(update.stage, STAGE.UPDATE)
+  luaunit.assertTrue(_menu.locked)
+  luaunit.assertTrue(norns.script.clear.called())
+  luaunit.assertTrue(_norns.cut_enable.called(6))
+  luaunit.assertEquals(_norns.cut_enable.args(1)[2], 0)
+  luaunit.assertTrue(_norns.execute.called())
+  luaunit.assertEquals(_norns.execute.args(1)[1], "sudo systemctl stop norns-sclang.service")
+  luaunit.assertEquals(norns.system_cmd.args(1)[1],
+    "/bin/bash /nonexistent/norns/update/update.sh download"
+      .. " http://example.com/bundle.tgz http://example.com/bundle.sha256")
+end
+
+function TestUpdate.test_late_manifest_reply_leaves_the_next_page_alone()
+  update.init()
+  local reply = norns.system_cmd.args(1)[2]
+
+  update.deinit()
+  _menu.timer.stop.reset()
+  _menu.redraw.reset()
+
+  reply("releases = { stable = { version = '260616' }, beta = { version = '260616' } }")
+
+  luaunit.assertFalse(_menu.timer.stop.called())
+  luaunit.assertFalse(_menu.redraw.called())
+  luaunit.assertEquals(update.stage, STAGE.CHECKING)
+end
+
+function TestUpdate.test_reply_from_a_previous_visit_loses_to_the_current_one()
+  update.init()
+  local stale_reply = norns.system_cmd.args(1)[2]
+
+  update.deinit()
+  update.init()
+  luaunit.assertEquals(update.stage, STAGE.CHECKING)
+  _menu.timer.stop.reset()
+
+  stale_reply("releases = { stable = { version = '260616' }, beta = { version = '260616' } }")
+  luaunit.assertEquals(update.stage, STAGE.CHECKING)
+  luaunit.assertFalse(_menu.timer.stop.called())
+
+  norns.system_cmd.args(2)[2]("releases = { stable = { version = '260616' }, beta = { version = '260616' } }")
+  luaunit.assertEquals(update.stage, STAGE.CONFIRM)
+end
+
+function TestUpdate.test_late_download_reply_leaves_the_next_page_alone()
+  releases = {
+    stable = { version = "260616", url = "http://example.com/bundle.tgz", sha = "http://example.com/bundle.sha256" },
+  }
+  update.install = "stable"
+  update.stage = STAGE.CONFIRM
+  update.key(3, 1)
+
+  local reply = norns.system_cmd.args(norns.system_cmd.call_count())[2]
+  update.deinit()
+  _menu.timer.stop.reset()
+  _menu.redraw.reset()
+
+  reply("download: ok\n")
+
+  luaunit.assertFalse(norns.system_update.called())
+  luaunit.assertNotEquals(update.stage, STAGE.INSTALLING)
+  luaunit.assertFalse(_menu.timer.stop.called())
+  luaunit.assertFalse(_menu.redraw.called())
+end
+
+function TestUpdate.test_failure_screen_names_the_failed_step()
+  update.stage = STAGE.INSTALL_FAILED
+  update.failed_step = "binary-swap"
+
+  update.redraw()
+
+  luaunit.assertStrContains(drawn_text(), "update failed")
+  luaunit.assertStrContains(drawn_text(), "binary-swap")
+  luaunit.assertStrContains(drawn_text(), "press any key")
+  luaunit.assertTrue(screen.update.called())
+end
+
+function TestUpdate.test_failure_screen_still_draws_without_a_step()
+  update.stage = STAGE.INSTALL_FAILED
+  update.failed_step = nil
+
+  update.redraw()
+
+  luaunit.assertStrContains(drawn_text(), "unknown")
+end
+
+function TestUpdate.test_late_systemd_reply_leaves_the_next_page_alone()
+  update.stage = STAGE.INSTALLING
+  update.install_timeout_ticks = 2
+
+  local reply = stall_until_systemd_is_asked()
+
+  update.deinit()
+  _menu.timer.stop.reset()
+  _menu.redraw.reset()
+
+  reply("inactive\n")
+
+  luaunit.assertNotEquals(update.stage, STAGE.INSTALL_FAILED)
+  luaunit.assertNotEquals(update.failed_step, "timeout")
+  luaunit.assertFalse(_menu.timer.stop.called())
+  luaunit.assertFalse(_menu.redraw.called())
+end

--- a/matron/src/event_types.h
+++ b/matron/src/event_types.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <stdbool.h>
 #include <stdint.h>
 #include <sys/types.h>
 
@@ -109,6 +110,8 @@ typedef enum {
     EVENT_TAPE_RECORD_FILE,
     EVENT_TAPE_PLAY_CLOSE,
     EVENT_TAPE_RECORD_CLOSE,
+    // detached system action launch result
+    EVENT_SYSTEM_CMD_DONE,
 } event_t;
 
 // a data structure for twelve volume levels
@@ -345,6 +348,13 @@ struct event_system_cmd {
     int cb_ref;
 }; // +8
 
+struct event_system_cmd_done {
+    struct event_common common;
+    char *err; // NULL on success
+    int cb_ref;
+    bool ok;
+}; // +9
+
 struct event_softcut_render {
     struct event_common common;
     int idx;
@@ -433,6 +443,7 @@ union event_data {
     struct event_crow_remove crow_remove;
     struct event_crow_event crow_event;
     struct event_system_cmd system_cmd;
+    struct event_system_cmd_done system_cmd_done;
     struct event_softcut_render softcut_render;
     struct event_softcut_position softcut_position;
     struct event_serial_config serial_config;

--- a/matron/src/events.cc
+++ b/matron/src/events.cc
@@ -131,6 +131,9 @@ MATRON_API void event_data_free(union event_data *ev) {
     case EVENT_SYSTEM_CMD:
         free(ev->system_cmd.capture);
         break;
+    case EVENT_SYSTEM_CMD_DONE:
+        free(ev->system_cmd_done.err);
+        break;
     case EVENT_SOFTCUT_RENDER:
         free(ev->softcut_render.data);
         break;
@@ -320,6 +323,9 @@ static void handle_event(union event_data *ev) {
         break;
     case EVENT_SYSTEM_CMD:
         w_handle_system_cmd(ev->system_cmd.capture, ev->system_cmd.cb_ref);
+        break;
+    case EVENT_SYSTEM_CMD_DONE:
+        w_handle_system_cmd_done(ev->system_cmd_done.ok, ev->system_cmd_done.err, ev->system_cmd_done.cb_ref);
         break;
     case EVENT_QUIT:
         quit = true;

--- a/matron/src/lua_shell.cc
+++ b/matron/src/lua_shell.cc
@@ -1,0 +1,302 @@
+// os.execute and io.popen run through the sidecar.
+
+// FIXME io.popen hands back a finished command rather than a live process, so
+// reads do not stream and an unbounded producer never returns. not fixable at
+// this layer, since the transport runs one command at a time.
+
+#include <stdlib.h>
+#include <string.h>
+
+#include <lauxlib.h>
+#include <lua.h>
+
+#include "system_cmd.h"
+
+#include "lua_shell.h"
+
+#define POPEN_HANDLE "norns.popen"
+
+static void print_capture(lua_State *l, const char *text) {
+    if (text == NULL || text[0] == '\0') {
+        return;
+    }
+
+    size_t len = strlen(text);
+    // print adds its own newline
+    if (text[len - 1] == '\n') {
+        len -= 1;
+    }
+
+    lua_getglobal(l, "print");
+    if (!lua_isfunction(l, -1)) {
+        lua_pop(l, 1);
+        return;
+    }
+
+    lua_pushlstring(l, text, len);
+    if (lua_pcall(l, 1, 0, 0) != LUA_OK) {
+        lua_pop(l, 1);
+    }
+}
+
+static int push_result(lua_State *l, const sidecar_status_t *status) {
+    if (status->result == SIDECAR_OK) {
+        lua_pushboolean(l, 1);
+        lua_pushliteral(l, "exit");
+        lua_pushinteger(l, 0);
+        return 3;
+    }
+
+    const bool ran = status->signalled || status->code != 0;
+
+    lua_pushnil(l);
+    lua_pushstring(l, ran && status->signalled ? "signal" : "exit");
+    lua_pushinteger(l, ran ? status->code : 1);
+    return 3;
+}
+
+static int _os_execute(lua_State *l) {
+    if (lua_isnoneornil(l, 1)) {
+        lua_pushboolean(l, 1);
+        return 1;
+    }
+
+    const char *cmd = luaL_checkstring(l, 1);
+
+    char *capture = NULL;
+    size_t size = 0;
+    sidecar_status_t status = {};
+    system_cmd_sync(cmd, &capture, &size, &status, SIDECAR_CMD_TIMEOUT_NONE);
+
+    print_capture(l, capture);
+    free(capture);
+
+    return push_result(l, &status);
+}
+
+typedef struct {
+    char *buf;
+    size_t len;
+    size_t pos;
+    sidecar_status_t status;
+    bool closed;
+} popen_handle_t;
+
+static popen_handle_t *check_open_handle(lua_State *l) {
+    popen_handle_t *h = (popen_handle_t *)luaL_checkudata(l, 1, POPEN_HANDLE);
+    if (h->closed) {
+        luaL_error(l, "attempt to use a closed file");
+    }
+    return h;
+}
+
+static size_t remaining(const popen_handle_t *h) {
+    return h->len - h->pos;
+}
+
+static void read_line(lua_State *l, popen_handle_t *h, bool keep_newline) {
+    if (remaining(h) == 0) {
+        lua_pushnil(l);
+        return;
+    }
+
+    const char *from = h->buf + h->pos;
+    const char *nl = (const char *)memchr(from, '\n', remaining(h));
+    const size_t taken = nl != NULL ? (size_t)(nl - from) + 1 : remaining(h);
+    const size_t pushed = (nl != NULL && !keep_newline) ? taken - 1 : taken;
+
+    lua_pushlstring(l, from, pushed);
+    h->pos += taken;
+}
+
+static void read_count(lua_State *l, popen_handle_t *h, size_t want) {
+    if (want == 0) {
+        if (remaining(h) == 0) {
+            lua_pushnil(l);
+        } else {
+            lua_pushliteral(l, "");
+        }
+        return;
+    }
+
+    if (remaining(h) == 0) {
+        lua_pushnil(l);
+        return;
+    }
+
+    const size_t taken = want < remaining(h) ? want : remaining(h);
+    lua_pushlstring(l, h->buf + h->pos, taken);
+    h->pos += taken;
+}
+
+static void read_number(lua_State *l, popen_handle_t *h) {
+    const char *from = h->buf + h->pos;
+    char *end = NULL;
+    const double v = strtod(from, &end);
+    if (end == from) {
+        lua_pushnil(l);
+        return;
+    }
+    lua_pushnumber(l, (lua_Number)v);
+    h->pos += (size_t)(end - from);
+}
+
+static void read_format(lua_State *l, popen_handle_t *h, int index) {
+    if (lua_isnumber(l, index)) {
+        read_count(l, h, (size_t)lua_tointeger(l, index));
+        return;
+    }
+
+    const char *fmt = luaL_checkstring(l, index);
+    if (*fmt == '*') {
+        fmt++;
+    }
+
+    switch (*fmt) {
+    case 'a':
+        lua_pushlstring(l, h->buf + h->pos, remaining(h));
+        h->pos = h->len;
+        break;
+    case 'l':
+        read_line(l, h, false);
+        break;
+    case 'L':
+        read_line(l, h, true);
+        break;
+    case 'n':
+        read_number(l, h);
+        break;
+    default:
+        luaL_argerror(l, index, "invalid format");
+    }
+}
+
+static int _popen_read(lua_State *l) {
+    popen_handle_t *h = check_open_handle(l);
+
+    const int args = lua_gettop(l) - 1;
+    if (args == 0) {
+        read_line(l, h, false);
+        return 1;
+    }
+
+    for (int i = 0; i < args; ++i) {
+        read_format(l, h, i + 2);
+    }
+    return args;
+}
+
+static int _popen_lines_iter(lua_State *l) {
+    popen_handle_t *h = (popen_handle_t *)lua_touserdata(l, lua_upvalueindex(1));
+    if (h->closed) {
+        return luaL_error(l, "attempt to use a closed file");
+    }
+    read_line(l, h, false);
+    return 1;
+}
+
+static int _popen_lines(lua_State *l) {
+    check_open_handle(l);
+    lua_pushvalue(l, 1);
+    lua_pushcclosure(l, _popen_lines_iter, 1);
+    return 1;
+}
+
+static void handle_release(popen_handle_t *h) {
+    free(h->buf);
+    h->buf = NULL;
+    h->len = 0;
+    h->pos = 0;
+}
+
+static int _popen_close(lua_State *l) {
+    popen_handle_t *h = check_open_handle(l);
+    h->closed = true;
+    handle_release(h);
+    return push_result(l, &h->status);
+}
+
+static int _popen_gc(lua_State *l) {
+    popen_handle_t *h = (popen_handle_t *)luaL_checkudata(l, 1, POPEN_HANDLE);
+    handle_release(h);
+    return 0;
+}
+
+static int _popen_tostring(lua_State *l) {
+    popen_handle_t *h = (popen_handle_t *)luaL_checkudata(l, 1, POPEN_HANDLE);
+    lua_pushfstring(l, h->closed ? "file (closed)" : "file (%p)", (void *)h);
+    return 1;
+}
+
+static int _io_popen(lua_State *l) {
+    const char *cmd = luaL_checkstring(l, 1);
+    const char *mode = luaL_optstring(l, 2, "r");
+
+    // fail on "w" mode, there is no live process to write to
+    // see the FIXME at the top of this file
+    if (strcmp(mode, "w") == 0) {
+        return luaL_error(l, "io.popen: write mode is not supported on norns at this time.");
+    }
+
+    if (strcmp(mode, "r") != 0) {
+        return luaL_error(l, "io.popen: mode must be 'r' or 'w', got '%s'", mode);
+    }
+
+    char *capture = NULL;
+    size_t size = 0;
+    sidecar_status_t status = {};
+    system_cmd_sync(cmd, &capture, &size, &status, SIDECAR_CMD_TIMEOUT_NONE);
+
+    popen_handle_t *h = (popen_handle_t *)lua_newuserdata(l, sizeof(popen_handle_t));
+    h->buf = capture;
+    // size counts the terminator, which is not part of the output
+    h->len = capture != NULL && size > 0 ? size - 1 : 0;
+    h->pos = 0;
+    h->status = status;
+    h->status.err = NULL;
+    h->closed = false;
+
+    luaL_getmetatable(l, POPEN_HANDLE);
+    lua_setmetatable(l, -2);
+    return 1;
+}
+
+static void register_popen_handle(lua_State *l) {
+    static const luaL_Reg methods[] = {
+        {"read", _popen_read},
+        {"lines", _popen_lines},
+        {"close", _popen_close},
+        {NULL, NULL},
+    };
+
+    luaL_newmetatable(l, POPEN_HANDLE);
+
+    lua_pushcfunction(l, _popen_gc);
+    lua_setfield(l, -2, "__gc");
+    lua_pushcfunction(l, _popen_tostring);
+    lua_setfield(l, -2, "__tostring");
+
+    lua_newtable(l);
+    luaL_setfuncs(l, methods, 0);
+    lua_setfield(l, -2, "__index");
+
+    lua_pop(l, 1);
+}
+
+void lua_shell_install(lua_State *l) {
+    register_popen_handle(l);
+
+    lua_getglobal(l, "os");
+    if (lua_istable(l, -1)) {
+        lua_pushcfunction(l, _os_execute);
+        lua_setfield(l, -2, "execute");
+    }
+    lua_pop(l, 1);
+
+    lua_getglobal(l, "io");
+    if (lua_istable(l, -1)) {
+        lua_pushcfunction(l, _io_popen);
+        lua_setfield(l, -2, "popen");
+    }
+    lua_pop(l, 1);
+}

--- a/matron/src/lua_shell.h
+++ b/matron/src/lua_shell.h
@@ -1,0 +1,5 @@
+#pragma once
+
+struct lua_State;
+
+extern void lua_shell_install(lua_State *l);

--- a/matron/src/system_cmd.cc
+++ b/matron/src/system_cmd.cc
@@ -1,38 +1,147 @@
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 #include "events.h"
 #include "sidecar.h"
 
+#include "system_cmd.h"
+
 //----------------------------
 //--- types and variables
 
-static void post_command_capture(const char *cmd, void *ctx, const char *response_buff, size_t response_size) {
-    int cb_ref = (int)ctx;
+#ifdef NORNS_TEST
+void *(*system_cmd_test_realloc)(void *, size_t) = realloc;
+#define CAPTURE_REALLOC system_cmd_test_realloc
+#else
+#define CAPTURE_REALLOC realloc
+#endif
 
-    if (response_size == 0) {
-        // FIXME the settings password change passes a plaintext password
-        // through here, and stderr reaches the journal and maiden.
-        fprintf(stderr, "system_cmd: command (%s) failed\n", cmd);
-        response_buff = "";
-        response_size = 1;
+// accumulated command output, capped at SYSTEM_CMD_CAPTURE_MAX
+typedef struct {
+    char *buf;
+    size_t len;
+    bool failed;
+    bool truncated;
+    int cb_ref;              // unused on the sync path
+    sidecar_status_t status; // sync path only
+} capture_t;
+
+static void capture_append(void *ctx, const char *chunk, size_t size) {
+    capture_t *cap = (capture_t *)ctx;
+    if (cap->truncated) {
+        return;
+    }
+    if (size > SYSTEM_CMD_CAPTURE_MAX - cap->len) {
+        size = SYSTEM_CMD_CAPTURE_MAX - cap->len;
+        cap->truncated = true;
+        fprintf(stderr, "system_cmd: output exceeded cap, truncating\n");
+    }
+    if (size == 0) {
+        return;
+    }
+    char *grown = (char *)CAPTURE_REALLOC(cap->buf, cap->len + size);
+    if (grown == NULL) {
+        cap->truncated = true;
+        fprintf(stderr, "system_cmd: out of memory, truncating\n");
+        return;
+    }
+    memcpy(grown + cap->len, chunk, size);
+    cap->buf = grown;
+    cap->len += size;
+}
+
+static void capture_discard_on_transport_failure(capture_t *cap, sidecar_result_t result) {
+    if (result != SIDECAR_TRANSPORT_FAILED) {
+        return;
+    }
+    cap->failed = true;
+    free(cap->buf);
+    cap->buf = NULL;
+    cap->len = 0;
+}
+
+static void capture_null_terminate(capture_t *cap) {
+    char *out = (char *)CAPTURE_REALLOC(cap->buf, cap->len + 1);
+    if (out == NULL) {
+        fprintf(stderr, "system_cmd: out of memory, dropping output\n");
+        free(cap->buf);
+        cap->truncated = true;
+        cap->len = 0;
+        out = (char *)calloc(1, 1);
+        if (out == NULL) {
+            cap->buf = NULL;
+            return;
+        }
+    }
+    out[cap->len] = '\0';
+    cap->buf = out;
+    cap->len += 1;
+}
+
+// FIXME the settings password change passes a plaintext password through here,
+// and stderr reaches the journal and maiden. fixing it needs a way to pass a
+// secret on stdin rather than in the command string
+static void log_cmd_failure(const char *label, const char *cmd, const char *err) {
+    fprintf(stderr, "%s: command (%s) failed: %s\n", label, cmd != NULL ? cmd : "", err != NULL ? err : "unknown error");
+}
+
+static void post_cmd_done(const char *cmd, void *ctx, const sidecar_status_t *status) {
+    capture_t *cap = (capture_t *)ctx;
+    capture_discard_on_transport_failure(cap, status->result);
+
+    if (status->result == SIDECAR_TRANSPORT_FAILED) {
+        log_cmd_failure("system_cmd", cmd, status->err);
     }
 
-    // response buffer is only valid during the callback so it is copied so that
-    // it is valid for the lifetime of the event
-    char *capture = (char *)malloc(response_size);
-    memcpy(capture, response_buff, response_size);
-
+    // FIXME failure and silent success both arrive as "". telling them apart
+    // needs an extra callback argument, which changes the signature every
+    // script's norns.system_cmd callback is written against
+    capture_null_terminate(cap);
     union event_data *ev = event_data_new(EVENT_SYSTEM_CMD);
-    // this will get freed when the event is handled
-    ev->system_cmd.capture = capture;
-    ev->system_cmd.cb_ref = cb_ref;
+    ev->system_cmd.capture = cap->buf; // freed when the event is handled
+    ev->system_cmd.cb_ref = cap->cb_ref;
     event_post(ev);
+    free(cap);
+}
+
+static void finish_sync_capture(const char *cmd, void *ctx, const sidecar_status_t *status) {
+    (void)cmd;
+    capture_t *cap = (capture_t *)ctx;
+    capture_discard_on_transport_failure(cap, status->result);
+    cap->status = *status;
+    cap->status.err = NULL;
 }
 
 //-------------------------------
 //-- extern function definitions
 
 bool system_cmd(const char *cmd, int cb_ref) {
-    return sidecar_client_cmd_async(cmd, (void *)cb_ref, post_command_capture);
+    capture_t *cap = (capture_t *)calloc(1, sizeof(capture_t));
+    if (cap == NULL) {
+        return false;
+    }
+    cap->cb_ref = cb_ref;
+    if (!sidecar_client_cmd_async(cmd, SIDECAR_CMD_TIMEOUT_DEFAULT_MS, cap, capture_append, post_cmd_done)) {
+        free(cap);
+        return false;
+    }
+    return true;
+}
+
+bool system_cmd_sync(const char *cmd, char **out, size_t *size, sidecar_status_t *status, uint32_t timeout_ms) {
+    capture_t cap = {};
+    sidecar_client_cmd(cmd, timeout_ms, &cap, capture_append, finish_sync_capture);
+    if (status != NULL) {
+        *status = cap.status;
+    }
+    if (cap.failed) {
+        *out = NULL;
+        *size = 0;
+        return false;
+    }
+    capture_null_terminate(&cap);
+    *out = cap.buf;
+    *size = cap.len;
+    return true;
 }

--- a/matron/src/system_cmd.cc
+++ b/matron/src/system_cmd.cc
@@ -1,3 +1,4 @@
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -113,6 +114,48 @@ static void finish_sync_capture(const char *cmd, void *ctx, const sidecar_status
     cap->status.err = NULL;
 }
 
+static void post_launch_done(const char *cmd, void *ctx, const sidecar_status_t *status) {
+    const int cb_ref = (int)(intptr_t)ctx;
+    const bool ok = (status->result == SIDECAR_OK);
+    const char *err = status->err;
+
+    if (status->result == SIDECAR_TRANSPORT_FAILED) {
+        err = "no answer from the sidecar, the action may still have started";
+    }
+
+    if (!ok) {
+        log_cmd_failure("system_cmd_detached", cmd, err);
+    }
+
+    union event_data *ev = event_data_new(EVENT_SYSTEM_CMD_DONE);
+    if (err != NULL) {
+        ev->system_cmd_done.err = strdup(err);
+    }
+    ev->system_cmd_done.cb_ref = cb_ref;
+    ev->system_cmd_done.ok = ok;
+    event_post(ev);
+}
+
+typedef struct {
+    const char *name;
+    const char *cmd;
+    const char *unit;
+} system_action_t;
+
+static const system_action_t system_actions[] = {
+    {"shutdown", "sleep 0.5; sudo shutdown now", "norns-shutdown"},
+    {"reset", "sudo systemctl restart norns-sclang.service norns-main.service", "norns-reset"},
+    {"update", NULL, "norns-update"},
+};
+
+static void build_update_cmd(char *buf, size_t len) {
+    const char *home = getenv("HOME");
+    if (home == NULL || home[0] == '\0') {
+        home = "/home/we";
+    }
+    snprintf(buf, len, "/bin/bash %s/norns/update/update.sh", home);
+}
+
 //-------------------------------
 //-- extern function definitions
 
@@ -144,4 +187,25 @@ bool system_cmd_sync(const char *cmd, char **out, size_t *size, sidecar_status_t
     *out = cap.buf;
     *size = cap.len;
     return true;
+}
+
+bool system_cmd_detached(const char *cmd, const char *unit, int cb_ref) {
+    return sidecar_client_detach_async(cmd, unit, (void *)(intptr_t)cb_ref, post_launch_done);
+}
+
+bool system_action(const char *action, int cb_ref) {
+    for (size_t i = 0; i < sizeof(system_actions) / sizeof(system_actions[0]); ++i) {
+        const system_action_t *a = &system_actions[i];
+        if (strcmp(a->name, action) != 0) {
+            continue;
+        }
+        if (a->cmd != NULL) {
+            return system_cmd_detached(a->cmd, a->unit, cb_ref);
+        }
+        char cmd[512];
+        build_update_cmd(cmd, sizeof(cmd));
+        return system_cmd_detached(cmd, a->unit, cb_ref);
+    }
+    fprintf(stderr, "system_action: unknown action (%s)\n", action);
+    return false;
 }

--- a/matron/src/system_cmd.h
+++ b/matron/src/system_cmd.h
@@ -9,6 +9,8 @@
 
 extern bool system_cmd(const char *cmd, int ref);
 extern bool system_cmd_sync(const char *cmd, char **out, size_t *size, sidecar_status_t *status = NULL, uint32_t timeout_ms = SIDECAR_CMD_TIMEOUT_DEFAULT_MS);
+extern bool system_cmd_detached(const char *cmd, const char *unit, int ref);
+extern bool system_action(const char *action, int ref);
 
 #ifdef NORNS_TEST
 extern void *(*system_cmd_test_realloc)(void *, size_t);

--- a/matron/src/system_cmd.h
+++ b/matron/src/system_cmd.h
@@ -1,5 +1,15 @@
 #pragma once
 
+#include <stddef.h>
 #include <stdint.h>
 
+#include "sidecar.h"
+
+#define SYSTEM_CMD_CAPTURE_MAX (1024 * 1024)
+
 extern bool system_cmd(const char *cmd, int ref);
+extern bool system_cmd_sync(const char *cmd, char **out, size_t *size, sidecar_status_t *status = NULL, uint32_t timeout_ms = SIDECAR_CMD_TIMEOUT_DEFAULT_MS);
+
+#ifdef NORNS_TEST
+extern void *(*system_cmd_test_realloc)(void *, size_t);
+#endif

--- a/matron/src/weaver.cc
+++ b/matron/src/weaver.cc
@@ -13,7 +13,6 @@
 // linux / posix
 #include <glob.h>
 #include <pthread.h>
-#include <signal.h>
 #include <sys/time.h>
 #include <unistd.h>
 
@@ -296,11 +295,11 @@ static int _sound_file_inspect(lua_State *l);
 // util
 /// run command in child process asynchronously (with callback)
 static int _system_cmd(lua_State *l);
+/// launch a named system action detached in a transient systemd unit
+static int _system_action(lua_State *l);
 static int _system_glob(lua_State *l);
 /// run command in child process, blocking (replaces `os.execute`)
 static int _execute(lua_State *l);
-/// self-terminate the process (for systemd restart)
-static int _terminate(lua_State *l);
 
 // clock
 static int _clock_schedule_sleep(lua_State *l);
@@ -497,9 +496,9 @@ void w_init(void) {
 
     // util
     lua_register_norns("system_cmd", &_system_cmd);
+    lua_register_norns("system_action", &_system_action);
     lua_register_norns("system_glob", &_system_glob);
     lua_register_norns("execute", &_execute);
-    lua_register_norns("terminate", &_terminate);
 
     // low-level monome grid control
     lua_register_norns("grid_set_led", &_grid_set_led);
@@ -2897,6 +2896,21 @@ void w_handle_system_cmd(char *capture, const int cb_ref) {
     luaL_unref(lvm, LUA_REGISTRYINDEX, cb_ref);
 }
 
+// handle detached system action launch result. ok reports the launch, not how
+// the action ended
+void w_handle_system_cmd_done(bool ok, char *err, const int cb_ref) {
+    lua_rawgeti(lvm, LUA_REGISTRYINDEX, cb_ref);
+    lua_pushboolean(lvm, ok);
+    if (err != NULL) {
+        lua_pushstring(lvm, err);
+    } else {
+        lua_pushnil(lvm);
+    }
+    l_report(lvm, l_docall(lvm, 2, 0));
+    // free the callback ref created in _system_action
+    luaL_unref(lvm, LUA_REGISTRYINDEX, cb_ref);
+}
+
 void w_handle_screen_refresh() {
     lua_getglobal(lvm, "refresh");
     l_report(lvm, l_docall(lvm, 0, 0));
@@ -3468,6 +3482,20 @@ int _system_cmd(lua_State *l) {
     return 1;
 }
 
+int _system_action(lua_State *l) {
+    lua_check_num_args(2);
+    const char *action = luaL_checkstring(l, 1);
+    // create a ref to callback to prevent garbage collection
+    const int cb_ref = luaL_ref(l, LUA_REGISTRYINDEX);
+    bool ok = system_action(action, cb_ref);
+    if (!ok) {
+        // unknown action, so no event will fire. free the ref here
+        luaL_unref(l, LUA_REGISTRYINDEX, cb_ref);
+    }
+    lua_pushboolean(l, ok);
+    return 1;
+}
+
 int _system_glob(lua_State *l) {
     lua_check_num_args(1);
     const char *pattern = luaL_checkstring(l, 1);
@@ -3504,13 +3532,6 @@ int _execute(lua_State *l) {
     lua_pushstring(l, capture ? capture : "");
     free(capture);
     return 1;
-}
-
-int _terminate(lua_State *l) {
-    lua_check_num_args(0);
-    fprintf(stderr, "norns: self-terminating for restart\n");
-    raise(SIGTERM);
-    return 0;
 }
 
 int _platform(lua_State *l) {

--- a/matron/src/weaver.cc
+++ b/matron/src/weaver.cc
@@ -40,6 +40,7 @@
 #include "i2c.h"
 #include "jack_client.h"
 #include "lua_eval.h"
+#include "lua_shell.h"
 #include "metro.h"
 #include "oracle.h"
 #include "osc.h"
@@ -404,6 +405,7 @@ void w_init(void) {
     lvm = luaL_newstate();
     luaL_openlibs(lvm);
     lua_pcall(lvm, 0, 0, 0);
+    lua_shell_install(lvm);
 
     // initialize embedded third-party modules
     lua_register_cjson();

--- a/matron/src/weaver.cc
+++ b/matron/src/weaver.cc
@@ -48,7 +48,6 @@
 #include "screen.h"
 #include "screen_events.h"
 #include "screen_results.h"
-#include "sidecar.h"
 #include "snd_file.h"
 #include "system_cmd.h"
 #include "time_since.h"
@@ -2892,7 +2891,7 @@ void w_handle_softcut_position(int idx, float pos) {
 // handle system command capture
 void w_handle_system_cmd(char *capture, const int cb_ref) {
     lua_rawgeti(lvm, LUA_REGISTRYINDEX, cb_ref);
-    lua_pushstring(lvm, capture);
+    lua_pushstring(lvm, capture != NULL ? capture : "");
     l_report(lvm, l_docall(lvm, 1, 0));
     // free the callback ref created in _system_cmd
     luaL_unref(lvm, LUA_REGISTRYINDEX, cb_ref);
@@ -3460,7 +3459,12 @@ int _system_cmd(lua_State *l) {
     const char *cmd = luaL_checkstring(l, 1);
     // create a ref to callback to prevent prevent garbage collection
     const int cb_ref = luaL_ref(l, LUA_REGISTRYINDEX);
-    lua_pushboolean(l, system_cmd(cmd, cb_ref));
+    bool ok = system_cmd(cmd, cb_ref);
+    if (!ok) {
+        // no event will fire, so free the ref here
+        luaL_unref(l, LUA_REGISTRYINDEX, cb_ref);
+    }
+    lua_pushboolean(l, ok);
     return 1;
 }
 
@@ -3491,14 +3495,14 @@ int _system_glob(lua_State *l) {
     return 1;
 }
 
-static void _execute_completion(const char *cmd, void *ctx, const char *buf, size_t size) {
-    lua_pushstring((lua_State *)ctx, buf != NULL ? buf : "");
-}
-
 int _execute(lua_State *l) {
     lua_check_num_args(1);
     const char *cmd = luaL_checkstring(l, 1);
-    sidecar_client_cmd(cmd, l, _execute_completion);
+    char *capture = NULL;
+    size_t size = 0;
+    system_cmd_sync(cmd, &capture, &size);
+    lua_pushstring(l, capture ? capture : "");
+    free(capture);
     return 1;
 }
 

--- a/matron/src/weaver.h
+++ b/matron/src/weaver.h
@@ -101,6 +101,7 @@ extern void w_handle_startup_ready_timeout();
 
 // util callbacks
 extern void w_handle_system_cmd(char *capture, int cb_ref);
+extern void w_handle_system_cmd_done(bool ok, char *err, int cb_ref);
 
 // display driver callbacks
 extern void w_handle_screen_refresh();

--- a/norns/main.cpp
+++ b/norns/main.cpp
@@ -13,6 +13,13 @@
 #include "sidecar.h"
 
 int main(int argc, char **argv) {
+    // update.sh gates the final reboot on this. exiting 0 before any
+    // fork/jack/hardware init proves the new binary links
+    if (argc > 1 && strcmp(argv[1], "--check") == 0) {
+        printf("norns: --check ok\n");
+        return 0;
+    }
+
     int exec_name_size = strlen(argv[0]);
 
     int sync_pipe[2];

--- a/norns/sidecar.cpp
+++ b/norns/sidecar.cpp
@@ -1,6 +1,8 @@
 #include <assert.h>
 #include <errno.h>
+#include <grp.h>
 #include <pthread.h>
+#include <pwd.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -28,6 +30,8 @@ static const char *quit_cmd = "__quit__";
 #define SIDECAR_CLIENT_SENDTIMEO_MS 10000   // 10 s
 #define SIDECAR_SERVER_SENDTIMEO_MS 10000   // 10 s
 
+// bounds the error text captured from a failed launch
+#define SIDECAR_DETACH_OUTPUT_BYTES 4096
 // bounds what matron will buffer for one command, the server itself streams
 #define SIDECAR_CMD_MAX_OUTPUT_BYTES (1024 * 1024)
 // how long a dying command gets to run its cleanup traps before SIGKILL
@@ -78,6 +82,15 @@ static nng_msg *frame_build_cmd(uint8_t req_id, uint32_t timeout_ms, const char 
     return msg;
 }
 
+static nng_msg *frame_build_detach(uint8_t req_id, const char *unit, const char *cmd) {
+    size_t n = sidecar_msg_encode_detach(NULL, 0, req_id, unit, cmd);
+    nng_msg *msg = frame_alloc(n);
+    if (msg != NULL) {
+        sidecar_msg_encode_detach((uint8_t *)nng_msg_body(msg), n, req_id, unit, cmd);
+    }
+    return msg;
+}
+
 static int frame_send_chunk(nng_socket sock, uint8_t req_id, const char *payload, size_t len) {
     size_t n = sidecar_msg_encode_chunk(NULL, 0, req_id, payload, len);
     nng_msg *msg = frame_alloc(n);
@@ -112,6 +125,7 @@ static void frame_send_error(nng_socket sock, uint8_t req_id, const char *text) 
 typedef enum {
     REQUEST_FIRST_REQUEST = 0,
     REQUEST_CMD,
+    REQUEST_DETACH,
     REQUEST_QUIT,
 } request_type_t;
 
@@ -128,9 +142,18 @@ struct request_cmd {
     sidecar_done_cb_t on_done;
 };
 
+struct request_detach {
+    struct request_common common;
+    char *cmd;
+    char *unit;
+    void *ctx;
+    sidecar_done_cb_t on_done;
+};
+
 union request {
     request_type_t type;
     struct request_cmd cmd;
+    struct request_detach detach;
 };
 
 static moodycamel::BlockingConcurrentQueue<union request *> requests(32);
@@ -262,6 +285,107 @@ static void sidecar_server_stream_cmd(nng_socket sock, const char *cmd, uint8_t 
     }
 }
 
+static void sidecar_server_detach_cmd(nng_socket sock, const char *unit, const char *cmd, uint8_t req_id) {
+    char unit_arg[128];
+    char user_prop[96];
+    char group_prop[96];
+
+    if ((size_t)snprintf(unit_arg, sizeof(unit_arg), "--unit=%s", unit) >= sizeof(unit_arg)) {
+        frame_send_error(sock, req_id, "unit name too long");
+        return;
+    }
+
+    struct passwd *pw = getpwuid(getuid());
+    if (pw != NULL) {
+        snprintf(user_prop, sizeof(user_prop), "User=%s", pw->pw_name);
+    } else {
+        snprintf(user_prop, sizeof(user_prop), "User=%u", (unsigned)getuid());
+    }
+    struct group *gr = getgrgid(getgid());
+    if (gr != NULL) {
+        snprintf(group_prop, sizeof(group_prop), "Group=%s", gr->gr_name);
+    } else {
+        snprintf(group_prop, sizeof(group_prop), "Group=%u", (unsigned)getgid());
+    }
+
+    const char *argv[] = {
+        "/usr/bin/sudo", "-n", "/usr/bin/env", "SYSTEMD_LOG_COLOR=0",
+        "systemd-run", "--no-block", "--collect", unit_arg,
+        "-p", user_prop, "-p", group_prop, "--service-type=oneshot",
+        "/bin/sh", "-c", cmd, NULL};
+
+    int fds[2];
+    if (pipe(fds) != 0) {
+        frame_send_error(sock, req_id, "pipe() failed");
+        return;
+    }
+
+    pid_t pid = fork();
+    if (pid < 0) {
+        close(fds[0]);
+        close(fds[1]);
+        frame_send_error(sock, req_id, "fork() failed");
+        return;
+    }
+
+    if (pid == 0) {
+        dup2(fds[1], STDOUT_FILENO);
+        dup2(fds[1], STDERR_FILENO);
+        close(fds[0]);
+        close(fds[1]);
+        execv(argv[0], (char *const *)argv);
+        fprintf(stderr, "exec of %s failed\n", argv[0]); // reaches the pipe
+        _exit(127);
+    }
+
+    close(fds[1]);
+    char output[SIDECAR_DETACH_OUTPUT_BYTES];
+    size_t out_len = 0;
+    for (;;) {
+        char scrap[256];
+        bool full = out_len >= sizeof(output) - 1;
+        ssize_t n = read(fds[0],
+                         full ? scrap : output + out_len,
+                         full ? sizeof(scrap) : sizeof(output) - 1 - out_len);
+        if (n < 0 && errno == EINTR) {
+            continue;
+        }
+        if (n <= 0) {
+            break;
+        }
+        if (!full) {
+            out_len += (size_t)n;
+        }
+    }
+    close(fds[0]);
+    output[out_len] = '\0';
+
+    int status = 0;
+    pid_t waited;
+    do {
+        waited = waitpid(pid, &status, 0);
+    } while (waited < 0 && errno == EINTR);
+    if (waited < 0) {
+        frame_send_error(sock, req_id, "waitpid() failed");
+        return;
+    }
+
+    if (WIFEXITED(status) && WEXITSTATUS(status) == 0) {
+        frame_send_end(sock, req_id, false, 0);
+        return;
+    }
+
+    fprintf(stderr, "sidecar: detach failed for unit %s\n", unit);
+    if (out_len == 0) {
+        if (WIFEXITED(status)) {
+            snprintf(output, sizeof(output), "systemd-run exit status %d", WEXITSTATUS(status));
+        } else {
+            snprintf(output, sizeof(output), "systemd-run killed by signal %d", WTERMSIG(status));
+        }
+    }
+    frame_send_error(sock, req_id, output);
+}
+
 int sidecar_server_main(int sync_fd) {
     nng_socket sock;
     nng_listener listener;
@@ -331,6 +455,10 @@ int sidecar_server_main(int sync_fd) {
 
             sidecar_server_stream_cmd(sock, cmd, req_id, timeout_ms);
             free(cmd);
+
+        } else if (frame.type == SIDECAR_MSG_DETACH) {
+            sidecar_server_detach_cmd(sock, frame.unit, frame.cmd, frame.req_id);
+            nng_msg_free(msg);
 
         } else {
             fprintf(stderr, "sidecar: unexpected msg type 0x%02x from client\n", (unsigned)frame.type);
@@ -454,7 +582,7 @@ static void transaction_send_recv(nng_msg *req, uint8_t req_id, const char *cmd,
             return;
 
         } else if (frame.type == SIDECAR_MSG_ERROR) {
-            char err_text[4096];
+            char err_text[SIDECAR_DETACH_OUTPUT_BYTES];
             snprintf(err_text, sizeof(err_text), "%s", frame.payload_len > 0 ? frame.payload : "unknown error");
             nng_msg_free(msg);
             const sidecar_status_t status = {SIDECAR_CMD_FAILED, false, 0, err_text};
@@ -489,11 +617,31 @@ static void cmd_transaction(const char *cmd, uint32_t timeout_ms, void *ctx, sid
     transaction_send_recv(req, req_id, cmd, ctx, on_chunk, on_done);
 }
 
+static void detach_transaction(const char *cmd, const char *unit, void *ctx, sidecar_done_cb_t on_done) {
+    transport_lock();
+    uint8_t req_id = ++next_req_id;
+
+    nng_msg *req = frame_build_detach(req_id, unit, cmd);
+    if (req == NULL) {
+        fprintf(stderr, "sidecar: failed to build DETACH frame\n");
+        transaction_out_of_memory(cmd, ctx, on_done);
+        return;
+    }
+
+    client_apply_recv_timeout(SIDECAR_CMD_TIMEOUT_DEFAULT_MS);
+    transaction_send_recv(req, req_id, cmd, ctx, NULL, on_done);
+}
+
 static void handle_request(union request *req) {
     switch (req->type) {
     case REQUEST_CMD:
         cmd_transaction(req->cmd.cmd, req->cmd.timeout_ms, req->cmd.ctx, req->cmd.on_chunk, req->cmd.on_done);
         free(req->cmd.cmd);
+        break;
+    case REQUEST_DETACH:
+        detach_transaction(req->detach.cmd, req->detach.unit, req->detach.ctx, req->detach.on_done);
+        free(req->detach.cmd);
+        free(req->detach.unit);
         break;
     default:
         fprintf(stderr, "sidecar: unhandled request type %d\n", req->type);
@@ -600,6 +748,25 @@ bool sidecar_client_cmd_async(const char *cmd, uint32_t timeout_ms, void *ctx, s
     req->cmd.ctx = ctx;
     req->cmd.on_chunk = on_chunk;
     req->cmd.on_done = on_done;
+    request_post(req);
+    return true;
+}
+
+bool sidecar_client_detach_async(const char *cmd, const char *unit, void *ctx, sidecar_done_cb_t on_done) {
+    union request *req = request_new(REQUEST_DETACH);
+    if (req == NULL) {
+        return false;
+    }
+    req->detach.cmd = REQUEST_STRDUP(cmd);
+    req->detach.unit = REQUEST_STRDUP(unit);
+    if (req->detach.cmd == NULL || req->detach.unit == NULL) {
+        free(req->detach.cmd);
+        free(req->detach.unit);
+        free(req);
+        return false;
+    }
+    req->detach.ctx = ctx;
+    req->detach.on_done = on_done;
     request_post(req);
     return true;
 }

--- a/norns/sidecar.cpp
+++ b/norns/sidecar.cpp
@@ -1,25 +1,109 @@
 #include <assert.h>
+#include <errno.h>
 #include <pthread.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/wait.h>
 #include <unistd.h>
 
 #include <nng/nng.h>
-#include <nng/protocol/reqrep0/rep.h>
-#include <nng/protocol/reqrep0/req.h>
+#include <nng/protocol/pair1/pair.h>
 #include <nng/transport/ipc/ipc.h>
 
 #include "blockingconcurrentqueue.h"
 #include "sidecar.h"
+#include "sidecar_lines.h"
+#include "sidecar_msg.h"
+#include "sidecar_shell.h"
 
 //---------------------------------
 //--- common
 
-const char *url = "ipc:///tmp/norns-sidecar.ipc";
+static const char *url = "ipc:///tmp/norns-sidecar.ipc";
+
+static const char *quit_cmd = "__quit__";
+
+#define SIDECAR_CLIENT_RECV_MARGIN_MS 60000 // 1 min
+#define SIDECAR_CLIENT_SENDTIMEO_MS 10000   // 10 s
+#define SIDECAR_SERVER_SENDTIMEO_MS 10000   // 10 s
+
+// bounds what matron will buffer for one command, the server itself streams
+#define SIDECAR_CMD_MAX_OUTPUT_BYTES (1024 * 1024)
+// how long a dying command gets to run its cleanup traps before SIGKILL
+#define SIDECAR_CMD_TERM_GRACE_MS 2000
+
+#ifdef NORNS_TEST
+// request allocators, tests point them at failing versions to hit the OOM paths
+void *(*sidecar_test_calloc)(size_t, size_t) = calloc;
+char *(*sidecar_test_strdup)(const char *) = strdup;
+#define REQUEST_CALLOC sidecar_test_calloc
+#define REQUEST_STRDUP sidecar_test_strdup
+#else
+#define REQUEST_CALLOC calloc
+#define REQUEST_STRDUP strdup
+#endif
 
 static void sidecar_nng_error(const char *func, int rv) {
     fprintf(stderr, "%s: %s\n", func, nng_strerror(rv));
+}
+
+//---------------------------------
+//--- frames
+
+static nng_msg *frame_alloc(size_t len) {
+    nng_msg *msg = NULL;
+    int rv = nng_msg_alloc(&msg, len);
+    if (rv != 0) {
+        sidecar_nng_error("sidecar: frame alloc failed", rv);
+        return NULL;
+    }
+    return msg;
+}
+
+static int frame_send(nng_socket sock, nng_msg *msg) {
+    int rv = nng_sendmsg(sock, msg, 0);
+    if (rv != 0) {
+        nng_msg_free(msg);
+    }
+    return rv;
+}
+
+static nng_msg *frame_build_cmd(uint8_t req_id, uint32_t timeout_ms, const char *cmd) {
+    size_t n = sidecar_msg_encode_cmd(NULL, 0, req_id, timeout_ms, cmd);
+    nng_msg *msg = frame_alloc(n);
+    if (msg != NULL) {
+        sidecar_msg_encode_cmd((uint8_t *)nng_msg_body(msg), n, req_id, timeout_ms, cmd);
+    }
+    return msg;
+}
+
+static int frame_send_chunk(nng_socket sock, uint8_t req_id, const char *payload, size_t len) {
+    size_t n = sidecar_msg_encode_chunk(NULL, 0, req_id, payload, len);
+    nng_msg *msg = frame_alloc(n);
+    if (msg == NULL) {
+        return NNG_ENOMEM;
+    }
+    sidecar_msg_encode_chunk((uint8_t *)nng_msg_body(msg), n, req_id, payload, len);
+    return frame_send(sock, msg);
+}
+
+static void frame_send_end(nng_socket sock, uint8_t req_id, bool signalled, uint8_t code) {
+    size_t n = sidecar_msg_encode_end(NULL, 0, req_id, signalled, code);
+    nng_msg *msg = frame_alloc(n);
+    if (msg != NULL) {
+        sidecar_msg_encode_end((uint8_t *)nng_msg_body(msg), n, req_id, signalled, code);
+        frame_send(sock, msg);
+    }
+}
+
+static void frame_send_error(nng_socket sock, uint8_t req_id, const char *text) {
+    size_t n = sidecar_msg_encode_error(NULL, 0, req_id, text);
+    nng_msg *msg = frame_alloc(n);
+    if (msg != NULL) {
+        sidecar_msg_encode_error((uint8_t *)nng_msg_body(msg), n, req_id, text);
+        frame_send(sock, msg);
+    }
 }
 
 //---------------------------------
@@ -27,31 +111,35 @@ static void sidecar_nng_error(const char *func, int rv) {
 
 typedef enum {
     REQUEST_FIRST_REQUEST = 0,
-    REQUEST_RUN_CMD,
+    REQUEST_CMD,
     REQUEST_QUIT,
-} request_type;
+} request_type_t;
 
 struct request_common {
-    request_type type;
+    request_type_t type;
 };
 
-struct request_run_cmd {
+struct request_cmd {
     struct request_common common;
     char *cmd;
+    uint32_t timeout_ms;
     void *ctx;
-    client_cmd_completion_t completion_handler;
+    sidecar_chunk_cb_t on_chunk;
+    sidecar_done_cb_t on_done;
 };
 
 union request {
-    request_type type;
-    struct request_run_cmd run_cmd;
+    request_type_t type;
+    struct request_cmd cmd;
 };
 
 static moodycamel::BlockingConcurrentQueue<union request *> requests(32);
 
-static union request *request_new(request_type type) {
-    union request *req = (request *)calloc(1, sizeof(union request));
-    req->type = type;
+static union request *request_new(request_type_t type) {
+    union request *req = (request *)REQUEST_CALLOC(1, sizeof(union request));
+    if (req != NULL) {
+        req->type = type;
+    }
     return req;
 }
 
@@ -63,55 +151,115 @@ static void request_post(union request *req) {
 //---------------------------------
 //--- server
 
-const size_t MAX_CAPTURE_BYTES = 1024 * 1000; // 10MB maximum
-const size_t READ_BUFFER_BYTES = 8192;
-static char read_buffer[READ_BUFFER_BYTES];
+static nng_msg *pending_request = NULL;
 
-static nng_msg *sidecar_server_run_cmd(const char *cmd) {
-    FILE *f = popen((char *)cmd, "r");
-    if (f == NULL) {
-        fprintf(stderr, "popen() failed\n");
-        return NULL;
+static int socket_recv_fd(nng_socket sock) {
+    int fd = -1;
+    int rv = nng_socket_get_int(sock, NNG_OPT_RECVFD, &fd);
+    if (rv != 0) {
+        sidecar_nng_error("sidecar: recv fd unavailable", rv);
+        return -1;
     }
+    return fd;
+}
 
-    int status;
+static bool request_arrived_during_cmd(nng_socket sock) {
     nng_msg *msg = NULL;
-    size_t capture_bytes = 0;
-    size_t read_bytes = 0;
-
-    // NOTE: initial allocation is 0 because nng_msg_append* place values at the
-    // end of the msg, allocating more space as needed. allocating space up front
-    // does not behave like a capacity reservation.
-    status = nng_msg_alloc(&msg, 0);
-    if (status != 0) {
-        fprintf(stderr, "nng_msg_alloc() failed\n");
-        return NULL;
+    if (nng_recvmsg(sock, &msg, NNG_FLAG_NONBLOCK) != 0) {
+        return false;
     }
 
-    while ((read_bytes = fread(read_buffer, 1, READ_BUFFER_BYTES, f)) > 0) {
-        status = nng_msg_append(msg, read_buffer, read_bytes);
-        if (status != 0) {
-            pclose(f);
-            nng_msg_free(msg);
-            fprintf(stderr, "nng_msg_append() failed\n");
-            return NULL;
-        }
+    pending_request = msg;
+    return true;
+}
 
-        capture_bytes += read_bytes;
+struct stream_ctx {
+    nng_socket sock;
+    uint8_t req_id;
+    int send_err;
+    sidecar_lines_t lines;
+};
 
-        if (capture_bytes > MAX_CAPTURE_BYTES) {
-            pclose(f);
-            nng_msg_free(msg);
-            fprintf(stderr, "sidecar: command output too large, %d bytes maxiumum\n", MAX_CAPTURE_BYTES);
-            return NULL;
-        }
+static void stream_send_chunk(void *ctx, const char *line, size_t len) {
+    struct stream_ctx *sc = (struct stream_ctx *)ctx;
+    if (sc->send_err != 0) {
+        return;
     }
+    sc->send_err = frame_send_chunk(sc->sock, sc->req_id, line, len);
+    if (sc->send_err != 0) {
+        sidecar_nng_error("sidecar: stream send error", sc->send_err);
+    }
+}
 
-    // append a null byte to the end of the buffer
-    nng_msg_append_u16(msg, 0);
+static bool stream_on_output(void *ctx, const char *buf, size_t len) {
+    struct stream_ctx *sc = (struct stream_ctx *)ctx;
+    for (size_t i = 0; i < len && sc->send_err == 0; ++i) {
+        sidecar_lines_push(&sc->lines, buf[i], sc, stream_send_chunk);
+    }
+    return sc->send_err == 0;
+}
 
-    pclose(f);
-    return msg;
+static bool stream_on_watch(void *ctx) {
+    struct stream_ctx *sc = (struct stream_ctx *)ctx;
+    return request_arrived_during_cmd(sc->sock);
+}
+
+static void sidecar_server_stream_cmd(nng_socket sock, const char *cmd, uint8_t req_id, uint32_t timeout_ms) {
+    struct stream_ctx sc = {sock, req_id, 0, {}};
+    sidecar_lines_init(&sc.lines);
+
+    sidecar_shell_opts_t opts = {};
+    opts.silence_timeout_ms = timeout_ms;
+    opts.max_output_bytes = SIDECAR_CMD_MAX_OUTPUT_BYTES;
+    opts.term_grace_ms = SIDECAR_CMD_TERM_GRACE_MS;
+    opts.watch_fd = socket_recv_fd(sock);
+    opts.ctx = &sc;
+    opts.on_output = stream_on_output;
+    opts.on_watch = stream_on_watch;
+
+    sidecar_shell_result_t res;
+    sidecar_shell_run(cmd, &opts, &res);
+
+    switch (res.outcome) {
+    case SIDECAR_SHELL_EXITED:
+    case SIDECAR_SHELL_SIGNALLED:
+        sidecar_lines_flush(&sc.lines, &sc, stream_send_chunk);
+        if (sc.send_err != 0) {
+            fprintf(stderr, "sidecar: command stopped (send failed mid-stream)\n");
+            frame_send_error(sock, req_id, "send failed mid-stream");
+            return;
+        }
+        frame_send_end(sock, req_id, res.outcome == SIDECAR_SHELL_SIGNALLED, (uint8_t)res.code);
+        return;
+
+    case SIDECAR_SHELL_ABANDONED:
+        fprintf(stderr, "sidecar: command abandoned, norns stopped waiting for it\n");
+        return;
+
+    case SIDECAR_SHELL_QUIET:
+        fprintf(stderr, "sidecar: command stopped (command went quiet)\n");
+        frame_send_error(sock, req_id, "command went quiet");
+        return;
+
+    case SIDECAR_SHELL_CAPPED:
+        fprintf(stderr, "sidecar: command stopped (output cap exceeded)\n");
+        frame_send_error(sock, req_id, "output cap exceeded");
+        return;
+
+    case SIDECAR_SHELL_REFUSED:
+        fprintf(stderr, "sidecar: command stopped (send failed mid-stream)\n");
+        frame_send_error(sock, req_id, "send failed mid-stream");
+        return;
+
+    case SIDECAR_SHELL_FAILED:
+        if (res.errnum != 0) {
+            fprintf(stderr, "sidecar: %s: %s\n", res.err, strerror(res.errnum));
+        } else {
+            fprintf(stderr, "sidecar: %s\n", res.err);
+        }
+        frame_send_error(sock, req_id, res.err);
+        return;
+    }
 }
 
 int sidecar_server_main(int sync_fd) {
@@ -121,7 +269,7 @@ int sidecar_server_main(int sync_fd) {
 
     nng_ipc_register();
 
-    if ((rv = nng_rep0_open(&sock)) != 0) {
+    if ((rv = nng_pair1_open(&sock)) != 0) {
         sidecar_nng_error("open socket failed", rv);
         close(sync_fd);
         return -1;
@@ -129,7 +277,7 @@ int sidecar_server_main(int sync_fd) {
 
     // remove stale ipc socket left behind after a hard kill.
     // safe because only one sidecar instance ever exists.
-    unlink(url + 6);
+    unlink(url + strlen("ipc://"));
 
     if ((rv = nng_listen(sock, url, &listener, 0)) != 0) {
         nng_close(sock);
@@ -138,45 +286,55 @@ int sidecar_server_main(int sync_fd) {
         return -1;
     }
 
+    nng_socket_set_ms(sock, NNG_OPT_SENDTIMEO, SIDECAR_SERVER_SENDTIMEO_MS);
+
     // signal parent that IPC is bound and ready
     char b = 1;
     write(sync_fd, &b, 1);
     close(sync_fd);
 
     for (;;) {
-        char *cmd = NULL;
-        size_t cmd_sz = 0;
+        nng_msg *msg = NULL;
 
-        if ((rv = nng_recv(sock, &cmd, &cmd_sz, NNG_FLAG_ALLOC)) != 0) {
+        if (pending_request != NULL) {
+            msg = pending_request;
+            pending_request = NULL;
+        } else if ((rv = nng_recvmsg(sock, &msg, 0)) != 0) {
             sidecar_nng_error("recv error", rv);
             continue;
         }
 
-        // handle quit command
-        if (cmd != NULL && cmd_sz >= 8 && strncmp((char *)cmd, "__quit__", 8) == 0) {
-            nng_msg *response;
-            nng_msg_alloc(&response, 0);
-            nng_msg_append_u16(response, 0);
-            nng_sendmsg(sock, response, 0);
-            nng_free(cmd, cmd_sz);
-            break;
+        sidecar_frame_t frame;
+        if (!sidecar_msg_parse(nng_msg_body(msg), nng_msg_len(msg), &frame)) {
+            fprintf(stderr, "sidecar: malformed frame from client\n");
+            nng_msg_free(msg);
+            continue;
         }
 
-        // handle run command
-        nng_msg *response = sidecar_server_run_cmd(cmd);
-        if (response == NULL) {
-            // allocate an empty message if the command failed, so the client doesn't block forever
-            nng_msg_alloc(&response, 0);
-            nng_msg_append_u16(response, 0);
-        }
+        if (frame.type == SIDECAR_MSG_CMD) {
+            uint8_t req_id = frame.req_id;
+            uint32_t timeout_ms = frame.timeout_ms;
+            char *cmd = strdup(frame.cmd);
+            nng_msg_free(msg);
 
-        if ((rv = nng_sendmsg(sock, response, 0)) != 0) {
-            nng_msg_free(response);
-            sidecar_nng_error("send error", rv);
-        }
+            if (cmd == NULL) {
+                fprintf(stderr, "sidecar: strdup failed\n");
+                frame_send_error(sock, req_id, "out of memory");
+                continue;
+            }
 
-        if (cmd != NULL) {
-            nng_free(cmd, cmd_sz);
+            if (strcmp(cmd, quit_cmd) == 0) {
+                free(cmd);
+                frame_send_end(sock, req_id, false, 0);
+                break;
+            }
+
+            sidecar_server_stream_cmd(sock, cmd, req_id, timeout_ms);
+            free(cmd);
+
+        } else {
+            fprintf(stderr, "sidecar: unexpected msg type 0x%02x from client\n", (unsigned)frame.type);
+            nng_msg_free(msg);
         }
     }
 
@@ -196,53 +354,149 @@ struct client_state {
 static pthread_t client_thread;
 static struct client_state cs;
 static pthread_mutex_t run_cmd_lock = PTHREAD_MUTEX_INITIALIZER;
+static union request *quit_request = NULL;
 
-static void handle_run_cmd(const char *cmd, void *ctx, client_cmd_completion_t completion) {
-    static char empty_result[1] = {'\0'};
+static void client_apply_timeouts() {
+    nng_socket_set_ms(cs.sock, NNG_OPT_SENDTIMEO, SIDECAR_CLIENT_SENDTIMEO_MS);
+}
 
-    int rv;
-    char *result = NULL;
-    size_t result_sz = 0;
-    char *recv_buf = NULL;
-    size_t recv_sz = 0;
+static void client_apply_recv_timeout(uint32_t timeout_ms) {
+    // the timeout applies to each recv, so every chunk resets it and the
+    // client bounds silence between frames just like the server does
+    const nng_duration wait = timeout_ms == 0 ? NNG_DURATION_INFINITE : (nng_duration)(timeout_ms + SIDECAR_CLIENT_RECV_MARGIN_MS);
+    nng_socket_set_ms(cs.sock, NNG_OPT_RECVTIMEO, wait);
+}
 
-    // serialize interaction with the sidecar so sync and async command invocation
-    // is not interlieved
+static void client_resync() {
+    nng_close(cs.sock);
+    cs.initialized = false;
+    if (nng_pair1_open(&cs.sock) != 0) {
+        fprintf(stderr, "sidecar: resync open failed\n");
+        return;
+    }
+    client_apply_timeouts();
+    if (nng_dial(cs.sock, url, &cs.dialer, 0) != 0) {
+        fprintf(stderr, "sidecar: resync dial failed\n");
+        return;
+    }
+    cs.initialized = true;
+}
+
+//---------------------------------
+//--- command transaction
+
+// serialize interaction with the sidecar so sync and async command invocation
+// is not interleaved
+static void transport_lock() {
+    if (pthread_mutex_trylock(&run_cmd_lock) == 0) {
+        return;
+    }
+    fprintf(stderr, "sidecar: a command is still running, waiting for the transport\n");
     pthread_mutex_lock(&run_cmd_lock);
+}
 
-    if ((rv = nng_send(cs.sock, (void *)cmd, strlen(cmd) + 1, 0)) != 0) {
-        sidecar_nng_error("sidecar: send error", rv);
-        goto complete;
-    }
+static uint8_t next_req_id = 0;
 
-    // TODO: investigate using a pre-allocated receive buffer
-    if ((rv = nng_recv(cs.sock, &recv_buf, &recv_sz, NNG_FLAG_ALLOC)) != 0) {
-        sidecar_nng_error("sidecar: recv error", rv);
-        goto complete;
-    }
-
-    if (recv_sz > 0) {
-        result = recv_buf;
-        result_sz = recv_sz;
-    } else {
-        result = empty_result;
-        result_sz = 1;
-    }
-
-complete:
+static void transaction_abort(const char *cmd, void *ctx, sidecar_done_cb_t on_done, const char *err) {
+    client_resync();
     pthread_mutex_unlock(&run_cmd_lock);
-    completion(cmd, ctx, result, result_sz);
-    nng_free(recv_buf, recv_sz);
+
+    const sidecar_status_t status = {SIDECAR_TRANSPORT_FAILED, false, 0, err};
+    on_done(cmd, ctx, &status);
+}
+
+static void transaction_send_recv(nng_msg *req, uint8_t req_id, const char *cmd, void *ctx, sidecar_chunk_cb_t on_chunk, sidecar_done_cb_t on_done) {
+    int rv;
+
+    if ((rv = frame_send(cs.sock, req)) != 0) {
+        sidecar_nng_error("stream: send error", rv);
+        transaction_abort(cmd, ctx, on_done, "sidecar send failed");
+        return;
+    }
+
+    for (;;) {
+        nng_msg *msg = NULL;
+        if ((rv = nng_recvmsg(cs.sock, &msg, 0)) != 0) {
+            sidecar_nng_error("stream: recv error", rv);
+            transaction_abort(cmd, ctx, on_done, "sidecar did not answer");
+            return;
+        }
+
+        sidecar_frame_t frame;
+        if (!sidecar_msg_parse(nng_msg_body(msg), nng_msg_len(msg), &frame)) {
+            fprintf(stderr, "sidecar: malformed frame from sidecar\n");
+            nng_msg_free(msg);
+            continue;
+        }
+
+        if (frame.req_id != req_id) {
+            nng_msg_free(msg);
+            continue;
+        }
+
+        if (frame.type == SIDECAR_MSG_CHUNK) {
+            if (on_chunk != NULL) {
+                on_chunk(ctx, frame.payload, frame.payload_len);
+            }
+            nng_msg_free(msg);
+
+        } else if (frame.type == SIDECAR_MSG_END) {
+            sidecar_status_t status = {SIDECAR_OK, frame.signalled, frame.code, NULL};
+            char exit_text[48];
+            if (frame.signalled || frame.code != 0) {
+                status.result = SIDECAR_CMD_FAILED;
+                snprintf(exit_text, sizeof(exit_text), frame.signalled ? "killed by signal %d" : "exit status %d", frame.code);
+                status.err = exit_text;
+            }
+            nng_msg_free(msg);
+            pthread_mutex_unlock(&run_cmd_lock);
+            on_done(cmd, ctx, &status);
+            return;
+
+        } else if (frame.type == SIDECAR_MSG_ERROR) {
+            char err_text[4096];
+            snprintf(err_text, sizeof(err_text), "%s", frame.payload_len > 0 ? frame.payload : "unknown error");
+            nng_msg_free(msg);
+            const sidecar_status_t status = {SIDECAR_CMD_FAILED, false, 0, err_text};
+            pthread_mutex_unlock(&run_cmd_lock);
+            on_done(cmd, ctx, &status);
+            return;
+
+        } else {
+            nng_msg_free(msg);
+        }
+    }
+}
+
+static void transaction_out_of_memory(const char *cmd, void *ctx, sidecar_done_cb_t on_done) {
+    pthread_mutex_unlock(&run_cmd_lock);
+    const sidecar_status_t status = {SIDECAR_TRANSPORT_FAILED, false, 0, "out of memory"};
+    on_done(cmd, ctx, &status);
+}
+
+static void cmd_transaction(const char *cmd, uint32_t timeout_ms, void *ctx, sidecar_chunk_cb_t on_chunk, sidecar_done_cb_t on_done) {
+    transport_lock();
+    uint8_t req_id = ++next_req_id;
+
+    nng_msg *req = frame_build_cmd(req_id, timeout_ms, cmd);
+    if (req == NULL) {
+        fprintf(stderr, "sidecar: failed to build CMD frame\n");
+        transaction_out_of_memory(cmd, ctx, on_done);
+        return;
+    }
+
+    client_apply_recv_timeout(timeout_ms);
+    transaction_send_recv(req, req_id, cmd, ctx, on_chunk, on_done);
 }
 
 static void handle_request(union request *req) {
     switch (req->type) {
-    case REQUEST_RUN_CMD:
-        handle_run_cmd(req->run_cmd.cmd, req->run_cmd.ctx, req->run_cmd.completion_handler);
-        free(req->run_cmd.cmd);
+    case REQUEST_CMD:
+        cmd_transaction(req->cmd.cmd, req->cmd.timeout_ms, req->cmd.ctx, req->cmd.on_chunk, req->cmd.on_done);
+        free(req->cmd.cmd);
         break;
     default:
-        fprintf(stderr, "sidecar: unhandled event type; %d\n", req->type);
+        fprintf(stderr, "sidecar: unhandled request type %d\n", req->type);
         break;
     }
 }
@@ -275,13 +529,21 @@ int sidecar_client_init() {
 
     cs.initialized = false;
 
-    if ((rv = nng_req0_open(&cs.sock)) != 0) {
+    if ((rv = nng_pair1_open(&cs.sock)) != 0) {
         sidecar_nng_error("sidecar: open socket failed", rv);
         return -1;
     }
 
+    client_apply_timeouts();
+
     if ((rv = nng_dial(cs.sock, url, &cs.dialer, 0)) != 0) {
         sidecar_nng_error("sidecar: establishing connection failed", rv);
+        return -1;
+    }
+
+    quit_request = request_new(REQUEST_QUIT);
+    if (quit_request == NULL) {
+        fprintf(stderr, "sidecar: unable to allocate quit request\n");
         return -1;
     }
 
@@ -296,11 +558,10 @@ int sidecar_client_init() {
     return 0;
 }
 
-static void _null_completion(const char *cmd, void *ctx, const char *buf, size_t size) {
+static void noop_done_cb(const char *cmd, void *ctx, const sidecar_status_t *status) {
     (void)cmd;
     (void)ctx;
-    (void)buf;
-    (void)size;
+    (void)status;
 }
 
 void sidecar_client_cleanup() {
@@ -309,11 +570,11 @@ void sidecar_client_cleanup() {
     }
 
     // Tell the sidecar server to exit
-    sidecar_client_cmd("__quit__", NULL, _null_completion);
+    cmd_transaction(quit_cmd, SIDECAR_CMD_TIMEOUT_DEFAULT_MS, NULL, NULL, noop_done_cb);
 
     // Tell the client thread to exit
-    union request *req = request_new(REQUEST_QUIT);
-    request_post(req);
+    request_post(quit_request);
+    quit_request = NULL;
 
     // Wait for the background thread to finish
     pthread_join(client_thread, NULL);
@@ -321,37 +582,24 @@ void sidecar_client_cleanup() {
     cs.initialized = false;
 }
 
-bool sidecar_client_cmd_async(const char *cmd, void *ctx, client_cmd_completion_t cb) {
-    union request *req = request_new(REQUEST_RUN_CMD);
-    req->run_cmd.cmd = strdup(cmd);
-    req->run_cmd.ctx = ctx;
-    req->run_cmd.completion_handler = cb;
+void sidecar_client_cmd(const char *cmd, uint32_t timeout_ms, void *ctx, sidecar_chunk_cb_t on_chunk, sidecar_done_cb_t on_done) {
+    cmd_transaction(cmd, timeout_ms, ctx, on_chunk, on_done);
+}
+
+bool sidecar_client_cmd_async(const char *cmd, uint32_t timeout_ms, void *ctx, sidecar_chunk_cb_t on_chunk, sidecar_done_cb_t on_done) {
+    union request *req = request_new(REQUEST_CMD);
+    if (req == NULL) {
+        return false;
+    }
+    req->cmd.cmd = REQUEST_STRDUP(cmd);
+    if (req->cmd.cmd == NULL) {
+        free(req);
+        return false;
+    }
+    req->cmd.timeout_ms = timeout_ms;
+    req->cmd.ctx = ctx;
+    req->cmd.on_chunk = on_chunk;
+    req->cmd.on_done = on_done;
     request_post(req);
     return true;
-}
-
-bool sidecar_client_cmd(const char *cmd, void *ctx, client_cmd_completion_t cb) {
-    handle_run_cmd(cmd, ctx, cb);
-    return true;
-}
-
-typedef struct {
-    char **result;
-    size_t *result_size;
-} buffer_fill_ctx;
-
-static void _buffer_fill_completion(const char *cmd, void *ctx, const char *buf, size_t size) {
-    buffer_fill_ctx *output = (buffer_fill_ctx *)ctx;
-    *(output->result_size) = size;
-    if (size != 0) {
-        *(output->result) = (char *)malloc(size);
-        memcpy(*(output->result), buf, size);
-    } else {
-        *(output->result) = NULL;
-    }
-}
-
-void sidecar_client_cmd(const char *cmd, char **dst, size_t *dst_size) {
-    buffer_fill_ctx ctx = {dst, dst_size};
-    handle_run_cmd(cmd, &ctx, _buffer_fill_completion);
 }

--- a/norns/sidecar.h
+++ b/norns/sidecar.h
@@ -1,35 +1,54 @@
-
 #ifndef _NORNS_SIDECAR_H_
 #define _NORNS_SIDECAR_H_
 
-#include <stdlib.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
 
-typedef void (*client_cmd_completion_t)(const char *cmd, void *ctx, const char *buff, size_t size);
+// timeouts bound the longest quiet stretch between output, not total
+// duration, so a command that keeps producing output is never cut off
+#define SIDECAR_CMD_TIMEOUT_DEFAULT_MS 240000 // 4 min
+#define SIDECAR_CMD_TIMEOUT_NONE 0
 
 // main loop of sidecar server process. sync_fd is a file descriptor that will be
 // written to when the server is ready to accept connections.
 int sidecar_server_main(int sync_fd);
 
-// intialize sidecar client IPC connections
+// initialize sidecar client IPC connections
 int sidecar_client_init();
 
 // cleanup sidecar client IPC connections
 void sidecar_client_cleanup();
 
+typedef enum {
+    SIDECAR_OK = 0,           // the command ran and exited zero
+    SIDECAR_CMD_FAILED,       // the command exited non-zero, or never ran at all
+    SIDECAR_TRANSPORT_FAILED, // the sidecar never answered
+} sidecar_result_t;
+
+typedef struct {
+    sidecar_result_t result;
+    bool signalled;  // code is a signal number, not an exit status
+    int code;        // exit status, or the signal that killed it
+    const char *err; // failure text, NULL when result is SIDECAR_OK
+} sidecar_status_t;
+
+typedef void (*sidecar_chunk_cb_t)(void *ctx, const char *buf, size_t size);
+typedef void (*sidecar_done_cb_t)(const char *cmd, void *ctx, const sidecar_status_t *status);
+
+// request a command to be executed synchronously by the sidecar server
+// calls the callbacks on the invoking thread, the outcome arrives via status
+void sidecar_client_cmd(const char *cmd, uint32_t timeout_ms, void *ctx, sidecar_chunk_cb_t on_chunk, sidecar_done_cb_t on_done);
+
 // request a command to be executed asynchronously by the sidecar server
-// returns immediately after enqueing command
-// calls completion function from a background thread with the command output
-bool sidecar_client_cmd_async(const char *cmd, void *ctx, client_cmd_completion_t cb);
+// returns false when the request could not be allocated, else enqueues it
+// and calls the callbacks from a background thread as output arrives
+bool sidecar_client_cmd_async(const char *cmd, uint32_t timeout_ms, void *ctx, sidecar_chunk_cb_t on_chunk, sidecar_done_cb_t on_done);
 
-// request a command be executed synchronously by the sidecar server
-// calls completion function for the invoking thread
-bool sidecar_client_cmd(const char *cmd, void *ctx, client_cmd_completion_t cb);
-
-// request a command be executed synchronously by the sidecar server and returns
-// the command output in result and size. if the command did not return any
-// output size will be 0 and result will be NULL.
-//
-// the caller is responsible for free()ing result
-void sidecar_client_cmd(const char *cmd, char **result, size_t *size);
-
+#ifdef NORNS_TEST
+extern void *(*sidecar_test_calloc)(size_t, size_t);
+extern char *(*sidecar_test_strdup)(const char *);
 #endif
+
+
+#endif // _NORNS_SIDECAR_H_

--- a/norns/sidecar.h
+++ b/norns/sidecar.h
@@ -45,10 +45,14 @@ void sidecar_client_cmd(const char *cmd, uint32_t timeout_ms, void *ctx, sidecar
 // and calls the callbacks from a background thread as output arrives
 bool sidecar_client_cmd_async(const char *cmd, uint32_t timeout_ms, void *ctx, sidecar_chunk_cb_t on_chunk, sidecar_done_cb_t on_done);
 
+// request a command be launched detached in a transient systemd unit, so it
+// outlives norns. its output goes to the journal, so there is no on_chunk.
+// returns false when the request could not be allocated
+bool sidecar_client_detach_async(const char *cmd, const char *unit, void *ctx, sidecar_done_cb_t on_done);
+
 #ifdef NORNS_TEST
 extern void *(*sidecar_test_calloc)(size_t, size_t);
 extern char *(*sidecar_test_strdup)(const char *);
 #endif
-
 
 #endif // _NORNS_SIDECAR_H_

--- a/norns/sidecar_lines.cpp
+++ b/norns/sidecar_lines.cpp
@@ -1,0 +1,50 @@
+#include <string.h>
+
+#include "sidecar_lines.h"
+
+void sidecar_lines_init(sidecar_lines_t *s) {
+    memset(s, 0, sizeof(*s));
+}
+
+static void lines_flush_segment(sidecar_lines_t *s, void *ctx, sidecar_lines_cb_t on_line) {
+    if (s->len == 0) {
+        return;
+    }
+    on_line(ctx, s->buf, s->len);
+    s->len = 0;
+}
+
+static void lines_append(sidecar_lines_t *s, char c, void *ctx, sidecar_lines_cb_t on_line) {
+    if (s->len == SIDECAR_LINE_BYTES) {
+        lines_flush_segment(s, ctx, on_line);
+    }
+    s->buf[s->len++] = c;
+}
+
+void sidecar_lines_push(sidecar_lines_t *s, char c, void *ctx, sidecar_lines_cb_t on_line) {
+    if (s->cr_pending) {
+        s->cr_pending = false;
+        if (c != '\n') {
+            lines_flush_segment(s, ctx, on_line);
+        }
+    }
+
+    if (c == '\r') {
+        lines_append(s, '\r', ctx, on_line);
+        s->cr_pending = true;
+        return;
+    }
+
+    if (c == '\n') {
+        lines_append(s, '\n', ctx, on_line);
+        lines_flush_segment(s, ctx, on_line);
+        return;
+    }
+
+    lines_append(s, c, ctx, on_line);
+}
+
+void sidecar_lines_flush(sidecar_lines_t *s, void *ctx, sidecar_lines_cb_t on_line) {
+    s->cr_pending = false;
+    lines_flush_segment(s, ctx, on_line);
+}

--- a/norns/sidecar_lines.h
+++ b/norns/sidecar_lines.h
@@ -1,0 +1,24 @@
+#ifndef _NORNS_SIDECAR_LINES_H_
+#define _NORNS_SIDECAR_LINES_H_
+
+#include <stdbool.h>
+#include <stddef.h>
+
+// splits output on '\n' and '\r' (so progress bars aren't one giant line),
+// keeping every byte, so segments concatenate back to the exact output.
+
+#define SIDECAR_LINE_BYTES 4096
+
+typedef void (*sidecar_lines_cb_t)(void *ctx, const char *line, size_t len);
+
+typedef struct {
+    char buf[SIDECAR_LINE_BYTES];
+    size_t len;
+    bool cr_pending;
+} sidecar_lines_t;
+
+void sidecar_lines_init(sidecar_lines_t *s);
+void sidecar_lines_push(sidecar_lines_t *s, char c, void *ctx, sidecar_lines_cb_t on_line);
+void sidecar_lines_flush(sidecar_lines_t *s, void *ctx, sidecar_lines_cb_t on_line);
+
+#endif // _NORNS_SIDECAR_LINES_H_

--- a/norns/sidecar_msg.cpp
+++ b/norns/sidecar_msg.cpp
@@ -1,0 +1,171 @@
+#include <string.h>
+
+#include "sidecar_msg.h"
+
+enum {
+    END_HOW_EXITED = 0,
+    END_HOW_SIGNALLED = 1,
+};
+
+static void put_u32(uint8_t *out, uint32_t v) {
+    out[0] = (uint8_t)(v & 0xFF);
+    out[1] = (uint8_t)((v >> 8) & 0xFF);
+    out[2] = (uint8_t)((v >> 16) & 0xFF);
+    out[3] = (uint8_t)((v >> 24) & 0xFF);
+}
+
+static uint32_t get_u32(const uint8_t *in) {
+    return (uint32_t)in[0] | ((uint32_t)in[1] << 8) | ((uint32_t)in[2] << 16) | ((uint32_t)in[3] << 24);
+}
+
+static size_t encode_payload(uint8_t *out, size_t cap, sidecar_msg_type_t type, uint8_t req_id, const char *payload, size_t len) {
+    const size_t frame = SIDECAR_MSG_HEADER_BYTES + len + 1;
+    if (out != NULL && cap >= frame) {
+        out[0] = (uint8_t)type;
+        out[1] = req_id;
+        if (len > 0) {
+            memcpy(out + SIDECAR_MSG_HEADER_BYTES, payload, len);
+        }
+        out[frame - 1] = 0;
+    }
+    return frame;
+}
+
+size_t sidecar_msg_encode_chunk(uint8_t *out, size_t cap, uint8_t req_id, const char *payload, size_t len) {
+    return encode_payload(out, cap, SIDECAR_MSG_CHUNK, req_id, payload, len);
+}
+
+size_t sidecar_msg_encode_end(uint8_t *out, size_t cap, uint8_t req_id, bool signalled, uint8_t code) {
+    const size_t frame = SIDECAR_MSG_HEADER_BYTES + SIDECAR_MSG_STATUS_BYTES;
+    if (out != NULL && cap >= frame) {
+        out[0] = (uint8_t)SIDECAR_MSG_END;
+        out[1] = req_id;
+        out[SIDECAR_MSG_HEADER_BYTES] = signalled ? END_HOW_SIGNALLED : END_HOW_EXITED;
+        out[SIDECAR_MSG_HEADER_BYTES + 1] = code;
+    }
+    return frame;
+}
+
+size_t sidecar_msg_encode_error(uint8_t *out, size_t cap, uint8_t req_id, const char *text) {
+    if (text == NULL) {
+        text = "";
+    }
+    return encode_payload(out, cap, SIDECAR_MSG_ERROR, req_id, text, strlen(text));
+}
+
+size_t sidecar_msg_encode_cmd(uint8_t *out, size_t cap, uint8_t req_id, uint32_t timeout_ms, const char *cmd) {
+    if (cmd == NULL) {
+        cmd = "";
+    }
+    const size_t cmd_len = strlen(cmd);
+    const size_t frame = SIDECAR_MSG_HEADER_BYTES + SIDECAR_MSG_TIMEOUT_BYTES + cmd_len + 1;
+    if (out != NULL && cap >= frame) {
+        out[0] = (uint8_t)SIDECAR_MSG_CMD;
+        out[1] = req_id;
+        put_u32(out + SIDECAR_MSG_HEADER_BYTES, timeout_ms);
+        memcpy(out + SIDECAR_MSG_HEADER_BYTES + SIDECAR_MSG_TIMEOUT_BYTES, cmd, cmd_len + 1);
+    }
+    return frame;
+}
+
+size_t sidecar_msg_encode_detach(uint8_t *out, size_t cap, uint8_t req_id, const char *unit, const char *cmd) {
+    if (unit == NULL) {
+        unit = "";
+    }
+    if (cmd == NULL) {
+        cmd = "";
+    }
+    const size_t unit_len = strlen(unit);
+    const size_t cmd_len = strlen(cmd);
+    const size_t frame = SIDECAR_MSG_HEADER_BYTES + unit_len + 1 + cmd_len + 1;
+    if (out != NULL && cap >= frame) {
+        out[0] = (uint8_t)SIDECAR_MSG_DETACH;
+        out[1] = req_id;
+        memcpy(out + SIDECAR_MSG_HEADER_BYTES, unit, unit_len + 1);
+        memcpy(out + SIDECAR_MSG_HEADER_BYTES + unit_len + 1, cmd, cmd_len + 1);
+    }
+    return frame;
+}
+
+static bool type_is_known(uint8_t tag) {
+    switch (tag) {
+    case SIDECAR_MSG_CHUNK:
+    case SIDECAR_MSG_END:
+    case SIDECAR_MSG_ERROR:
+    case SIDECAR_MSG_CMD:
+    case SIDECAR_MSG_DETACH:
+        return true;
+    default:
+        return false;
+    }
+}
+
+bool sidecar_msg_parse(const void *body, size_t len, sidecar_frame_t *out) {
+    memset(out, 0, sizeof(*out));
+
+    if (body == NULL || len < SIDECAR_MSG_HEADER_BYTES) {
+        return false;
+    }
+
+    const char *bytes = (const char *)body;
+    if (!type_is_known((uint8_t)bytes[0])) {
+        return false;
+    }
+    const sidecar_msg_type_t type = (sidecar_msg_type_t)(uint8_t)bytes[0];
+    const uint8_t req_id = (uint8_t)bytes[1];
+
+    const char *payload = bytes + SIDECAR_MSG_HEADER_BYTES;
+    const size_t region = len - SIDECAR_MSG_HEADER_BYTES;
+
+    const bool terminated = region > 0 && payload[region - 1] == '\0';
+
+    switch (type) {
+    case SIDECAR_MSG_END: {
+        if (region != SIDECAR_MSG_STATUS_BYTES) {
+            return false;
+        }
+        const uint8_t how = (uint8_t)payload[0];
+        if (how != END_HOW_EXITED && how != END_HOW_SIGNALLED) {
+            return false;
+        }
+        out->signalled = (how == END_HOW_SIGNALLED);
+        out->code = (uint8_t)payload[1];
+        break;
+    }
+
+    case SIDECAR_MSG_CHUNK:
+    case SIDECAR_MSG_ERROR:
+        if (!terminated) {
+            return false;
+        }
+        out->payload = payload;
+        out->payload_len = region - 1;
+        break;
+
+    case SIDECAR_MSG_CMD: {
+        if (region < SIDECAR_MSG_TIMEOUT_BYTES + 1 || !terminated) {
+            return false;
+        }
+        out->timeout_ms = get_u32((const uint8_t *)payload);
+        out->cmd = payload + SIDECAR_MSG_TIMEOUT_BYTES;
+        break;
+    }
+
+    case SIDECAR_MSG_DETACH: {
+        if (!terminated) {
+            return false;
+        }
+        const size_t unit_len = strnlen(payload, region);
+        if (unit_len + 1 >= region) {
+            return false;
+        }
+        out->unit = payload;
+        out->cmd = payload + unit_len + 1;
+        break;
+    }
+    }
+
+    out->type = type;
+    out->req_id = req_id;
+    return true;
+}

--- a/norns/sidecar_msg.h
+++ b/norns/sidecar_msg.h
@@ -20,6 +20,10 @@
 // it did not, so a non-zero exit is an END and a command that never started is
 // an ERROR.
 
+#define SIDECAR_MSG_HEADER_BYTES 2
+#define SIDECAR_MSG_TIMEOUT_BYTES 4
+#define SIDECAR_MSG_STATUS_BYTES 2
+
 typedef enum {
     // sidecar -> norns
     SIDECAR_MSG_CHUNK = 0x01,
@@ -30,10 +34,6 @@ typedef enum {
     SIDECAR_MSG_DETACH = 0x11,
 } sidecar_msg_type_t;
 
-#define SIDECAR_MSG_HEADER_BYTES 2
-#define SIDECAR_MSG_TIMEOUT_BYTES 4
-#define SIDECAR_MSG_STATUS_BYTES 2
-
 typedef struct {
     sidecar_msg_type_t type;
     uint8_t req_id;
@@ -41,7 +41,7 @@ typedef struct {
     size_t payload_len;
     const char *unit;
     const char *cmd;
-    uint32_t timeout_ms; // CMD only, zero for no ceiling
+    uint32_t timeout_ms; // CMD only, longest quiet stretch between output, zero for no ceiling
     bool signalled;      // END only, true when code is a signal
     uint8_t code;        // END only
 } sidecar_frame_t;

--- a/norns/sidecar_msg.h
+++ b/norns/sidecar_msg.h
@@ -1,0 +1,56 @@
+#ifndef _NORNS_SIDECAR_MSG_H_
+#define _NORNS_SIDECAR_MSG_H_
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+// sidecar wire protocol. every frame is a type tag, a request id echoed on
+// each reply, and a payload.
+//
+//   norns -> sidecar
+//     CMD    [0x10][req id][timeout ms][command][0]
+//     DETACH [0x11][req id][unit name][0][command][0]
+//   sidecar -> norns
+//     CHUNK  [0x01][req id][raw output bytes, may contain null characters][0]
+//     END    [0x02][req id][how][code]
+//     ERROR  [0x03][req id][error text][0]
+//
+// END means the command ran to completion and carries how it ended, ERROR means
+// it did not, so a non-zero exit is an END and a command that never started is
+// an ERROR.
+
+typedef enum {
+    // sidecar -> norns
+    SIDECAR_MSG_CHUNK = 0x01,
+    SIDECAR_MSG_END = 0x02,
+    SIDECAR_MSG_ERROR = 0x03,
+    // norns -> sidecar
+    SIDECAR_MSG_CMD = 0x10,
+    SIDECAR_MSG_DETACH = 0x11,
+} sidecar_msg_type_t;
+
+#define SIDECAR_MSG_HEADER_BYTES 2
+#define SIDECAR_MSG_TIMEOUT_BYTES 4
+#define SIDECAR_MSG_STATUS_BYTES 2
+
+typedef struct {
+    sidecar_msg_type_t type;
+    uint8_t req_id;
+    const char *payload;
+    size_t payload_len;
+    const char *unit;
+    const char *cmd;
+    uint32_t timeout_ms; // CMD only, zero for no ceiling
+    bool signalled;      // END only, true when code is a signal
+    uint8_t code;        // END only
+} sidecar_frame_t;
+
+size_t sidecar_msg_encode_chunk(uint8_t *out, size_t cap, uint8_t req_id, const char *payload, size_t len);
+size_t sidecar_msg_encode_end(uint8_t *out, size_t cap, uint8_t req_id, bool signalled, uint8_t code);
+size_t sidecar_msg_encode_error(uint8_t *out, size_t cap, uint8_t req_id, const char *text);
+size_t sidecar_msg_encode_cmd(uint8_t *out, size_t cap, uint8_t req_id, uint32_t timeout_ms, const char *cmd);
+size_t sidecar_msg_encode_detach(uint8_t *out, size_t cap, uint8_t req_id, const char *unit, const char *cmd);
+bool sidecar_msg_parse(const void *body, size_t len, sidecar_frame_t *out);
+
+#endif // _NORNS_SIDECAR_MSG_H_

--- a/norns/sidecar_shell.cpp
+++ b/norns/sidecar_shell.cpp
@@ -1,0 +1,280 @@
+#include <errno.h>
+#include <fcntl.h>
+#include <poll.h>
+#include <signal.h>
+#include <sys/wait.h>
+#include <time.h>
+#include <unistd.h>
+
+#include "sidecar_shell.h"
+
+#define SHELL_POLL_MS 10000 // 10 s
+#define SHELL_AWAIT_EXIT_POLL_MS 100
+
+static uint64_t now_ms(void) {
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return (uint64_t)ts.tv_sec * 1000u + (uint64_t)ts.tv_nsec / 1000000u;
+}
+
+static void fail(sidecar_shell_result_t *result, const char *err, int errnum) {
+    result->outcome = SIDECAR_SHELL_FAILED;
+    result->code = 0;
+    result->err = err;
+    result->errnum = errnum;
+}
+
+static pid_t shell_spawn(const char *cmd, int *out_fd) {
+    int fds[2];
+    if (pipe(fds) != 0) {
+        return -1;
+    }
+
+    pid_t pid = fork();
+    if (pid < 0) {
+        int err = errno;
+        close(fds[0]);
+        close(fds[1]);
+        errno = err;
+        return -1;
+    }
+
+    if (pid == 0) {
+        setpgid(0, 0);
+        int devnull = open("/dev/null", O_RDONLY);
+        if (devnull >= 0) {
+            dup2(devnull, STDIN_FILENO);
+            close(devnull);
+        }
+        dup2(fds[1], STDOUT_FILENO);
+        dup2(fds[1], STDERR_FILENO);
+        close(fds[0]);
+        close(fds[1]);
+        execl("/bin/sh", "sh", "-c", cmd, (char *)NULL);
+        _exit(127);
+    }
+
+    setpgid(pid, pid);
+    close(fds[1]);
+    fcntl(fds[0], F_SETFD, FD_CLOEXEC);
+    *out_fd = fds[0];
+    return pid;
+}
+
+static bool went_quiet(const sidecar_shell_opts_t *opts, uint64_t last_output, int *wait) {
+    if (opts->silence_timeout_ms == 0) {
+        return false;
+    }
+    uint64_t silent = now_ms() - last_output;
+    if (silent >= opts->silence_timeout_ms) {
+        return true;
+    }
+    uint64_t remaining = opts->silence_timeout_ms - silent;
+    if (remaining < (uint64_t)*wait) {
+        *wait = (int)remaining;
+    }
+    return false;
+}
+
+static bool watch_fired(const sidecar_shell_opts_t *opts, short revents, int *watch_fd) {
+    if (revents == 0) {
+        return false;
+    }
+    if (revents & POLLIN) {
+        return opts->on_watch(opts->ctx);
+    }
+    *watch_fd = -1;
+    return false;
+}
+
+static bool shell_exited(pid_t pid, int *status) {
+    pid_t waited = waitpid(pid, status, WNOHANG);
+    return waited == pid || (waited < 0 && errno != EINTR);
+}
+
+static void shell_await_exit(pid_t pid, int *status, uint64_t kill_at, bool killed) {
+    for (;;) {
+        if (shell_exited(pid, status)) {
+            return;
+        }
+        int wait = SHELL_AWAIT_EXIT_POLL_MS;
+        if (!killed) {
+            uint64_t now = now_ms();
+            if (now >= kill_at) {
+                kill(-pid, SIGKILL);
+                killed = true;
+            } else if (kill_at - now < (uint64_t)wait) {
+                wait = (int)(kill_at - now);
+            }
+        }
+        poll(NULL, 0, wait);
+    }
+}
+
+static void shell_stop(pid_t pid, int fd, uint32_t term_grace_ms) {
+    kill(-pid, SIGTERM);
+    uint64_t kill_at = now_ms() + term_grace_ms;
+    bool killed = false;
+    if (fd >= 0) {
+        for (;;) {
+            uint64_t now = now_ms();
+            if (!killed && now >= kill_at) {
+                kill(-pid, SIGKILL);
+                killed = true;
+            }
+            int wait = killed ? SHELL_POLL_MS : (int)(kill_at - now);
+            struct pollfd pfd = {fd, POLLIN, 0};
+            int ready = poll(&pfd, 1, wait);
+            if (ready < 0 && errno == EINTR) {
+                continue;
+            }
+            if (ready < 0) {
+                break;
+            }
+            if (ready == 0) {
+                continue;
+            }
+            char scrap[4096];
+            ssize_t n = read(fd, scrap, sizeof(scrap));
+            if (n < 0 && errno == EINTR) {
+                continue;
+            }
+            if (n <= 0) {
+                break;
+            }
+        }
+        close(fd);
+    }
+    int status;
+    shell_await_exit(pid, &status, kill_at, killed);
+}
+
+void sidecar_shell_run(const char *cmd, const sidecar_shell_opts_t *opts, sidecar_shell_result_t *result) {
+    result->code = 0;
+    result->err = NULL;
+    result->errnum = 0;
+
+    int fd = -1;
+    pid_t pid = shell_spawn(cmd, &fd);
+    if (pid < 0) {
+        fail(result, "could not start command", errno);
+        return;
+    }
+
+    uint64_t last_output = now_ms();
+    size_t total = 0;
+    int watch_fd = opts->watch_fd;
+    bool aborted = false;
+    sidecar_shell_outcome_t why = SIDECAR_SHELL_FAILED;
+    const char *err = NULL;
+    int err_errno = 0;
+
+    for (;;) {
+        int wait = SHELL_POLL_MS;
+        if (went_quiet(opts, last_output, &wait)) {
+            aborted = true;
+            why = SIDECAR_SHELL_QUIET;
+            break;
+        }
+
+        struct pollfd pfds[2] = {{fd, POLLIN, 0}, {watch_fd, POLLIN, 0}};
+        const nfds_t nfds = watch_fd >= 0 ? 2 : 1;
+        int ready = poll(pfds, nfds, wait);
+        if (ready < 0) {
+            if (errno == EINTR) {
+                continue;
+            }
+            aborted = true;
+            err = "poll() failed";
+            err_errno = errno;
+            break;
+        }
+        if (ready == 0) {
+            continue;
+        }
+
+        if (nfds > 1 && watch_fired(opts, pfds[1].revents, &watch_fd)) {
+            aborted = true;
+            why = SIDECAR_SHELL_ABANDONED;
+            break;
+        }
+
+        if (pfds[0].revents == 0) {
+            continue;
+        }
+
+        char buf[4096];
+        ssize_t n = read(fd, buf, sizeof(buf));
+        if (n < 0) {
+            if (errno == EINTR) {
+                continue;
+            }
+            aborted = true;
+            err = "read failed";
+            err_errno = errno;
+            break;
+        }
+        if (n == 0) {
+            break;
+        }
+
+        total += (size_t)n;
+        if (opts->max_output_bytes != 0 && total > opts->max_output_bytes) {
+            aborted = true;
+            why = SIDECAR_SHELL_CAPPED;
+            break;
+        }
+
+        last_output = now_ms();
+        if (!opts->on_output(opts->ctx, buf, (size_t)n)) {
+            aborted = true;
+            why = SIDECAR_SHELL_REFUSED;
+            break;
+        }
+    }
+
+    int status = 0;
+
+    if (!aborted) {
+        close(fd);
+        fd = -1;
+        for (;;) {
+            if (shell_exited(pid, &status)) {
+                break;
+            }
+            int wait = SHELL_AWAIT_EXIT_POLL_MS;
+            if (went_quiet(opts, last_output, &wait)) {
+                aborted = true;
+                why = SIDECAR_SHELL_QUIET;
+                break;
+            }
+            struct pollfd pfd = {watch_fd, POLLIN, 0};
+            int ready = poll(watch_fd >= 0 ? &pfd : NULL, watch_fd >= 0 ? 1 : 0, wait);
+            if (ready > 0 && watch_fired(opts, pfd.revents, &watch_fd)) {
+                aborted = true;
+                why = SIDECAR_SHELL_ABANDONED;
+                break;
+            }
+        }
+    }
+
+    if (aborted) {
+        shell_stop(pid, fd, opts->term_grace_ms);
+        if (err != NULL) {
+            fail(result, err, err_errno);
+        } else {
+            result->outcome = why;
+        }
+        return;
+    }
+
+    if (WIFEXITED(status)) {
+        result->outcome = SIDECAR_SHELL_EXITED;
+        result->code = WEXITSTATUS(status);
+    } else if (WIFSIGNALED(status)) {
+        result->outcome = SIDECAR_SHELL_SIGNALLED;
+        result->code = WTERMSIG(status);
+    } else {
+        fail(result, "command ended in an unknown way", 0);
+    }
+}

--- a/norns/sidecar_shell.h
+++ b/norns/sidecar_shell.h
@@ -1,0 +1,45 @@
+#ifndef _NORNS_SIDECAR_SHELL_H_
+#define _NORNS_SIDECAR_SHELL_H_
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+// runs one shell command under supervision and streams its output as it
+// arrives. transport-free, the sidecar server wires the callbacks to NNG.
+
+typedef enum {
+    SIDECAR_SHELL_EXITED,    // ran to completion, code holds the exit status
+    SIDECAR_SHELL_SIGNALLED, // died on a signal, code holds the signal
+    SIDECAR_SHELL_QUIET,     // produced no output within the silence budget
+    SIDECAR_SHELL_CAPPED,    // produced more output than max_output_bytes
+    SIDECAR_SHELL_REFUSED,   // on_output returned false
+    SIDECAR_SHELL_ABANDONED, // on_watch said the caller stopped waiting
+    SIDECAR_SHELL_FAILED,    // never ran or supervision broke, err says why
+} sidecar_shell_outcome_t;
+
+typedef struct {
+    sidecar_shell_outcome_t outcome;
+    int code;        // exit status or signal number
+    const char *err; // static text for SIDECAR_SHELL_FAILED, else NULL
+    int errnum;      // errno at the failure for SIDECAR_SHELL_FAILED, else 0
+} sidecar_shell_result_t;
+
+typedef struct {
+    // longest quiet stretch allowed between output, zero for no ceiling
+    uint32_t silence_timeout_ms;
+    // output cap in bytes, zero for no cap
+    size_t max_output_bytes;
+    // how long SIGTERM gets before SIGKILL, zero kills at once
+    uint32_t term_grace_ms;
+    int watch_fd;
+    void *ctx;
+    bool (*on_output)(void *ctx, const char *buf, size_t len);
+    bool (*on_watch)(void *ctx);
+} sidecar_shell_opts_t;
+
+// runs cmd via /bin/sh with stdin from /dev/null and stdout and stderr
+// merged into the output stream, blocks until the command is over
+void sidecar_shell_run(const char *cmd, const sidecar_shell_opts_t *opts, sidecar_shell_result_t *result);
+
+#endif // _NORNS_SIDECAR_SHELL_H_

--- a/norns/wscript
+++ b/norns/wscript
@@ -131,7 +131,8 @@ def build(bld):
         'main.cpp',
         'sidecar.cpp',
         'sidecar_lines.cpp',
-        'sidecar_msg.cpp'
+        'sidecar_msg.cpp',
+        'sidecar_shell.cpp'
     ]
 
     norns_libs = [

--- a/norns/wscript
+++ b/norns/wscript
@@ -129,7 +129,9 @@ def build(bld):
 
     norns_sources = [
         'main.cpp',
-        'sidecar.cpp'
+        'sidecar.cpp',
+        'sidecar_lines.cpp',
+        'sidecar_msg.cpp'
     ]
 
     norns_libs = [

--- a/norns/wscript
+++ b/norns/wscript
@@ -26,6 +26,7 @@ def build(bld):
         '../matron/src/input.cc',
         '../matron/src/jack_client.cpp',
         '../matron/src/lua_eval.cc',
+        '../matron/src/lua_shell.cc',
         '../matron/src/main.cc',
         '../matron/src/metro.cc',
         '../matron/src/oracle.cc',

--- a/tests/matron/lua_shell/lua_shell_stubs.cpp
+++ b/tests/matron/lua_shell/lua_shell_stubs.cpp
@@ -1,0 +1,63 @@
+// test stubs for matron/src/lua_shell.cc externs.
+
+#include <cstdlib>
+#include <cstring>
+
+#include "system_cmd.h"
+
+#include "lua_shell_stubs.h"
+
+//---------------------------------
+//--- test state
+
+const char *g_stub_output = "";
+sidecar_result_t g_stub_result = SIDECAR_OK;
+bool g_stub_signalled = false;
+int g_stub_code = 0;
+
+const char *g_last_cmd = nullptr;
+uint32_t g_last_timeout_ms = 0;
+int g_call_count = 0;
+
+static char *owned_cmd = nullptr;
+
+void lua_shell_stubs_reset() {
+    free(owned_cmd);
+    owned_cmd = nullptr;
+    g_stub_output = "";
+    g_stub_result = SIDECAR_OK;
+    g_stub_signalled = false;
+    g_stub_code = 0;
+    g_last_cmd = nullptr;
+    g_last_timeout_ms = 0;
+    g_call_count = 0;
+}
+
+//---------------------------------
+//--- stubbed externs
+
+bool system_cmd_sync(const char *cmd, char **out, size_t *size, sidecar_status_t *status, uint32_t timeout_ms) {
+    free(owned_cmd);
+    owned_cmd = strdup(cmd);
+    g_last_cmd = owned_cmd;
+    g_last_timeout_ms = timeout_ms;
+    ++g_call_count;
+
+    if (status != nullptr) {
+        status->result = g_stub_result;
+        status->signalled = g_stub_signalled;
+        status->code = g_stub_code;
+        status->err = nullptr;
+    }
+
+    if (g_stub_result == SIDECAR_TRANSPORT_FAILED) {
+        *out = nullptr;
+        *size = 0;
+        return false;
+    }
+
+    *size = strlen(g_stub_output) + 1;
+    *out = (char *)malloc(*size);
+    memcpy(*out, g_stub_output, *size);
+    return true;
+}

--- a/tests/matron/lua_shell/lua_shell_stubs.h
+++ b/tests/matron/lua_shell/lua_shell_stubs.h
@@ -1,0 +1,18 @@
+// shared declarations for the lua_shell test stubs.
+
+#pragma once
+
+#include <stdint.h>
+
+#include "sidecar.h"
+
+extern const char *g_stub_output;
+extern sidecar_result_t g_stub_result;
+extern bool g_stub_signalled;
+extern int g_stub_code;
+
+extern const char *g_last_cmd;
+extern uint32_t g_last_timeout_ms;
+extern int g_call_count;
+
+void lua_shell_stubs_reset();

--- a/tests/matron/lua_shell/test_lua_shell.cpp
+++ b/tests/matron/lua_shell/test_lua_shell.cpp
@@ -1,0 +1,424 @@
+// tests for matron/src/lua_shell.cc.
+//
+// these drive a real lua vm.
+
+#include <doctest/doctest.h>
+#include <string>
+
+#include <lauxlib.h>
+#include <lua.h>
+#include <lualib.h>
+
+#include "lua_shell.h"
+
+#include "lua_shell_stubs.h"
+
+namespace {
+
+struct vm_t {
+    vm_t() {
+        lua_shell_stubs_reset();
+        l = luaL_newstate();
+        luaL_openlibs(l);
+        lua_shell_install(l);
+        run("printed = {}\nprint = function(s) printed[#printed + 1] = s end");
+    }
+
+    ~vm_t() {
+        lua_close(l);
+    }
+
+    void run(const char *src) {
+        if (luaL_dostring(l, src) != LUA_OK) {
+            FAIL(lua_tostring(l, -1));
+        }
+    }
+
+    void push_eval(const char *expr) {
+        const std::string src = std::string("return ") + expr;
+        if (luaL_dostring(l, src.c_str()) != LUA_OK) {
+            FAIL(lua_tostring(l, -1));
+        }
+    }
+
+    bool is_nil(const char *expr) {
+        push_eval(expr);
+        const bool v = lua_isnil(l, -1);
+        lua_pop(l, 1);
+        return v;
+    }
+
+    bool boolean(const char *expr) {
+        push_eval(expr);
+        const bool v = lua_toboolean(l, -1);
+        lua_pop(l, 1);
+        return v;
+    }
+
+    std::string string(const char *expr) {
+        push_eval(expr);
+        const char *s = lua_tostring(l, -1);
+        const std::string v = s != nullptr ? s : "";
+        lua_pop(l, 1);
+        return v;
+    }
+
+    lua_Integer integer(const char *expr) {
+        push_eval(expr);
+        const lua_Integer v = lua_tointeger(l, -1);
+        lua_pop(l, 1);
+        return v;
+    }
+
+    lua_State *l;
+};
+
+} // namespace
+
+//---------------------------------
+//--- the stdlib contract
+
+TEST_CASE("lua_shell: a command that exits zero returns the stdlib triple") {
+    vm_t vm;
+    vm.run("ok, how, code = os.execute('true')");
+
+    CHECK(vm.boolean("ok"));
+    CHECK(vm.string("how") == "exit");
+    CHECK(vm.integer("code") == 0);
+}
+
+TEST_CASE("lua_shell: a non-zero exit returns nil and its own code") {
+    vm_t vm;
+    g_stub_result = SIDECAR_CMD_FAILED;
+    g_stub_code = 7;
+    vm.run("ok, how, code = os.execute('exit 7')");
+
+    CHECK(vm.is_nil("ok"));
+    CHECK(vm.string("how") == "exit");
+    CHECK(vm.integer("code") == 7);
+}
+
+TEST_CASE("lua_shell: a signalled command reports the signal, not an exit") {
+    vm_t vm;
+    g_stub_result = SIDECAR_CMD_FAILED;
+    g_stub_signalled = true;
+    g_stub_code = 9;
+    vm.run("ok, how, code = os.execute('kill -9 $$')");
+
+    CHECK(vm.is_nil("ok"));
+    CHECK(vm.string("how") == "signal");
+    CHECK(vm.integer("code") == 9);
+}
+
+TEST_CASE("lua_shell: a command that never ran reads as a plain failure") {
+    vm_t vm;
+    g_stub_result = SIDECAR_CMD_FAILED;
+    g_stub_code = 0;
+    vm.run("ok, how, code = os.execute('x')");
+
+    CHECK(vm.is_nil("ok"));
+    CHECK(vm.string("how") == "exit");
+    CHECK(vm.integer("code") == 1);
+}
+
+TEST_CASE("lua_shell: a transport failure reads as a failure too") {
+    vm_t vm;
+    g_stub_result = SIDECAR_TRANSPORT_FAILED;
+    vm.run("ok, how, code = os.execute('x')");
+
+    CHECK(vm.is_nil("ok"));
+    CHECK(vm.string("how") == "exit");
+    CHECK(vm.integer("code") == 1);
+}
+
+TEST_CASE("lua_shell: os.execute with no argument reports a shell is available") {
+    vm_t vm;
+    vm.run("available = os.execute()");
+
+    CHECK(vm.boolean("available"));
+    CHECK(g_call_count == 0);
+}
+
+//---------------------------------
+//--- output
+
+TEST_CASE("lua_shell: what the command printed reaches print") {
+    vm_t vm;
+    g_stub_output = "hello\n";
+    vm.run("os.execute('echo hello')");
+
+    CHECK(vm.integer("#printed") == 1);
+    CHECK(vm.string("printed[1]") == "hello");
+}
+
+TEST_CASE("lua_shell: the command's own trailing newline is not doubled") {
+    vm_t vm;
+    g_stub_output = "a\nb\n";
+    vm.run("os.execute('x')");
+
+    CHECK(vm.string("printed[1]") == "a\nb");
+}
+
+TEST_CASE("lua_shell: a command printing a bare newline still prints a line") {
+    vm_t vm;
+    g_stub_output = "\n";
+    vm.run("os.execute('echo')");
+
+    CHECK(vm.integer("#printed") == 1);
+    CHECK(vm.string("printed[1]") == "");
+}
+
+TEST_CASE("lua_shell: a silent command prints nothing at all") {
+    vm_t vm;
+    g_stub_output = "";
+    vm.run("os.execute('true')");
+
+    CHECK(vm.integer("#printed") == 0);
+}
+
+TEST_CASE("lua_shell: output survives a failing command") {
+    vm_t vm;
+    g_stub_output = "partial\n";
+    g_stub_result = SIDECAR_CMD_FAILED;
+    g_stub_code = 1;
+    vm.run("ok = os.execute('x')");
+
+    CHECK(vm.is_nil("ok"));
+    CHECK(vm.string("printed[1]") == "partial");
+}
+
+TEST_CASE("lua_shell: a script that breaks print does not break os.execute") {
+    vm_t vm;
+    g_stub_output = "hi\n";
+    vm.run("print = function() error('no printing here') end");
+    vm.run("ok, how, code = os.execute('x')");
+
+    CHECK(vm.boolean("ok"));
+    CHECK(vm.integer("code") == 0);
+}
+
+//---------------------------------
+//--- what reaches the sidecar
+
+TEST_CASE("lua_shell: the command text goes to the sidecar unchanged") {
+    vm_t vm;
+    vm.run("os.execute('ls -la /tmp')");
+
+    REQUIRE(g_last_cmd != nullptr);
+    CHECK(std::string(g_last_cmd) == "ls -la /tmp");
+    CHECK(g_call_count == 1);
+}
+
+TEST_CASE("lua_shell: os.execute asks for no silence ceiling") {
+    vm_t vm;
+    vm.run("os.execute('sleep 300')");
+
+    CHECK(g_last_timeout_ms == SIDECAR_CMD_TIMEOUT_NONE);
+}
+
+TEST_CASE("lua_shell: a non-string command is refused rather than run") {
+    vm_t vm;
+    vm.run("ok = pcall(os.execute, {})");
+
+    CHECK_FALSE(vm.boolean("ok"));
+    CHECK(g_call_count == 0);
+}
+
+//---------------------------------
+//--- io.popen
+
+TEST_CASE("lua_shell: io.popen reads a command's whole output") {
+    vm_t vm;
+    g_stub_output = "one\ntwo\n";
+    vm.run("f = io.popen('ls')\nall = f:read('a')");
+
+    CHECK(vm.string("all") == "one\ntwo\n");
+}
+
+TEST_CASE("lua_shell: io.popen accepts the older starred read formats") {
+    vm_t vm;
+    g_stub_output = "hi\n";
+    vm.run("f = io.popen('x')\nall = f:read('*a')");
+
+    CHECK(vm.string("all") == "hi\n");
+}
+
+TEST_CASE("lua_shell: reading lines drops the newline, and runs out at the end") {
+    vm_t vm;
+    g_stub_output = "one\ntwo\n";
+    vm.run("f = io.popen('x')\na = f:read('l')\nb = f:read('l')\nc = f:read('l')");
+
+    CHECK(vm.string("a") == "one");
+    CHECK(vm.string("b") == "two");
+    CHECK(vm.is_nil("c"));
+}
+
+TEST_CASE("lua_shell: the L format keeps the newline") {
+    vm_t vm;
+    g_stub_output = "one\ntwo";
+    vm.run("f = io.popen('x')\na = f:read('L')\nb = f:read('L')");
+
+    CHECK(vm.string("a") == "one\n");
+    CHECK(vm.string("b") == "two"); // the last line had none to keep
+}
+
+TEST_CASE("lua_shell: reading with no format returns a line") {
+    vm_t vm;
+    g_stub_output = "only\n";
+    vm.run("f = io.popen('x')\na = f:read()");
+
+    CHECK(vm.string("a") == "only");
+}
+
+TEST_CASE("lua_shell: a byte count reads exactly that many") {
+    vm_t vm;
+    g_stub_output = "abcdef";
+    vm.run("f = io.popen('x')\na = f:read(3)\nb = f:read(3)\nc = f:read(1)");
+
+    CHECK(vm.string("a") == "abc");
+    CHECK(vm.string("b") == "def");
+    CHECK(vm.is_nil("c"));
+}
+
+TEST_CASE("lua_shell: reading zero bytes probes for the end of the output") {
+    vm_t vm;
+    g_stub_output = "abc";
+    vm.run("f = io.popen('x')\na = f:read(0)\nf:read('a')\nb = f:read(0)");
+
+    CHECK(vm.boolean("a == ''"));
+    CHECK(vm.is_nil("b"));
+}
+
+TEST_CASE("lua_shell: reading a number parses it out of the output") {
+    vm_t vm;
+    g_stub_output = "  42  7\n";
+    vm.run("f = io.popen('x')\na = f:read('n')\nb = f:read('n')");
+
+    CHECK(vm.integer("a") == 42);
+    CHECK(vm.integer("b") == 7);
+}
+
+TEST_CASE("lua_shell: several formats can be read at once") {
+    vm_t vm;
+    g_stub_output = "one\ntwo\n";
+    vm.run("f = io.popen('x')\na, b = f:read('l', 'l')");
+
+    CHECK(vm.string("a") == "one");
+    CHECK(vm.string("b") == "two");
+}
+
+TEST_CASE("lua_shell: reading past the end yields an empty string for a, nil for a line") {
+    vm_t vm;
+    g_stub_output = "";
+    vm.run("f = io.popen('x')\na = f:read('a')\nb = f:read('l')");
+
+    CHECK(vm.string("a") == "");
+    CHECK(vm.is_nil("b"));
+}
+
+TEST_CASE("lua_shell: lines iterates the output") {
+    vm_t vm;
+    g_stub_output = "one\ntwo\nthree\n";
+    vm.run("f = io.popen('x')\ngot = {}\nfor line in f:lines() do got[#got + 1] = line end");
+
+    CHECK(vm.integer("#got") == 3);
+    CHECK(vm.string("got[1]") == "one");
+    CHECK(vm.string("got[3]") == "three");
+}
+
+TEST_CASE("lua_shell: close reports how the command ended") {
+    vm_t vm;
+    vm.run("f = io.popen('true')\nok, how, code = f:close()");
+
+    CHECK(vm.boolean("ok"));
+    CHECK(vm.string("how") == "exit");
+    CHECK(vm.integer("code") == 0);
+}
+
+TEST_CASE("lua_shell: close reports a failing command's own code") {
+    vm_t vm;
+    g_stub_result = SIDECAR_CMD_FAILED;
+    g_stub_code = 3;
+    vm.run("f = io.popen('x')\nok, how, code = f:close()");
+
+    CHECK(vm.is_nil("ok"));
+    CHECK(vm.string("how") == "exit");
+    CHECK(vm.integer("code") == 3);
+}
+
+TEST_CASE("lua_shell: output is still readable after a failing command") {
+    vm_t vm;
+    g_stub_output = "partial\n";
+    g_stub_result = SIDECAR_CMD_FAILED;
+    g_stub_code = 1;
+    vm.run("f = io.popen('x')\nall = f:read('a')");
+
+    CHECK(vm.string("all") == "partial\n");
+}
+
+TEST_CASE("lua_shell: reading a closed handle is an error, as it is in the stdlib") {
+    vm_t vm;
+    vm.run("f = io.popen('x')\nf:close()\nok = pcall(function() return f:read('a') end)");
+
+    CHECK_FALSE(vm.boolean("ok"));
+}
+
+TEST_CASE("lua_shell: closing twice is an error rather than a second answer") {
+    vm_t vm;
+    vm.run("f = io.popen('x')\nf:close()\nok = pcall(function() return f:close() end)");
+
+    CHECK_FALSE(vm.boolean("ok"));
+}
+
+TEST_CASE("lua_shell: iterating lines after close is an error too") {
+    vm_t vm;
+    g_stub_output = "one\ntwo\n";
+    vm.run("f = io.popen('x')\nit = f:lines()\nf:close()\nok = pcall(it)");
+
+    CHECK_FALSE(vm.boolean("ok"));
+}
+
+TEST_CASE("lua_shell: write mode is refused") {
+    // remove this test when io.popen is fixed
+    vm_t vm;
+    vm.run("ok, err = pcall(io.popen, 'x', 'w')");
+
+    CHECK_FALSE(vm.boolean("ok"));
+    CHECK(vm.string("err").find("write mode") != std::string::npos);
+    CHECK(g_call_count == 0);
+}
+
+TEST_CASE("lua_shell: an unknown mode is refused") {
+    vm_t vm;
+    vm.run("ok, err = pcall(io.popen, 'x', 'q')");
+
+    CHECK_FALSE(vm.boolean("ok"));
+    CHECK(vm.string("err").find("write mode") == std::string::npos);
+    CHECK(g_call_count == 0);
+}
+
+TEST_CASE("lua_shell: read mode may be given explicitly") {
+    vm_t vm;
+    g_stub_output = "fine\n";
+    vm.run("f = io.popen('x', 'r')\nall = f:read('a')");
+
+    CHECK(vm.string("all") == "fine\n");
+}
+
+TEST_CASE("lua_shell: io.popen asks for no silence ceiling either") {
+    vm_t vm;
+    vm.run("f = io.popen('sleep 300')");
+
+    CHECK(g_last_timeout_ms == SIDECAR_CMD_TIMEOUT_NONE);
+    CHECK(g_call_count == 1);
+}
+
+TEST_CASE("lua_shell: a transport failure still yields a usable handle") {
+    vm_t vm;
+    g_stub_result = SIDECAR_TRANSPORT_FAILED;
+    vm.run("f = io.popen('x')\nall = f:read('a')\nok, how, code = f:close()");
+
+    CHECK(vm.string("all") == "");
+    CHECK(vm.is_nil("ok"));
+    CHECK(vm.integer("code") == 1);
+}

--- a/tests/matron/system_cmd/system_cmd_stubs.cpp
+++ b/tests/matron/system_cmd/system_cmd_stubs.cpp
@@ -1,0 +1,98 @@
+// test stubs for matron/src/system_cmd.cc externs.
+
+#include <cstdlib>
+#include <cstring>
+
+#include "events.h"
+#include "sidecar.h"
+#include "system_cmd.h"
+
+#include "system_cmd_stubs.h"
+
+//---------------------------------
+//--- test state
+
+const char *g_last_cmd = nullptr;
+void *g_last_ctx = nullptr;
+sidecar_chunk_cb_t g_last_on_chunk = nullptr;
+sidecar_done_cb_t g_last_on_done = nullptr;
+
+static char *owned_cmd = nullptr;
+
+static void capture_cmd(const char *cmd) {
+    free(owned_cmd);
+    owned_cmd = strdup(cmd);
+    g_last_cmd = owned_cmd;
+}
+
+const char *g_sync_chunks[SYNC_SCRIPT_MAX_CHUNKS] = {};
+int g_sync_chunk_count = 0;
+sidecar_result_t g_sync_result = SIDECAR_OK;
+const char *g_sync_errmsg = nullptr;
+bool g_sync_signalled = false;
+int g_sync_code = 0;
+
+uint32_t g_last_timeout_ms = 0;
+
+bool g_cmd_async_result = true;
+
+union event_data *g_last_event = nullptr;
+int g_event_post_count = 0;
+
+void system_cmd_stubs_reset() {
+    free(owned_cmd);
+    owned_cmd = nullptr;
+    g_last_cmd = nullptr;
+    g_last_ctx = nullptr;
+    g_last_on_chunk = nullptr;
+    g_last_on_done = nullptr;
+    for (int i = 0; i < SYNC_SCRIPT_MAX_CHUNKS; ++i) {
+        g_sync_chunks[i] = nullptr;
+    }
+    g_sync_chunk_count = 0;
+    g_sync_result = SIDECAR_OK;
+    g_sync_errmsg = nullptr;
+    g_sync_signalled = false;
+    g_sync_code = 0;
+    g_last_timeout_ms = 0;
+    g_cmd_async_result = true;
+    g_last_event = nullptr;
+    g_event_post_count = 0;
+    system_cmd_test_realloc = realloc;
+}
+
+//---------------------------------
+//--- stubbed externs
+
+bool sidecar_client_cmd_async(const char *cmd, uint32_t timeout_ms, void *ctx, sidecar_chunk_cb_t on_chunk, sidecar_done_cb_t on_done) {
+    capture_cmd(cmd);
+    g_last_timeout_ms = timeout_ms;
+    g_last_ctx = ctx;
+    g_last_on_chunk = on_chunk;
+    g_last_on_done = on_done;
+    return g_cmd_async_result;
+}
+
+void sidecar_client_cmd(const char *cmd, uint32_t timeout_ms, void *ctx, sidecar_chunk_cb_t on_chunk, sidecar_done_cb_t on_done) {
+    capture_cmd(cmd);
+    g_last_timeout_ms = timeout_ms;
+    g_last_ctx = ctx;
+    g_last_on_chunk = on_chunk;
+    g_last_on_done = on_done;
+    for (int i = 0; i < g_sync_chunk_count; ++i) {
+        on_chunk(ctx, g_sync_chunks[i], std::strlen(g_sync_chunks[i]));
+    }
+    const sidecar_status_t status = {g_sync_result, g_sync_signalled, g_sync_code, g_sync_errmsg};
+    on_done(cmd, ctx, &status);
+}
+
+union event_data *event_data_new(event_t evcode) {
+    auto *ev = (union event_data *)calloc(1, sizeof(union event_data));
+    ev->type = evcode;
+    return ev;
+}
+
+void event_post(union event_data *ev) {
+    g_last_event = ev;
+    ++g_event_post_count;
+}

--- a/tests/matron/system_cmd/system_cmd_stubs.cpp
+++ b/tests/matron/system_cmd/system_cmd_stubs.cpp
@@ -17,12 +17,21 @@ void *g_last_ctx = nullptr;
 sidecar_chunk_cb_t g_last_on_chunk = nullptr;
 sidecar_done_cb_t g_last_on_done = nullptr;
 
+const char *g_last_unit = nullptr;
+
 static char *owned_cmd = nullptr;
+static char *owned_unit = nullptr;
 
 static void capture_cmd(const char *cmd) {
     free(owned_cmd);
     owned_cmd = strdup(cmd);
     g_last_cmd = owned_cmd;
+}
+
+static void capture_unit(const char *unit) {
+    free(owned_unit);
+    owned_unit = strdup(unit);
+    g_last_unit = owned_unit;
 }
 
 const char *g_sync_chunks[SYNC_SCRIPT_MAX_CHUNKS] = {};
@@ -42,10 +51,13 @@ int g_event_post_count = 0;
 void system_cmd_stubs_reset() {
     free(owned_cmd);
     owned_cmd = nullptr;
+    free(owned_unit);
+    owned_unit = nullptr;
     g_last_cmd = nullptr;
     g_last_ctx = nullptr;
     g_last_on_chunk = nullptr;
     g_last_on_done = nullptr;
+    g_last_unit = nullptr;
     for (int i = 0; i < SYNC_SCRIPT_MAX_CHUNKS; ++i) {
         g_sync_chunks[i] = nullptr;
     }
@@ -71,6 +83,14 @@ bool sidecar_client_cmd_async(const char *cmd, uint32_t timeout_ms, void *ctx, s
     g_last_on_chunk = on_chunk;
     g_last_on_done = on_done;
     return g_cmd_async_result;
+}
+
+bool sidecar_client_detach_async(const char *cmd, const char *unit, void *ctx, sidecar_done_cb_t on_done) {
+    capture_cmd(cmd);
+    capture_unit(unit);
+    g_last_ctx = ctx;
+    g_last_on_done = on_done;
+    return true;
 }
 
 void sidecar_client_cmd(const char *cmd, uint32_t timeout_ms, void *ctx, sidecar_chunk_cb_t on_chunk, sidecar_done_cb_t on_done) {

--- a/tests/matron/system_cmd/system_cmd_stubs.h
+++ b/tests/matron/system_cmd/system_cmd_stubs.h
@@ -10,6 +10,8 @@ extern void *g_last_ctx;
 extern sidecar_chunk_cb_t g_last_on_chunk;
 extern sidecar_done_cb_t g_last_on_done;
 
+extern const char *g_last_unit;
+
 enum { SYNC_SCRIPT_MAX_CHUNKS = 8 };
 extern const char *g_sync_chunks[SYNC_SCRIPT_MAX_CHUNKS];
 extern int g_sync_chunk_count;

--- a/tests/matron/system_cmd/system_cmd_stubs.h
+++ b/tests/matron/system_cmd/system_cmd_stubs.h
@@ -1,0 +1,28 @@
+// shared declarations for the system_cmd test stubs.
+
+#pragma once
+
+#include "events.h"
+#include "sidecar.h"
+
+extern const char *g_last_cmd;
+extern void *g_last_ctx;
+extern sidecar_chunk_cb_t g_last_on_chunk;
+extern sidecar_done_cb_t g_last_on_done;
+
+enum { SYNC_SCRIPT_MAX_CHUNKS = 8 };
+extern const char *g_sync_chunks[SYNC_SCRIPT_MAX_CHUNKS];
+extern int g_sync_chunk_count;
+extern sidecar_result_t g_sync_result;
+extern const char *g_sync_errmsg;
+extern bool g_sync_signalled;
+extern int g_sync_code;
+
+extern uint32_t g_last_timeout_ms;
+
+extern bool g_cmd_async_result;
+
+extern union event_data *g_last_event;
+extern int g_event_post_count;
+
+void system_cmd_stubs_reset();

--- a/tests/matron/system_cmd/test_system_cmd.cpp
+++ b/tests/matron/system_cmd/test_system_cmd.cpp
@@ -1,0 +1,355 @@
+// tests for matron/src/system_cmd.cc
+
+#include <cstdlib>
+#include <cstring>
+#include <doctest/doctest.h>
+#include <vector>
+
+#include "events.h"
+#include "system_cmd.h"
+
+#include "sidecar.h"
+#include "system_cmd_stubs.h"
+
+// helpers for the tests below.
+namespace {
+
+void start_async(int cb_ref) {
+    system_cmd_stubs_reset();
+    REQUIRE(system_cmd("x", cb_ref));
+    REQUIRE(g_last_on_chunk != nullptr);
+    REQUIRE(g_last_on_done != nullptr);
+    REQUIRE(g_last_ctx != nullptr);
+}
+
+void emit_chunk(const char *chunk, size_t size) {
+    g_last_on_chunk(g_last_ctx, chunk, size);
+}
+
+void emit_done(sidecar_result_t result, const char *err) {
+    const sidecar_status_t status = {result, false, result == SIDECAR_OK ? 0 : 1, err};
+    g_last_on_done(g_last_cmd, g_last_ctx, &status);
+}
+
+void free_event(union event_data *ev) {
+    free(ev->system_cmd.capture);
+    free(ev);
+}
+
+void *failing_realloc(void *ptr, size_t size) {
+    (void)ptr;
+    (void)size;
+    return nullptr;
+}
+
+} // namespace
+
+TEST_CASE("system_cmd: chunks accumulate into one whole-output event") {
+    start_async(7);
+    emit_chunk("hel", 3);
+    emit_chunk("lo", 2);
+    CHECK(g_event_post_count == 0); // nothing posted until the command is done
+    emit_done(SIDECAR_OK, nullptr);
+
+    CHECK(g_event_post_count == 1);
+    REQUIRE(g_last_event != nullptr);
+    CHECK(g_last_event->system_cmd.cb_ref == 7);
+    REQUIRE(g_last_event->system_cmd.capture != nullptr);
+    CHECK(std::strcmp(g_last_event->system_cmd.capture, "hello") == 0);
+
+    free_event(g_last_event);
+}
+
+TEST_CASE("system_cmd: a silent successful command posts one event with empty capture") {
+    start_async(11);
+    emit_done(SIDECAR_OK, nullptr); // no chunks
+
+    CHECK(g_event_post_count == 1);
+    REQUIRE(g_last_event != nullptr);
+    CHECK(g_last_event->system_cmd.cb_ref == 11);
+    REQUIRE(g_last_event->system_cmd.capture != nullptr);
+    CHECK(g_last_event->system_cmd.capture[0] == '\0');
+
+    free_event(g_last_event);
+}
+
+TEST_CASE("system_cmd: transport failure posts one event with empty capture") {
+    start_async(42);
+    emit_chunk("par", 3); // partial output, discarded on failure
+    emit_done(SIDECAR_TRANSPORT_FAILED, "sidecar did not answer");
+
+    CHECK(g_event_post_count == 1);
+    REQUIRE(g_last_event != nullptr);
+    CHECK(g_last_event->system_cmd.cb_ref == 42);
+    REQUIRE(g_last_event->system_cmd.capture != nullptr);
+    CHECK(g_last_event->system_cmd.capture[0] == '\0');
+
+    free_event(g_last_event);
+}
+
+TEST_CASE("system_cmd: a failed enqueue is reported and posts nothing") {
+    system_cmd_stubs_reset();
+    g_cmd_async_result = false;
+
+    CHECK_FALSE(system_cmd("x", 8));
+    CHECK(g_event_post_count == 0);
+}
+
+TEST_CASE("system_cmd: non-zero exit delivers output without the error text") {
+    start_async(9);
+    emit_chunk("out", 3);
+    emit_done(SIDECAR_CMD_FAILED, "exit status 1");
+
+    CHECK(g_event_post_count == 1);
+    REQUIRE(g_last_event != nullptr);
+    CHECK(g_last_event->system_cmd.cb_ref == 9);
+    REQUIRE(g_last_event->system_cmd.capture != nullptr);
+    CHECK(std::strcmp(g_last_event->system_cmd.capture, "out") == 0);
+
+    free_event(g_last_event);
+}
+
+TEST_CASE("system_cmd: accumulated output is capped, command still completes") {
+    start_async(21);
+    emit_chunk("hello", 5);
+
+    std::vector<char> block(256 * 1024, 'x');
+    for (int i = 0; i < 5; ++i) {
+        emit_chunk(block.data(), block.size());
+    }
+    CHECK(g_event_post_count == 0);
+    emit_done(SIDECAR_OK, nullptr);
+
+    CHECK(g_event_post_count == 1);
+    REQUIRE(g_last_event != nullptr);
+    CHECK(g_last_event->system_cmd.cb_ref == 21);
+    REQUIRE(g_last_event->system_cmd.capture != nullptr);
+    CHECK(std::strlen(g_last_event->system_cmd.capture) == SYSTEM_CMD_CAPTURE_MAX);
+    CHECK(std::strncmp(g_last_event->system_cmd.capture, "hello", 5) == 0);
+
+    free_event(g_last_event);
+}
+
+TEST_CASE("system_cmd: output that cannot be stored truncates, leaving no gap") {
+    start_async(22);
+    emit_chunk("111", 3);
+
+    system_cmd_test_realloc = failing_realloc;
+    emit_chunk("222", 3);
+    system_cmd_test_realloc = realloc; // allocation works again
+
+    emit_chunk("333", 3);
+    emit_done(SIDECAR_OK, nullptr);
+
+    CHECK(g_event_post_count == 1);
+    REQUIRE(g_last_event != nullptr);
+    CHECK(g_last_event->system_cmd.cb_ref == 22);
+    REQUIRE(g_last_event->system_cmd.capture != nullptr);
+    CHECK(std::strcmp(g_last_event->system_cmd.capture, "111") == 0); // not "111333"
+
+    free_event(g_last_event);
+}
+
+TEST_CASE("system_cmd: output that cannot be terminated is dropped, command still completes") {
+    start_async(23);
+    emit_chunk("111", 3);
+
+    system_cmd_test_realloc = failing_realloc;
+    emit_done(SIDECAR_OK, nullptr);
+    system_cmd_test_realloc = realloc;
+
+    CHECK(g_event_post_count == 1);
+    REQUIRE(g_last_event != nullptr);
+    CHECK(g_last_event->system_cmd.cb_ref == 23);
+    REQUIRE(g_last_event->system_cmd.capture != nullptr);
+    CHECK(g_last_event->system_cmd.capture[0] == '\0');
+
+    free_event(g_last_event);
+}
+
+TEST_CASE("system_cmd_sync: concatenates chunks into a null character terminated buffer") {
+    system_cmd_stubs_reset();
+    g_sync_chunks[0] = "hel";
+    g_sync_chunks[1] = "lo";
+    g_sync_chunk_count = 2;
+
+    char *out = nullptr;
+    size_t size = 0;
+    REQUIRE(system_cmd_sync("x", &out, &size));
+    CHECK(std::strcmp(g_last_cmd, "x") == 0);
+    REQUIRE(out != nullptr);
+    CHECK(std::strcmp(out, "hello") == 0);
+    CHECK(size == 6); // includes the terminator
+
+    free(out);
+}
+
+TEST_CASE("system_cmd_sync: no output yields empty string with size 1") {
+    system_cmd_stubs_reset();
+
+    char *out = nullptr;
+    size_t size = 0;
+    REQUIRE(system_cmd_sync("x", &out, &size));
+    REQUIRE(out != nullptr);
+    CHECK(out[0] == '\0');
+    CHECK(size == 1);
+
+    free(out);
+}
+
+TEST_CASE("system_cmd_sync: non-zero exit keeps the output and still succeeds") {
+    system_cmd_stubs_reset();
+    g_sync_chunks[0] = "partial";
+    g_sync_chunk_count = 1;
+    g_sync_result = SIDECAR_CMD_FAILED;
+    g_sync_errmsg = "exit status 1";
+
+    // matching os.execute, a command that runs and fails still returns what
+    // it printed. only a transport failure discards the output
+    char *out = nullptr;
+    size_t size = 0;
+    CHECK(system_cmd_sync("x", &out, &size));
+    REQUIRE(out != nullptr);
+    CHECK(std::strcmp(out, "partial") == 0);
+
+    free(out);
+}
+
+TEST_CASE("system_cmd_sync: transport failure yields NULL out and returns false") {
+    system_cmd_stubs_reset();
+    g_sync_chunks[0] = "par"; // partial output, discarded on failure
+    g_sync_chunk_count = 1;
+    g_sync_result = SIDECAR_TRANSPORT_FAILED;
+    g_sync_errmsg = "sidecar did not answer";
+
+    char sentinel = 0;
+    char *out = &sentinel;
+    size_t size = 99;
+    CHECK_FALSE(system_cmd_sync("x", &out, &size));
+    CHECK(out == nullptr);
+    CHECK(size == 0);
+}
+
+//---------------------------------
+//--- how a command ended
+
+TEST_CASE("system_cmd_sync: a command that exits zero reports OK") {
+    system_cmd_stubs_reset();
+
+    char *out = nullptr;
+    size_t size = 0;
+    sidecar_status_t status = {};
+    REQUIRE(system_cmd_sync("x", &out, &size, &status));
+    CHECK(status.result == SIDECAR_OK);
+    CHECK_FALSE(status.signalled);
+    CHECK(status.code == 0);
+
+    free(out);
+}
+
+TEST_CASE("system_cmd_sync: a non-zero exit reports its own code") {
+    system_cmd_stubs_reset();
+    g_sync_result = SIDECAR_CMD_FAILED;
+    g_sync_code = 7;
+
+    char *out = nullptr;
+    size_t size = 0;
+    sidecar_status_t status = {};
+    CHECK(system_cmd_sync("x", &out, &size, &status));
+    CHECK(status.result == SIDECAR_CMD_FAILED);
+    CHECK_FALSE(status.signalled);
+    CHECK(status.code == 7);
+
+    free(out);
+}
+
+TEST_CASE("system_cmd_sync: a signalled command is told apart from an exit") {
+    system_cmd_stubs_reset();
+    g_sync_result = SIDECAR_CMD_FAILED;
+    g_sync_signalled = true;
+    g_sync_code = 9;
+
+    char *out = nullptr;
+    size_t size = 0;
+    sidecar_status_t status = {};
+    CHECK(system_cmd_sync("x", &out, &size, &status));
+    CHECK(status.signalled);
+    CHECK(status.code == 9);
+
+    free(out);
+}
+
+TEST_CASE("system_cmd_sync: a transport failure still fills in the status") {
+    system_cmd_stubs_reset();
+    g_sync_result = SIDECAR_TRANSPORT_FAILED;
+    g_sync_errmsg = "sidecar did not answer";
+
+    char *out = nullptr;
+    size_t size = 0;
+    sidecar_status_t status = {};
+    CHECK_FALSE(system_cmd_sync("x", &out, &size, &status));
+    CHECK(status.result == SIDECAR_TRANSPORT_FAILED);
+}
+
+TEST_CASE("system_cmd_sync: the status err text does not outlive the call") {
+    system_cmd_stubs_reset();
+    g_sync_result = SIDECAR_CMD_FAILED;
+    g_sync_errmsg = "exit status 1";
+    g_sync_code = 1;
+
+    char *out = nullptr;
+    size_t size = 0;
+    sidecar_status_t status = {};
+    CHECK(system_cmd_sync("x", &out, &size, &status));
+    CHECK(status.err == nullptr);
+
+    free(out);
+}
+
+TEST_CASE("system_cmd_sync: a caller wanting no status still works") {
+    system_cmd_stubs_reset();
+    g_sync_result = SIDECAR_CMD_FAILED;
+    g_sync_code = 3;
+
+    char *out = nullptr;
+    size_t size = 0;
+    CHECK(system_cmd_sync("x", &out, &size));
+    REQUIRE(out != nullptr);
+
+    free(out);
+}
+
+//---------------------------------
+//--- silence ceilings
+
+TEST_CASE("system_cmd_sync: the default ceiling travels with the request") {
+    system_cmd_stubs_reset();
+
+    char *out = nullptr;
+    size_t size = 0;
+    REQUIRE(system_cmd_sync("x", &out, &size));
+    CHECK(g_last_timeout_ms == SIDECAR_CMD_TIMEOUT_DEFAULT_MS);
+
+    free(out);
+}
+
+TEST_CASE("system_cmd_sync: a caller can ask for no ceiling at all") {
+    system_cmd_stubs_reset();
+
+    char *out = nullptr;
+    size_t size = 0;
+    sidecar_status_t status = {};
+    REQUIRE(system_cmd_sync("x", &out, &size, &status, SIDECAR_CMD_TIMEOUT_NONE));
+    CHECK(g_last_timeout_ms == 0);
+
+    free(out);
+}
+
+TEST_CASE("system_cmd: the async path keeps the default ceiling") {
+    system_cmd_stubs_reset();
+    REQUIRE(system_cmd("x", 5));
+    CHECK(g_last_timeout_ms == SIDECAR_CMD_TIMEOUT_DEFAULT_MS);
+
+    emit_done(SIDECAR_OK, nullptr);
+    free_event(g_last_event);
+}

--- a/tests/matron/system_cmd/test_system_cmd.cpp
+++ b/tests/matron/system_cmd/test_system_cmd.cpp
@@ -3,6 +3,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <doctest/doctest.h>
+#include <string>
 #include <vector>
 
 #include "events.h"
@@ -22,6 +23,12 @@ void start_async(int cb_ref) {
     REQUIRE(g_last_ctx != nullptr);
 }
 
+void start_detached(int cb_ref) {
+    system_cmd_stubs_reset();
+    REQUIRE(system_cmd_detached("x", "test-unit", cb_ref));
+    REQUIRE(g_last_on_done != nullptr);
+}
+
 void emit_chunk(const char *chunk, size_t size) {
     g_last_on_chunk(g_last_ctx, chunk, size);
 }
@@ -36,11 +43,36 @@ void free_event(union event_data *ev) {
     free(ev);
 }
 
+void free_done_event(union event_data *ev) {
+    free(ev->system_cmd_done.err);
+    free(ev);
+}
+
 void *failing_realloc(void *ptr, size_t size) {
     (void)ptr;
     (void)size;
     return nullptr;
 }
+
+// restores HOME on destruction, so cases that change it stay isolated
+struct home_guard_t {
+    home_guard_t() {
+        const char *home = getenv("HOME");
+        had = home != nullptr;
+        if (had) {
+            saved = home;
+        }
+    }
+    ~home_guard_t() {
+        if (had) {
+            setenv("HOME", saved.c_str(), 1);
+        } else {
+            unsetenv("HOME");
+        }
+    }
+    bool had;
+    std::string saved;
+};
 
 } // namespace
 
@@ -165,6 +197,52 @@ TEST_CASE("system_cmd: output that cannot be terminated is dropped, command stil
     CHECK(g_last_event->system_cmd.capture[0] == '\0');
 
     free_event(g_last_event);
+}
+
+TEST_CASE("system_cmd_detached: passes command and unit through to the transport") {
+    start_detached(15);
+    CHECK(std::strcmp(g_last_cmd, "x") == 0);
+    REQUIRE(g_last_unit != nullptr);
+    CHECK(std::strcmp(g_last_unit, "test-unit") == 0);
+    CHECK(g_last_on_chunk == nullptr);
+}
+
+TEST_CASE("system_cmd_detached: accepted launch posts one ok event") {
+    start_detached(16);
+    emit_done(SIDECAR_OK, nullptr);
+
+    CHECK(g_event_post_count == 1);
+    REQUIRE(g_last_event != nullptr);
+    CHECK(g_last_event->system_cmd_done.cb_ref == 16);
+    CHECK(g_last_event->system_cmd_done.ok);
+    CHECK(g_last_event->system_cmd_done.err == nullptr);
+    free_done_event(g_last_event);
+}
+
+TEST_CASE("system_cmd_detached: failed launch posts one event carrying the output") {
+    start_detached(17);
+    emit_done(SIDECAR_CMD_FAILED, "Failed to start transient service unit");
+
+    CHECK(g_event_post_count == 1);
+    REQUIRE(g_last_event != nullptr);
+    CHECK(g_last_event->system_cmd_done.cb_ref == 17);
+    CHECK_FALSE(g_last_event->system_cmd_done.ok);
+    REQUIRE(g_last_event->system_cmd_done.err != nullptr);
+    CHECK(std::strcmp(g_last_event->system_cmd_done.err, "Failed to start transient service unit") == 0);
+    free_done_event(g_last_event);
+}
+
+TEST_CASE("system_cmd_detached: transport failure posts one event, not ok") {
+    start_detached(18);
+    emit_done(SIDECAR_TRANSPORT_FAILED, "sidecar did not answer");
+
+    CHECK(g_event_post_count == 1);
+    REQUIRE(g_last_event != nullptr);
+    CHECK_FALSE(g_last_event->system_cmd_done.ok);
+    REQUIRE(g_last_event->system_cmd_done.err != nullptr);
+    CHECK(std::strstr(g_last_event->system_cmd_done.err, "may still have started") != nullptr);
+
+    free_done_event(g_last_event);
 }
 
 TEST_CASE("system_cmd_sync: concatenates chunks into a null character terminated buffer") {
@@ -352,4 +430,63 @@ TEST_CASE("system_cmd: the async path keeps the default ceiling") {
 
     emit_done(SIDECAR_OK, nullptr);
     free_event(g_last_event);
+}
+
+TEST_CASE("system_action: shutdown maps to the poweroff command and unit") {
+    system_cmd_stubs_reset();
+    REQUIRE(system_action("shutdown", 31));
+    REQUIRE(g_last_cmd != nullptr);
+    CHECK(std::strcmp(g_last_cmd, "sleep 0.5; sudo shutdown now") == 0);
+    REQUIRE(g_last_unit != nullptr);
+    CHECK(std::strcmp(g_last_unit, "norns-shutdown") == 0);
+}
+
+TEST_CASE("system_action: reset maps to the service restart command and unit") {
+    system_cmd_stubs_reset();
+    REQUIRE(system_action("reset", 32));
+    REQUIRE(g_last_cmd != nullptr);
+    CHECK(std::strcmp(g_last_cmd, "sudo systemctl restart norns-sclang.service norns-main.service") == 0);
+    REQUIRE(g_last_unit != nullptr);
+    CHECK(std::strcmp(g_last_unit, "norns-reset") == 0);
+}
+
+TEST_CASE("system_action: update builds the updater path from HOME") {
+    system_cmd_stubs_reset();
+    home_guard_t home;
+    setenv("HOME", "/test-home", 1);
+    REQUIRE(system_action("update", 33));
+    REQUIRE(g_last_cmd != nullptr);
+    CHECK(std::strcmp(g_last_cmd, "/bin/bash /test-home/norns/update/update.sh") == 0);
+    REQUIRE(g_last_unit != nullptr);
+    CHECK(std::strcmp(g_last_unit, "norns-update") == 0);
+}
+
+TEST_CASE("system_action: update falls back to /home/we when HOME is unset") {
+    system_cmd_stubs_reset();
+    home_guard_t home;
+    unsetenv("HOME");
+    REQUIRE(system_action("update", 34));
+    REQUIRE(g_last_cmd != nullptr);
+    CHECK(std::strcmp(g_last_cmd, "/bin/bash /home/we/norns/update/update.sh") == 0);
+}
+
+TEST_CASE("system_action: unknown action is rejected without touching the transport") {
+    system_cmd_stubs_reset();
+    CHECK_FALSE(system_action("frobnicate", 35));
+    CHECK(g_last_cmd == nullptr);
+    CHECK(g_last_on_done == nullptr);
+    CHECK(g_event_post_count == 0);
+}
+
+TEST_CASE("system_action: failed launch posts one event carrying the ref") {
+    system_cmd_stubs_reset();
+    REQUIRE(system_action("shutdown", 19));
+    REQUIRE(g_last_on_done != nullptr);
+    emit_done(SIDECAR_CMD_FAILED, "Failed to start transient service unit");
+
+    CHECK(g_event_post_count == 1);
+    REQUIRE(g_last_event != nullptr);
+    CHECK(g_last_event->system_cmd_done.cb_ref == 19);
+    CHECK_FALSE(g_last_event->system_cmd_done.ok);
+    free_done_event(g_last_event);
 }

--- a/tests/norns/sidecar/sidecar_deps.cpp
+++ b/tests/norns/sidecar/sidecar_deps.cpp
@@ -1,0 +1,5 @@
+// the mirror map compiles only sidecar.cpp, this pulls its sidecar_*
+// dependencies into the test binary as well
+#include "sidecar_lines.cpp"
+#include "sidecar_msg.cpp"
+#include "sidecar_shell.cpp"

--- a/tests/norns/sidecar/test_sidecar.cpp
+++ b/tests/norns/sidecar/test_sidecar.cpp
@@ -1,0 +1,57 @@
+// tests for norns/sidecar.cpp
+
+#include <doctest/doctest.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "sidecar.h"
+
+// helpers for the tests below.
+namespace {
+
+void *failing_calloc(size_t, size_t) {
+    return nullptr;
+}
+
+int strdup_successes_left = 0;
+char *counting_strdup(const char *s) {
+    if (strdup_successes_left <= 0) {
+        return nullptr;
+    }
+    strdup_successes_left--;
+    return strdup(s);
+}
+
+void ignore_chunk(void *, const char *, size_t) {
+}
+void ignore_done(const char *, void *, const sidecar_status_t *) {
+}
+
+// restores the real allocators when a test ends
+struct seam_guard {
+    ~seam_guard() {
+        sidecar_test_calloc = calloc;
+        sidecar_test_strdup = strdup;
+    }
+};
+
+} // namespace
+
+TEST_CASE("sidecar_client_cmd_async: reports failure when the request cannot be allocated") {
+    seam_guard guard;
+    sidecar_test_calloc = failing_calloc;
+
+    CHECK(sidecar_client_cmd_async("echo hi", 0, nullptr, ignore_chunk, ignore_done) == false);
+}
+
+TEST_CASE("sidecar_client_cmd_async: reports failure when the command cannot be copied") {
+    seam_guard guard;
+    strdup_successes_left = 0;
+    sidecar_test_strdup = counting_strdup;
+
+    CHECK(sidecar_client_cmd_async("echo hi", 0, nullptr, ignore_chunk, ignore_done) == false);
+}
+
+TEST_CASE("sidecar_client_cmd_async: enqueues and reports success when allocation works") {
+    CHECK(sidecar_client_cmd_async("echo hi", 0, nullptr, ignore_chunk, ignore_done) == true);
+}

--- a/tests/norns/sidecar/test_sidecar.cpp
+++ b/tests/norns/sidecar/test_sidecar.cpp
@@ -55,3 +55,14 @@ TEST_CASE("sidecar_client_cmd_async: reports failure when the command cannot be 
 TEST_CASE("sidecar_client_cmd_async: enqueues and reports success when allocation works") {
     CHECK(sidecar_client_cmd_async("echo hi", 0, nullptr, ignore_chunk, ignore_done) == true);
 }
+
+TEST_CASE("sidecar_client_detach_async: reports failure when either copy fails") {
+    seam_guard guard;
+    sidecar_test_strdup = counting_strdup;
+
+    strdup_successes_left = 0;
+    CHECK(sidecar_client_detach_async("cmd", "unit", nullptr, ignore_done) == false);
+
+    strdup_successes_left = 1;
+    CHECK(sidecar_client_detach_async("cmd", "unit", nullptr, ignore_done) == false);
+}

--- a/tests/norns/sidecar_lines/test_sidecar_lines.cpp
+++ b/tests/norns/sidecar_lines/test_sidecar_lines.cpp
@@ -1,0 +1,127 @@
+// tests for norns/sidecar_lines.cpp, the output splitter.
+
+#include <cstring>
+#include <doctest/doctest.h>
+#include <string>
+#include <vector>
+
+#include "sidecar_lines.h"
+
+// helpers for the tests below.
+namespace {
+
+using segments_t = std::vector<std::string>;
+
+void collect(void *ctx, const char *line, size_t len) {
+    ((segments_t *)ctx)->emplace_back(line, len);
+}
+
+segments_t split(const std::string &input) {
+    sidecar_lines_t s;
+    sidecar_lines_init(&s);
+    segments_t out;
+    for (char c : input) {
+        sidecar_lines_push(&s, c, &out, collect);
+    }
+    sidecar_lines_flush(&s, &out, collect);
+    return out;
+}
+
+std::string accumulated(const segments_t &segs) {
+    std::string all;
+    for (const auto &s : segs) {
+        all += s;
+    }
+    return all;
+}
+
+} // namespace
+
+TEST_CASE("sidecar_lines: a newline ends a segment and stays in it") {
+    CHECK(split("a\n") == segments_t{"a\n"});
+}
+
+TEST_CASE("sidecar_lines: CRLF is one line ending, not two") {
+    CHECK(split("a\r\n") == segments_t{"a\r\n"});
+}
+
+TEST_CASE("sidecar_lines: blank lines survive") {
+    CHECK(split("a\n\nb\n") == segments_t{"a\n", "\n", "b\n"});
+}
+
+TEST_CASE("sidecar_lines: a lone newline is a segment") {
+    CHECK(split("\n") == segments_t{"\n"});
+}
+
+TEST_CASE("sidecar_lines: a bare carriage return ends a segment and stays in it") {
+    CHECK(split("a\rb\r") == segments_t{"a\r", "b\r"});
+}
+
+TEST_CASE("sidecar_lines: progress lines arrive as they are overwritten") {
+    CHECK(split("In:1%\rIn:2%\rIn:3%\r") == segments_t{"In:1%\r", "In:2%\r", "In:3%\r"});
+}
+
+TEST_CASE("sidecar_lines: CRLF line endings throughout produce one segment per line") {
+    CHECK(split("one\r\ntwo\r\n") == segments_t{"one\r\n", "two\r\n"});
+}
+
+TEST_CASE("sidecar_lines: an unterminated tail is emitted by the flush") {
+    CHECK(split("a\nbc") == segments_t{"a\n", "bc"});
+}
+
+TEST_CASE("sidecar_lines: a trailing carriage return is emitted by the flush") {
+    CHECK(split("a\rb") == segments_t{"a\r", "b"});
+}
+
+TEST_CASE("sidecar_lines: empty input emits nothing") {
+    CHECK(split("").empty());
+}
+
+TEST_CASE("sidecar_lines: consecutive carriage returns each end a segment") {
+    CHECK(split("\r\r\r") == segments_t{"\r", "\r", "\r"});
+}
+
+TEST_CASE("sidecar_lines: accumulated output is the command's output, byte for byte") {
+    CHECK(accumulated(split("a\r\nb\r\n")) == "a\r\nb\r\n");
+    CHECK(accumulated(split("a\nb\n")) == "a\nb\n");
+    CHECK(accumulated(split("a\n\n\nb")) == "a\n\n\nb");
+    CHECK(accumulated(split("In:1%\rIn:2%\rdone\n")) == "In:1%\rIn:2%\rdone\n");
+    CHECK(accumulated(split("\r\r\r")) == "\r\r\r");
+}
+
+TEST_CASE("sidecar_lines: an overlong line spills across segments and loses nothing") {
+    std::string huge(SIDECAR_LINE_BYTES * 2 + 7, 'x');
+    huge += '\n';
+
+    segments_t segs = split(huge);
+    REQUIRE(segs.size() > 1);
+    CHECK(accumulated(segs) == huge);
+    for (const auto &s : segs) {
+        CHECK(s.size() <= SIDECAR_LINE_BYTES);
+    }
+}
+
+TEST_CASE("sidecar_lines: an overlong line stays separated from the next one") {
+    std::string input(SIDECAR_LINE_BYTES * 2, 'x');
+    input += '\n';
+    input += "next\n";
+
+    std::string all = accumulated(split(input));
+    CHECK(all == input);
+    CHECK(all.find("x\nnext\n") != std::string::npos);
+}
+
+TEST_CASE("sidecar_lines: the splitter recovers after an overlong line") {
+    std::string input(SIDECAR_LINE_BYTES * 2, 'x');
+    input += "\nshort\n";
+
+    segments_t segs = split(input);
+    CHECK(segs.back() == "short\n");
+    CHECK(accumulated(segs) == input);
+}
+
+TEST_CASE("sidecar_lines: an overlong line with no newline at all loses nothing") {
+    std::string huge(SIDECAR_LINE_BYTES * 3, 'x');
+
+    CHECK(accumulated(split(huge)) == huge);
+}

--- a/tests/norns/sidecar_msg/test_sidecar_msg.cpp
+++ b/tests/norns/sidecar_msg/test_sidecar_msg.cpp
@@ -1,0 +1,349 @@
+// tests for norns/sidecar_msg.cpp, the frame encoder and parser.
+
+#include <cstring>
+#include <doctest/doctest.h>
+#include <vector>
+
+#include "sidecar_msg.h"
+
+// per-frame encode helpers for the tests below.
+namespace {
+
+constexpr size_t WIRE_HEADER_BYTES = 2;  // type tag + req id
+constexpr size_t WIRE_TIMEOUT_BYTES = 4; // CMD only
+constexpr size_t WIRE_STATUS_BYTES = 2;  // END only
+
+std::vector<uint8_t> encode_chunk(uint8_t req_id, const char *payload, size_t len) {
+    size_t n = sidecar_msg_encode_chunk(nullptr, 0, req_id, payload, len);
+    std::vector<uint8_t> buf(n);
+    sidecar_msg_encode_chunk(buf.data(), buf.size(), req_id, payload, len);
+    return buf;
+}
+
+std::vector<uint8_t> encode_error(uint8_t req_id, const char *text) {
+    size_t n = sidecar_msg_encode_error(nullptr, 0, req_id, text);
+    std::vector<uint8_t> buf(n);
+    sidecar_msg_encode_error(buf.data(), buf.size(), req_id, text);
+    return buf;
+}
+
+std::vector<uint8_t> encode_cmd(uint8_t req_id, uint32_t timeout_ms, const char *cmd) {
+    size_t n = sidecar_msg_encode_cmd(nullptr, 0, req_id, timeout_ms, cmd);
+    std::vector<uint8_t> buf(n);
+    sidecar_msg_encode_cmd(buf.data(), buf.size(), req_id, timeout_ms, cmd);
+    return buf;
+}
+
+std::vector<uint8_t> encode_end(uint8_t req_id, bool signalled, uint8_t code) {
+    size_t n = sidecar_msg_encode_end(nullptr, 0, req_id, signalled, code);
+    std::vector<uint8_t> buf(n);
+    sidecar_msg_encode_end(buf.data(), buf.size(), req_id, signalled, code);
+    return buf;
+}
+
+std::vector<uint8_t> encode_detach(uint8_t req_id, const char *unit, const char *cmd) {
+    size_t n = sidecar_msg_encode_detach(nullptr, 0, req_id, unit, cmd);
+    std::vector<uint8_t> buf(n);
+    sidecar_msg_encode_detach(buf.data(), buf.size(), req_id, unit, cmd);
+    return buf;
+}
+
+} // namespace
+
+//---------------------------------
+//--- round trips
+
+TEST_CASE("sidecar_msg: a CMD frame round-trips") {
+    auto buf = encode_cmd(7, 240000, "ls -la");
+
+    sidecar_frame_t f;
+    REQUIRE(sidecar_msg_parse(buf.data(), buf.size(), &f));
+    CHECK(f.type == SIDECAR_MSG_CMD);
+    CHECK(f.req_id == 7);
+    CHECK(f.timeout_ms == 240000);
+    REQUIRE(f.cmd != nullptr);
+    CHECK(std::strcmp(f.cmd, "ls -la") == 0);
+}
+
+TEST_CASE("sidecar_msg: a CMD timeout of zero means no ceiling and round-trips as zero") {
+    auto buf = encode_cmd(7, 0, "sleep 300");
+
+    sidecar_frame_t f;
+    REQUIRE(sidecar_msg_parse(buf.data(), buf.size(), &f));
+    CHECK(f.timeout_ms == 0);
+    CHECK(std::strcmp(f.cmd, "sleep 300") == 0);
+}
+
+TEST_CASE("sidecar_msg: a CMD timeout uses the full width of its field") {
+    auto buf = encode_cmd(1, UINT32_MAX, "x");
+
+    sidecar_frame_t f;
+    REQUIRE(sidecar_msg_parse(buf.data(), buf.size(), &f));
+    CHECK(f.timeout_ms == UINT32_MAX);
+}
+
+TEST_CASE("sidecar_msg: a DETACH frame round-trips both of its strings") {
+    auto buf = encode_detach(9, "norns-update", "/bin/bash update.sh");
+
+    sidecar_frame_t f;
+    REQUIRE(sidecar_msg_parse(buf.data(), buf.size(), &f));
+    CHECK(f.type == SIDECAR_MSG_DETACH);
+    CHECK(f.req_id == 9);
+    REQUIRE(f.unit != nullptr);
+    REQUIRE(f.cmd != nullptr);
+    CHECK(std::strcmp(f.unit, "norns-update") == 0);
+    CHECK(std::strcmp(f.cmd, "/bin/bash update.sh") == 0);
+}
+
+TEST_CASE("sidecar_msg: an END frame carries how the command ended") {
+    auto buf = encode_end(3, false, 0);
+
+    sidecar_frame_t f;
+    REQUIRE(sidecar_msg_parse(buf.data(), buf.size(), &f));
+    CHECK(f.type == SIDECAR_MSG_END);
+    CHECK(f.req_id == 3);
+    CHECK_FALSE(f.signalled);
+    CHECK(f.code == 0);
+    CHECK(f.payload == nullptr);
+    CHECK(f.payload_len == 0);
+}
+
+TEST_CASE("sidecar_msg: an END frame round-trips a non-zero exit code") {
+    auto buf = encode_end(3, false, 7);
+
+    sidecar_frame_t f;
+    REQUIRE(sidecar_msg_parse(buf.data(), buf.size(), &f));
+    CHECK_FALSE(f.signalled);
+    CHECK(f.code == 7);
+}
+
+TEST_CASE("sidecar_msg: an END frame tells a signal apart from an exit") {
+    auto buf = encode_end(3, true, 9);
+
+    sidecar_frame_t f;
+    REQUIRE(sidecar_msg_parse(buf.data(), buf.size(), &f));
+    CHECK(f.signalled);
+    CHECK(f.code == 9);
+}
+
+TEST_CASE("sidecar_msg: an END frame carries the highest exit code a shell can report") {
+    auto buf = encode_end(3, false, 255);
+
+    sidecar_frame_t f;
+    REQUIRE(sidecar_msg_parse(buf.data(), buf.size(), &f));
+    CHECK(f.code == 255);
+}
+
+TEST_CASE("sidecar_msg: a CHUNK frame round-trips, and its length excludes the terminator") {
+    auto buf = encode_chunk(1, "hello\n", 6);
+
+    sidecar_frame_t f;
+    REQUIRE(sidecar_msg_parse(buf.data(), buf.size(), &f));
+    CHECK(f.type == SIDECAR_MSG_CHUNK);
+    CHECK(f.req_id == 1);
+    REQUIRE(f.payload != nullptr);
+    CHECK(f.payload_len == 6);
+    CHECK(std::memcmp(f.payload, "hello\n", 6) == 0);
+    CHECK(f.payload[f.payload_len] == '\0');
+}
+
+TEST_CASE("sidecar_msg: an ERROR frame round-trips as a readable C string") {
+    auto buf = encode_error(2, "exit status 1");
+
+    sidecar_frame_t f;
+    REQUIRE(sidecar_msg_parse(buf.data(), buf.size(), &f));
+    CHECK(f.type == SIDECAR_MSG_ERROR);
+    CHECK(f.req_id == 2);
+    REQUIRE(f.payload != nullptr);
+    CHECK(f.payload_len == 13);
+    CHECK(std::strcmp(f.payload, "exit status 1") == 0);
+}
+
+//---------------------------------
+//--- payload edge cases
+
+TEST_CASE("sidecar_msg: a zero-length CHUNK is legal") {
+    auto buf = encode_chunk(4, "", 0);
+    CHECK(buf.size() == WIRE_HEADER_BYTES + 1); // just the terminator
+
+    sidecar_frame_t f;
+    REQUIRE(sidecar_msg_parse(buf.data(), buf.size(), &f));
+    CHECK(f.type == SIDECAR_MSG_CHUNK);
+    CHECK(f.payload_len == 0);
+    REQUIRE(f.payload != nullptr);
+    CHECK(f.payload[0] == '\0');
+}
+
+TEST_CASE("sidecar_msg: an empty ERROR is legal") {
+    auto buf = encode_error(5, "");
+
+    sidecar_frame_t f;
+    REQUIRE(sidecar_msg_parse(buf.data(), buf.size(), &f));
+    CHECK(f.type == SIDECAR_MSG_ERROR);
+    CHECK(f.payload_len == 0);
+}
+
+TEST_CASE("sidecar_msg: a CHUNK carrying null characters round-trips byte for byte") {
+    // chunk length is carried in the frame, not derived from strlen, so
+    // interior null characters survive
+    const char raw[] = {'a', '\0', 'b', '\0', 'c'};
+    auto buf = encode_chunk(6, raw, sizeof(raw));
+
+    sidecar_frame_t f;
+    REQUIRE(sidecar_msg_parse(buf.data(), buf.size(), &f));
+    CHECK(f.payload_len == sizeof(raw));
+    CHECK(std::memcmp(f.payload, raw, sizeof(raw)) == 0);
+}
+
+TEST_CASE("sidecar_msg: an empty command and an empty unit are still terminated") {
+    auto buf = encode_detach(8, "", "");
+
+    sidecar_frame_t f;
+    REQUIRE(sidecar_msg_parse(buf.data(), buf.size(), &f));
+    CHECK(f.unit[0] == '\0');
+    CHECK(f.cmd[0] == '\0');
+}
+
+//---------------------------------
+//--- sizing
+
+TEST_CASE("sidecar_msg: sizing with a null buffer agrees with the filled length") {
+    CHECK(sidecar_msg_encode_cmd(nullptr, 0, 1, 0, "abc") == WIRE_HEADER_BYTES + WIRE_TIMEOUT_BYTES + 3 + 1);
+    CHECK(sidecar_msg_encode_error(nullptr, 0, 1, "ab") == WIRE_HEADER_BYTES + 2 + 1);
+    CHECK(sidecar_msg_encode_chunk(nullptr, 0, 1, "abcd", 4) == WIRE_HEADER_BYTES + 4 + 1);
+    CHECK(sidecar_msg_encode_end(nullptr, 0, 1, false, 0) == WIRE_HEADER_BYTES + WIRE_STATUS_BYTES);
+    CHECK(sidecar_msg_encode_detach(nullptr, 0, 1, "u", "c") == WIRE_HEADER_BYTES + (1 + 1) + (1 + 1));
+}
+
+TEST_CASE("sidecar_msg: encoding into a too-small output buffer writes nothing but still returns the size") {
+    uint8_t buf[4], buf_before[4];
+    std::memset(buf, 0xAA, sizeof(buf));
+    std::memset(buf_before, 0xAA, sizeof(buf_before));
+
+    CHECK(sidecar_msg_encode_cmd(buf, sizeof(buf), 1, 0, "abc") == WIRE_HEADER_BYTES + WIRE_TIMEOUT_BYTES + 3 + 1);
+    CHECK(std::memcmp(buf, buf_before, sizeof(buf)) == 0);
+
+    CHECK(sidecar_msg_encode_end(buf, 1, 1, false, 0) == WIRE_HEADER_BYTES + WIRE_STATUS_BYTES);
+    CHECK(std::memcmp(buf, buf_before, sizeof(buf)) == 0);
+}
+
+//---------------------------------
+//--- malformed frames
+
+TEST_CASE("sidecar_msg: a frame shorter than a header is rejected") {
+    const uint8_t one[] = {SIDECAR_MSG_END};
+
+    sidecar_frame_t f;
+    CHECK_FALSE(sidecar_msg_parse(one, 1, &f));
+    CHECK_FALSE(sidecar_msg_parse(one, 0, &f));
+    CHECK_FALSE(sidecar_msg_parse(nullptr, 0, &f));
+}
+
+TEST_CASE("sidecar_msg: an unknown type byte is rejected") {
+    sidecar_frame_t f;
+    for (unsigned tag = 0; tag <= 0xFF; ++tag) {
+        if (tag == SIDECAR_MSG_CHUNK || tag == SIDECAR_MSG_END || tag == SIDECAR_MSG_ERROR ||
+            tag == SIDECAR_MSG_CMD || tag == SIDECAR_MSG_DETACH) {
+            continue;
+        }
+        const uint8_t frame[] = {(uint8_t)tag, 1, 'x', 0};
+        CHECK_FALSE(sidecar_msg_parse(frame, sizeof(frame), &f));
+    }
+}
+
+TEST_CASE("sidecar_msg: a CMD whose command never terminates is rejected") {
+    const uint8_t frame[] = {SIDECAR_MSG_CMD, 1, 0, 0, 0, 0, 'l', 's'};
+
+    sidecar_frame_t f;
+    CHECK_FALSE(sidecar_msg_parse(frame, sizeof(frame), &f));
+}
+
+TEST_CASE("sidecar_msg: a CMD too short to hold its timeout is rejected") {
+    const uint8_t frame[] = {SIDECAR_MSG_CMD, 1, 0, 0, 0};
+
+    sidecar_frame_t f;
+    CHECK_FALSE(sidecar_msg_parse(frame, sizeof(frame), &f));
+}
+
+TEST_CASE("sidecar_msg: a CMD carrying a timeout but no command is rejected") {
+    const uint8_t frame[] = {SIDECAR_MSG_CMD, 1, 0, 0, 0, 0};
+
+    sidecar_frame_t f;
+    CHECK_FALSE(sidecar_msg_parse(frame, sizeof(frame), &f));
+}
+
+TEST_CASE("sidecar_msg: a CMD at its shortest legal size is accepted") {
+    const uint8_t frame[] = {SIDECAR_MSG_CMD, 1, 0, 0, 0, 0, 0};
+
+    sidecar_frame_t f;
+    REQUIRE(sidecar_msg_parse(frame, sizeof(frame), &f));
+    CHECK(f.timeout_ms == 0);
+    CHECK(f.cmd[0] == '\0');
+}
+
+TEST_CASE("sidecar_msg: a CHUNK whose payload never terminates is rejected") {
+    const uint8_t frame[] = {SIDECAR_MSG_CHUNK, 1, 'a', 'b'};
+
+    sidecar_frame_t f;
+    CHECK_FALSE(sidecar_msg_parse(frame, sizeof(frame), &f));
+}
+
+TEST_CASE("sidecar_msg: an ERROR whose text never terminates is rejected") {
+    const uint8_t frame[] = {SIDECAR_MSG_ERROR, 1, 'e'};
+
+    sidecar_frame_t f;
+    CHECK_FALSE(sidecar_msg_parse(frame, sizeof(frame), &f));
+}
+
+TEST_CASE("sidecar_msg: a CMD with no payload at all is rejected") {
+    const uint8_t frame[] = {SIDECAR_MSG_CMD, 1};
+
+    sidecar_frame_t f;
+    CHECK_FALSE(sidecar_msg_parse(frame, sizeof(frame), &f));
+}
+
+TEST_CASE("sidecar_msg: an END missing its status is rejected") {
+    const uint8_t bare[] = {SIDECAR_MSG_END, 1};
+    const uint8_t half[] = {SIDECAR_MSG_END, 1, 0};
+
+    sidecar_frame_t f;
+    CHECK_FALSE(sidecar_msg_parse(bare, sizeof(bare), &f));
+    CHECK_FALSE(sidecar_msg_parse(half, sizeof(half), &f));
+}
+
+TEST_CASE("sidecar_msg: an END carrying more than its status is rejected") {
+    const uint8_t frame[] = {SIDECAR_MSG_END, 1, 0, 0, 0};
+
+    sidecar_frame_t f;
+    CHECK_FALSE(sidecar_msg_parse(frame, sizeof(frame), &f));
+}
+
+TEST_CASE("sidecar_msg: an END whose how byte is neither exit nor signal is rejected") {
+    const uint8_t frame[] = {SIDECAR_MSG_END, 1, 2, 0};
+
+    sidecar_frame_t f;
+    CHECK_FALSE(sidecar_msg_parse(frame, sizeof(frame), &f));
+}
+
+TEST_CASE("sidecar_msg: a DETACH carrying only one string is rejected") {
+    const uint8_t frame[] = {SIDECAR_MSG_DETACH, 1, 'u', 0};
+
+    sidecar_frame_t f;
+    CHECK_FALSE(sidecar_msg_parse(frame, sizeof(frame), &f));
+}
+
+TEST_CASE("sidecar_msg: a DETACH whose command never terminates is rejected") {
+    const uint8_t frame[] = {SIDECAR_MSG_DETACH, 1, 'u', 0, 'c'};
+
+    sidecar_frame_t f;
+    CHECK_FALSE(sidecar_msg_parse(frame, sizeof(frame), &f));
+}
+
+TEST_CASE("sidecar_msg: a DETACH at its shortest legal size is accepted") {
+    const uint8_t frame[] = {SIDECAR_MSG_DETACH, 1, 0, 0};
+
+    sidecar_frame_t f;
+    REQUIRE(sidecar_msg_parse(frame, sizeof(frame), &f));
+    CHECK(f.unit[0] == '\0');
+    CHECK(f.cmd[0] == '\0');
+}

--- a/tests/norns/sidecar_shell/test_sidecar_shell.cpp
+++ b/tests/norns/sidecar_shell/test_sidecar_shell.cpp
@@ -1,0 +1,353 @@
+// tests for norns/sidecar_shell.cpp, supervised shell execution.
+
+#include <chrono>
+#include <doctest/doctest.h>
+#include <errno.h>
+#include <signal.h>
+#include <string>
+#include <sys/resource.h>
+#include <thread>
+#include <unistd.h>
+
+#include "sidecar_shell.h"
+
+// helpers for the tests below.
+namespace {
+
+struct capture_t {
+    std::string out;
+    bool refuse = false;
+    bool abandon = false;
+    int watch_drain_fd = -1;
+    int watch_calls = 0;
+};
+
+bool collect(void *ctx, const char *buf, size_t len) {
+    capture_t *cap = (capture_t *)ctx;
+    if (cap->refuse) {
+        return false;
+    }
+    cap->out.append(buf, len);
+    return true;
+}
+
+bool watch(void *ctx) {
+    capture_t *cap = (capture_t *)ctx;
+    cap->watch_calls++;
+    if (cap->watch_drain_fd >= 0) {
+        char b;
+        read(cap->watch_drain_fd, &b, 1);
+    }
+    return cap->abandon;
+}
+
+sidecar_shell_opts_t opts_for(capture_t *cap) {
+    sidecar_shell_opts_t opts = {};
+    opts.ctx = cap;
+    opts.on_output = collect;
+    opts.on_watch = watch;
+    opts.watch_fd = -1;
+    return opts;
+}
+
+} // namespace
+
+//---------------------------------
+//--- execution
+
+TEST_CASE("sidecar_shell: runs a command, streams its output, reports the exit status") {
+    capture_t cap;
+    sidecar_shell_opts_t opts = opts_for(&cap);
+
+    sidecar_shell_result_t res;
+    sidecar_shell_run("echo hi; exit 7", &opts, &res);
+
+    CHECK(res.outcome == SIDECAR_SHELL_EXITED);
+    CHECK(res.code == 7);
+    CHECK(cap.out == "hi\n");
+}
+
+TEST_CASE("sidecar_shell: a command that dies on a signal is reported as signalled") {
+    capture_t cap;
+    sidecar_shell_opts_t opts = opts_for(&cap);
+
+    sidecar_shell_result_t res;
+    sidecar_shell_run("kill -KILL $$", &opts, &res);
+
+    CHECK(res.outcome == SIDECAR_SHELL_SIGNALLED);
+    CHECK(res.code == SIGKILL);
+}
+
+TEST_CASE("sidecar_shell: stderr rides the output stream") {
+    capture_t cap;
+    sidecar_shell_opts_t opts = opts_for(&cap);
+
+    sidecar_shell_result_t res;
+    sidecar_shell_run("echo oops >&2", &opts, &res);
+
+    CHECK(res.outcome == SIDECAR_SHELL_EXITED);
+    CHECK(res.code == 0);
+    CHECK(cap.out == "oops\n");
+}
+
+TEST_CASE("sidecar_shell: a missing command reports 127 and the shell's complaint") {
+    capture_t cap;
+    sidecar_shell_opts_t opts = opts_for(&cap);
+
+    sidecar_shell_result_t res;
+    sidecar_shell_run("definitely_not_a_command_xyz", &opts, &res);
+
+    CHECK(res.outcome == SIDECAR_SHELL_EXITED);
+    CHECK(res.code == 127);
+    CHECK(cap.out.find("definitely_not_a_command_xyz") != std::string::npos);
+}
+
+TEST_CASE("sidecar_shell: a command that cannot start reports the reason") {
+    struct rlimit saved;
+    REQUIRE(getrlimit(RLIMIT_NOFILE, &saved) == 0);
+    struct rlimit tight = saved;
+    tight.rlim_cur = 3;
+    REQUIRE(setrlimit(RLIMIT_NOFILE, &tight) == 0);
+
+    capture_t cap;
+    sidecar_shell_opts_t opts = opts_for(&cap);
+
+    sidecar_shell_result_t res;
+    sidecar_shell_run("echo hi", &opts, &res);
+
+    REQUIRE(setrlimit(RLIMIT_NOFILE, &saved) == 0);
+
+    CHECK(res.outcome == SIDECAR_SHELL_FAILED);
+    CHECK(res.err != nullptr);
+    CHECK(res.errnum == EMFILE);
+    CHECK(cap.out.empty());
+}
+
+TEST_CASE("sidecar_shell: the command sees an empty stdin, not the caller's") {
+    int stdin_pipe[2];
+    REQUIRE(pipe(stdin_pipe) == 0);
+    int saved_stdin = dup(STDIN_FILENO);
+    REQUIRE(saved_stdin >= 0);
+    REQUIRE(dup2(stdin_pipe[0], STDIN_FILENO) >= 0);
+
+    capture_t cap;
+    sidecar_shell_opts_t opts = opts_for(&cap);
+    opts.silence_timeout_ms = 1000;
+
+    sidecar_shell_result_t res;
+    sidecar_shell_run("cat", &opts, &res);
+
+    dup2(saved_stdin, STDIN_FILENO);
+    close(saved_stdin);
+    close(stdin_pipe[0]);
+    close(stdin_pipe[1]);
+
+    CHECK(res.outcome == SIDECAR_SHELL_EXITED);
+    CHECK(res.code == 0);
+    CHECK(cap.out == "");
+}
+
+//---------------------------------
+//--- silence timeout
+
+TEST_CASE("sidecar_shell: a command that goes quiet past the silence budget is killed") {
+    capture_t cap;
+    sidecar_shell_opts_t opts = opts_for(&cap);
+    opts.silence_timeout_ms = 300;
+
+    sidecar_shell_result_t res;
+    sidecar_shell_run("sleep 10", &opts, &res);
+
+    CHECK(res.outcome == SIDECAR_SHELL_QUIET);
+}
+
+TEST_CASE("sidecar_shell: output resets the silence budget, total duration is unbounded") {
+    capture_t cap;
+    sidecar_shell_opts_t opts = opts_for(&cap);
+    opts.silence_timeout_ms = 2000;
+
+    sidecar_shell_result_t res;
+    sidecar_shell_run("for i in 1 2 3 4 5 6; do echo t$i; sleep 0.5; done", &opts, &res);
+
+    CHECK(res.outcome == SIDECAR_SHELL_EXITED);
+    CHECK(res.code == 0);
+    CHECK(cap.out == "t1\nt2\nt3\nt4\nt5\nt6\n");
+}
+
+//---------------------------------
+//--- output limits
+
+TEST_CASE("sidecar_shell: a command that exceeds the output cap is killed") {
+    capture_t cap;
+    sidecar_shell_opts_t opts = opts_for(&cap);
+    opts.max_output_bytes = 1000;
+
+    sidecar_shell_result_t res;
+    sidecar_shell_run("head -c 100000 /dev/zero", &opts, &res);
+
+    CHECK(res.outcome == SIDECAR_SHELL_CAPPED);
+    CHECK(cap.out.size() <= 1000);
+}
+
+TEST_CASE("sidecar_shell: the command is stopped once on_output refuses more") {
+    capture_t cap;
+    cap.refuse = true;
+    sidecar_shell_opts_t opts = opts_for(&cap);
+
+    sidecar_shell_result_t res;
+    sidecar_shell_run("head -c 50000 /dev/zero", &opts, &res);
+
+    CHECK(res.outcome == SIDECAR_SHELL_REFUSED);
+    CHECK(cap.out.empty());
+}
+
+//---------------------------------
+//--- watch fd
+
+TEST_CASE("sidecar_shell: a readable watch fd can abandon the command") {
+    int wpipe[2];
+    REQUIRE(pipe(wpipe) == 0);
+    REQUIRE(write(wpipe[1], "x", 1) == 1);
+
+    capture_t cap;
+    cap.abandon = true;
+    cap.watch_drain_fd = wpipe[0];
+    sidecar_shell_opts_t opts = opts_for(&cap);
+    opts.watch_fd = wpipe[0];
+
+    auto start = std::chrono::steady_clock::now();
+    sidecar_shell_result_t res;
+    sidecar_shell_run("sleep 10", &opts, &res);
+    auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start).count();
+
+    close(wpipe[0]);
+    close(wpipe[1]);
+
+    CHECK(res.outcome == SIDECAR_SHELL_ABANDONED);
+    CHECK(elapsed < 5000);
+}
+
+TEST_CASE("sidecar_shell: a watch wake the callback declines leaves the command alone") {
+    int wpipe[2];
+    REQUIRE(pipe(wpipe) == 0);
+    REQUIRE(write(wpipe[1], "x", 1) == 1);
+
+    capture_t cap;
+    cap.watch_drain_fd = wpipe[0];
+    sidecar_shell_opts_t opts = opts_for(&cap);
+    opts.watch_fd = wpipe[0];
+
+    sidecar_shell_result_t res;
+    sidecar_shell_run("echo done", &opts, &res);
+
+    close(wpipe[0]);
+    close(wpipe[1]);
+
+    CHECK(res.outcome == SIDECAR_SHELL_EXITED);
+    CHECK(cap.out == "done\n");
+    CHECK(cap.watch_calls >= 1);
+}
+
+TEST_CASE("sidecar_shell: a dead watch fd is dropped, not spun on") {
+    int dead = 900;
+    close(dead);
+
+    capture_t cap;
+    sidecar_shell_opts_t opts = opts_for(&cap);
+    opts.watch_fd = dead;
+
+    struct rusage before;
+    struct rusage after;
+    getrusage(RUSAGE_SELF, &before);
+    sidecar_shell_result_t res;
+    sidecar_shell_run("sleep 1; echo ok", &opts, &res);
+    getrusage(RUSAGE_SELF, &after);
+
+    CHECK(res.outcome == SIDECAR_SHELL_EXITED);
+    CHECK(cap.out == "ok\n");
+    CHECK(cap.watch_calls == 0);
+
+    long cpu_ms = (after.ru_utime.tv_sec - before.ru_utime.tv_sec) * 1000 + (after.ru_utime.tv_usec - before.ru_utime.tv_usec) / 1000 + (after.ru_stime.tv_sec - before.ru_stime.tv_sec) * 1000 + (after.ru_stime.tv_usec - before.ru_stime.tv_usec) / 1000;
+    CHECK(cpu_ms < 500);
+}
+
+//---------------------------------
+//--- after eof
+
+TEST_CASE("sidecar_shell: a child that closes its output and lingers still honors the watch") {
+    int wpipe[2];
+    REQUIRE(pipe(wpipe) == 0);
+
+    capture_t cap;
+    cap.abandon = true;
+    cap.watch_drain_fd = wpipe[0];
+    sidecar_shell_opts_t opts = opts_for(&cap);
+    opts.watch_fd = wpipe[0];
+
+    std::thread poker([&] {
+        std::this_thread::sleep_for(std::chrono::milliseconds(500));
+        write(wpipe[1], "x", 1);
+    });
+
+    auto start = std::chrono::steady_clock::now();
+    sidecar_shell_result_t res;
+    sidecar_shell_run("exec >/dev/null 2>&1; sleep 10", &opts, &res);
+    auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start).count();
+
+    poker.join();
+    close(wpipe[0]);
+    close(wpipe[1]);
+
+    CHECK(res.outcome == SIDECAR_SHELL_ABANDONED);
+    CHECK(elapsed < 5000);
+}
+
+TEST_CASE("sidecar_shell: a child that closes its output and lingers still goes quiet") {
+    capture_t cap;
+    sidecar_shell_opts_t opts = opts_for(&cap);
+    opts.silence_timeout_ms = 500;
+
+    auto start = std::chrono::steady_clock::now();
+    sidecar_shell_result_t res;
+    sidecar_shell_run("exec >/dev/null 2>&1; sleep 10", &opts, &res);
+    auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start).count();
+
+    CHECK(res.outcome == SIDECAR_SHELL_QUIET);
+    CHECK(elapsed < 5000);
+}
+
+//---------------------------------
+//--- stopping a command
+
+TEST_CASE("sidecar_shell: a killed command gets SIGTERM first, so cleanup traps run") {
+    const char *marker = "/tmp/sidecar_shell_term_marker";
+    unlink(marker);
+
+    capture_t cap;
+    sidecar_shell_opts_t opts = opts_for(&cap);
+    opts.silence_timeout_ms = 300;
+    opts.term_grace_ms = 2000;
+
+    sidecar_shell_result_t res;
+    std::string cmd = std::string("trap 'touch ") + marker + "; exit 0' TERM; sleep 10";
+    sidecar_shell_run(cmd.c_str(), &opts, &res);
+
+    CHECK(res.outcome == SIDECAR_SHELL_QUIET);
+    CHECK(access(marker, F_OK) == 0);
+    unlink(marker);
+}
+
+TEST_CASE("sidecar_shell: a command that ignores SIGTERM is SIGKILLed after the grace") {
+    capture_t cap;
+    sidecar_shell_opts_t opts = opts_for(&cap);
+    opts.silence_timeout_ms = 300;
+    opts.term_grace_ms = 300;
+
+    auto start = std::chrono::steady_clock::now();
+    sidecar_shell_result_t res;
+    sidecar_shell_run("trap '' TERM; for i in 1 2 3 4 5 6 7 8 9 10; do sleep 1; done", &opts, &res);
+    auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start).count();
+
+    CHECK(res.outcome == SIDECAR_SHELL_QUIET);
+    CHECK(elapsed < 5000);
+}

--- a/tests/wscript
+++ b/tests/wscript
@@ -733,7 +733,7 @@ def test(bld: BuildContext):
     # common libs many tests require. NNG is here so units that compile
     # norns/sidecar.cpp link, the tests themselves never reach the transport.
     link_libs = ["pthread"]
-    uselibs = ["NNG"]
+    uselibs = ["LUA53", "NNG"]
 
     # collect test units
     test_units: List[TestUnit] = []

--- a/tests/wscript
+++ b/tests/wscript
@@ -192,6 +192,7 @@ def _setup_includes_and_flags(bld: BuildContext) -> TestRunnerConfig:
         _abs("../crone/src", bld),
         _abs("../crone", bld),
         _abs("../crone/softcut/softcut-lib/include", bld),
+        _abs("../norns", bld),
         _abs("../ws-wrapper/src", bld),
         _abs("../maiden-repl/src", bld),
     ]
@@ -332,6 +333,25 @@ def _dedupe_nodes_case_insensitive(nodes: Iterable[Node]) -> List[Node]:
     return dedup
 
 
+def _project_src_root(bld: BuildContext, proj: str) -> Node:
+    """resolve the directory a module keeps its sources in.
+
+    matron and crone nest their sources under `<proj>/src/`. norns keeps them
+    directly in `<proj>/`. prefer `<proj>/src/` when it exists, else `<proj>/`.
+
+    Args:
+        bld: waf build context - `bld.path` is the tests root node.
+        proj: module directory name, e.g. "matron" or "norns".
+
+    Returns:
+        node for `<proj>/src` when that directory exists, else for `<proj>`.
+    """
+    src_root = bld.path.make_node("../%s/src" % proj)
+    if src_root.exists() and src_root.isdir():
+        return src_root
+    return bld.path.make_node("../%s" % proj)
+
+
 def _mirror_map_system_sources(
     bld: BuildContext,
     test_dir: str,
@@ -374,8 +394,8 @@ def _mirror_map_system_sources(
     system_header_nodes: List[Any] = []
 
     if proj and unit_path:
-        # nested path mapping: tests/<proj>/<unit>/ → <proj>/src/<unit>.*
-        src_root = bld.path.make_node("../%s/src" % proj)
+        # nested path mapping: tests/<proj>/<unit>/ → <src root>/<unit>.*
+        src_root = _project_src_root(bld, proj)
         mapped_file_c = src_root.make_node(unit_path + ".c")
         mapped_file_cc = src_root.make_node(unit_path + ".cc")
         mapped_file_cpp = src_root.make_node(unit_path + ".cpp")
@@ -434,7 +454,7 @@ def _mirror_map_system_sources(
 
     elif proj:
         # project root mapping: derive unit from test filename, try case variants
-        src_root = bld.path.make_node("../%s/src" % proj)
+        src_root = _project_src_root(bld, proj)
         for test_file in test_source_files:
             filename = test_file.name
             if filename.startswith("test_") and filename.endswith(".cpp"):
@@ -624,6 +644,16 @@ def _self_test(bld: BuildContext):
     except Exception as e:
         Logs.error(f"test runner self-test failed: {e}")
         bld.fatal("self-test failed - check TestSources methods")
+
+    # test 7: verify source roots resolve for both nested and flat modules
+    try:
+        assert _project_src_root(bld, "matron").name == "src"
+        assert _project_src_root(bld, "crone").name == "src"
+        assert _project_src_root(bld, "norns").name == "norns"
+        Logs.info("  ✓ module source roots resolve")
+    except AssertionError:
+        Logs.error("test runner self-test failed: module source root")
+        bld.fatal("self-test failed - _project_src_root broken")
 
     Logs.info("\033[32mtest runner self-tests passed\033[0m")
 

--- a/tests/wscript
+++ b/tests/wscript
@@ -730,8 +730,10 @@ def test(bld: BuildContext):
     # discover: group test files by directory
     tests_root, test_dirs = _discover_test_dirs(bld)
 
-    # common libs many tests require
+    # common libs many tests require. NNG is here so units that compile
+    # norns/sidecar.cpp link, the tests themselves never reach the transport.
     link_libs = ["pthread"]
+    uselibs = ["NNG"]
 
     # collect test units
     test_units: List[TestUnit] = []
@@ -768,6 +770,7 @@ def test(bld: BuildContext):
             cxxflags=build_config.cxxflags,
             defines=build_config.defines,
             lib=link_libs,
+            use=uselibs,
         )
 
     # store test units for validation hook

--- a/update/test-update.sh
+++ b/update/test-update.sh
@@ -1,0 +1,490 @@
+#!/usr/bin/env bash
+# dry-run tests for update/update.sh. no device, no root, no network.
+#
+# run: bash update/test-update.sh [case-glob]
+#
+# each case builds a throwaway file tree and runs the real update.sh against it.
+
+set -u
+UPDATE_SH="$(cd "$(dirname "$0")" && pwd)/update.sh"
+
+if ! bash -n "$UPDATE_SH"; then
+	echo "FAIL: bash -n update.sh"
+	exit 1
+fi
+
+TEST_VERSION=260616
+TEST_LIVE_VERSION=260000
+NORNS_BINARY=build/norns/norns
+
+fails=0
+cases=0
+
+ONLY="${1:-}"
+
+trap 'rm -rf "${TEST_ROOT:-}"' INT TERM
+
+export NORNS_UPDATE_HEARTBEAT_SECS=1
+
+TGZ_URL=http://example.com/bundle.tgz
+SHA_URL=http://example.com/bundle.sha256
+
+# update.sh builds every absolute path from its ROOT prefix. this catches a
+# hardcoded system path.
+stray="$(sed 's|\$ROOT/|$ROOT_|g' "$UPDATE_SH" | grep -nE '(/(home/we|etc/|var/log|boot/|tmp/norns)|~/)' | grep -vE '^[0-9]+:[[:space:]]*#' || true)"
+if [ -n "$stray" ]; then
+	echo "FAIL: update.sh has absolute paths not built from ROOT:"
+	echo "$stray"
+	exit 1
+fi
+
+#---------------------------------
+#--- file builders
+
+write_binary() {
+	mkdir -p "$1/$(dirname "$NORNS_BINARY")"
+	printf '%s' "$2" > "$1/$NORNS_BINARY"
+	chmod +x "$1/$NORNS_BINARY"
+}
+
+write_ok_script() {
+	printf '#!/bin/sh\nexit 0\n' > "$1"
+	chmod +x "$1"
+}
+
+make_bundle_with_script() {
+	rm -rf "$TEST_ROOT/build"
+	mkdir -p "$TEST_ROOT/build/$TEST_VERSION"
+	printf '%s' "$1" > "$TEST_ROOT/build/$TEST_VERSION/update.sh"
+	tar czf "$TEST_ROOT/home/we/update/bundle.tgz" -C "$TEST_ROOT/build" "$TEST_VERSION"
+}
+
+make_bundle_without_script() {
+	rm -rf "$TEST_ROOT/build"
+	mkdir -p "$TEST_ROOT/build/$TEST_VERSION"
+	printf 'x\n' > "$TEST_ROOT/build/$TEST_VERSION/other"
+	tar czf "$TEST_ROOT/home/we/update/bundle.tgz" -C "$TEST_ROOT/build" "$TEST_VERSION"
+}
+
+place_installed_binary() { write_binary "$TEST_ROOT/home/we/norns" NEW; }
+
+write_bundle_sha() { (cd "$TEST_ROOT/home/we/update" && sha256sum bundle.tgz > bundle.tgz.sha256); }
+write_bad_bundle_sha() { printf '%064d  bundle.tgz\n' 0 > "$TEST_ROOT/home/we/update/bundle.tgz.sha256"; }
+
+#---------------------------------
+#--- post-run checks
+
+check_update_progress() { [ -s "$TEST_ROOT/tmp/norns-update-progress" ]; }
+
+check_download_result() {
+	[ -f "$TEST_ROOT/home/we/update/bundle.tgz" ] || return 1
+	[ -f "$TEST_ROOT/home/we/update/bundle.tgz.sha256" ] || return 1
+	[ ! -e "$TEST_ROOT/home/we/update/junk" ]
+}
+
+check_download_untouched() { [ -e "$TEST_ROOT/home/we/update/junk" ]; }
+
+check_progress_beat() {
+	local beat
+	beat="$(sed -n 2p "$TEST_ROOT/progress-during-apt" 2>/dev/null)"
+	[ -n "$beat" ] && [ "$beat" -gt 0 ] 2>/dev/null
+}
+
+check_install_complete() {
+	[ -f "$TEST_ROOT/home/we/maiden/index.html" ] || return 1
+	[ -x "$TEST_ROOT/home/we/bin/maiden-repl" ] || return 1
+	[ -f "$TEST_ROOT/etc/systemd/system/norns-main.service" ] || return 1
+	[ "$(cat "$TEST_ROOT/home/we/version.txt")" = "$TEST_VERSION" ]
+}
+
+check_common_audio_cwd() { grep -q "^wget .* | $TEST_ROOT/home/we/dust/audio\$" "$TEST_ROOT/calls.log"; }
+check_no_wget() { ! grep -q '^wget' "$TEST_ROOT/calls.log" 2>/dev/null; }
+check_expected_one_tgz() { grep -q "exactly one" "$TEST_ROOT/tmp/norns-update.log"; }
+
+#---------------------------------
+#--- fake commands
+
+INSTALL_OK=$'#!/bin/sh\nexit 0'
+
+shim() {
+	cat > "$TEST_ROOT/bin/$1"
+	chmod +x "$TEST_ROOT/bin/$1"
+}
+
+shim_fails_on() {
+	local name="$1" fault="$2" only_arg="${3:-}"
+	if [ -n "$only_arg" ]; then
+		shim "$name" <<EOF
+#!/usr/bin/env bash
+if [ "\$1" = "$only_arg" ]; then case "\${FAULT:-}" in $fault) exit 1 ;; esac; fi
+exit 0
+EOF
+	else
+		shim "$name" <<EOF
+#!/usr/bin/env bash
+case "\${FAULT:-}" in $fault) exit 1 ;; esac
+exit 0
+EOF
+	fi
+}
+
+shim_wraps_real() {
+	local name="$1" fault="$2" glob="$3"
+	shim "$name" <<EOF
+#!/usr/bin/env bash
+if [ "\${FAULT:-}" = "$fault" ]; then
+	for a in "\$@"; do case "\$a" in $glob) exit 1 ;; esac; done
+fi
+exec /bin/$name "\$@"
+EOF
+}
+
+shim_ok() {
+	local name
+	for name in "$@"; do
+		shim "$name" <<EOF
+#!/usr/bin/env bash
+printf '%s %s | %s\n' "\$(basename "\$0")" "\$*" "\$PWD" >> "$TEST_ROOT/calls.log"
+exit 0
+EOF
+	done
+}
+
+#---------------------------------
+#--- install fixtures
+
+make_release_fixture() {
+	RELEASE_DIR="$TEST_ROOT/home/we/update/$TEST_VERSION"
+	mkdir -p "$RELEASE_DIR/norns/build/maiden-repl" "$RELEASE_DIR/maiden" "$RELEASE_DIR/config"
+	write_binary "$RELEASE_DIR/norns" NEW
+	write_ok_script "$RELEASE_DIR/norns/build/maiden-repl/maiden-repl"
+	write_ok_script "$RELEASE_DIR/maiden/project-setup.sh"
+	printf 'maiden\n' > "$RELEASE_DIR/maiden/index.html"
+	local f
+	for f in journald.conf logrotate.conf norns-jack.service norns-main.service \
+		norns-sclang.service norns-watcher.service norns.target raspi.list; do
+		printf 'stub\n' > "$RELEASE_DIR/config/$f"
+	done
+	printf '%s\n' "$TEST_VERSION" > "$RELEASE_DIR/version.txt"
+	printf 'changelog\n' > "$RELEASE_DIR/changelog.txt"
+}
+
+make_live_system() {
+	mkdir -p "$TEST_ROOT/home/we/maiden" "$TEST_ROOT/home/we/bin" "$TEST_ROOT/home/we/dust/audio/common"
+	write_binary "$TEST_ROOT/home/we/norns" OLD
+	printf '%s\n' "$TEST_LIVE_VERSION" > "$TEST_ROOT/home/we/version.txt"
+	mkdir -p "$TEST_ROOT/etc/apt/sources.list.d" "$TEST_ROOT/etc/systemd/system" "$TEST_ROOT/var/log" "$TEST_ROOT/boot"
+	printf '#stub\n' > "$TEST_ROOT/boot/config.txt"
+	printf 'stub\n' > "$TEST_ROOT/boot/cmdline.txt"
+}
+
+make_install_shims() {
+	mkdir -p "$TEST_ROOT/bin"
+	shim df <<'EOF'
+#!/usr/bin/env bash
+echo "Filesystem 1K-blocks Used Available Capacity Mounted"
+if [ "${FAULT:-}" = "disk" ]; then echo "stub 100 90 1000 90% /"; else echo "stub 100 10 99999999 1% /"; fi
+EOF
+	shim apt-get <<EOF
+#!/usr/bin/env bash
+if [ "\${FAULT:-}" = "slow" ]; then
+	sleep 3
+	cp "$TEST_ROOT/tmp/norns-update-progress" "$TEST_ROOT/progress-during-apt" 2>/dev/null
+fi
+exit 0
+EOF
+	shim_fails_on dpkg libnng -s
+	shim_fails_on systemctl units enable
+	shim_fails_on timeout 'launch|launch-restore'
+	shim_wraps_real rm launch-restore '*/norns'
+	shim_ok apt amixer alsactl wget
+}
+
+setup_install_test() {
+	TEST_ROOT="$(mktemp -d)"
+	make_release_fixture
+	make_live_system
+	make_install_shims
+	mkdir -p "$TEST_ROOT/tmp"
+	cp "$UPDATE_SH" "$RELEASE_DIR/update.sh"
+	STATUS_FILE="$TEST_ROOT/tmp/norns-update-status"
+}
+
+remove_release_binary() { rm -f "$RELEASE_DIR/norns/$NORNS_BINARY"; }
+empty_release_maiden()  { rm -rf "$RELEASE_DIR"/maiden/*; }
+old_disk_image()        { printf '220305\n' > "$TEST_ROOT/home/we/version.txt"; }
+garbage_version()       { printf '\n' > "$TEST_ROOT/home/we/version.txt"; }
+remove_common_audio()   { rm -rf "$TEST_ROOT/home/we/dust/audio/common"; }
+remove_dust_audio()     { rm -rf "$TEST_ROOT/home/we/dust/audio"; }
+
+#---------------------------------
+#--- update fixtures
+
+make_update_shims() {
+	mkdir -p "$TEST_ROOT/bin"
+	shim systemctl <<EOF
+#!/usr/bin/env bash
+if [ "\$1" = "reboot" ]; then : > "$REBOOT_FLAG"; fi
+if [ "\$1" = "is-active" ]; then
+	if [ "\${FAULT:-}" = "busy" ]; then echo activating; exit 0; fi
+	echo inactive
+	exit 3
+fi
+exit 0
+EOF
+	shim wget <<EOF
+#!/usr/bin/env bash
+[ "\${FAULT:-}" = "wget" ] && exit 1
+dest=.
+while [ \$# -gt 0 ]; do
+	if [ "\$1" = "-P" ]; then dest="\$2"; shift; fi
+	shift
+done
+cp "$TEST_ROOT/fixture/"* "\$dest/"
+EOF
+	shim_fails_on timeout launch
+	shim_wraps_real cp stage '*norns-update-staged*'
+}
+
+setup_update_test() {
+	TEST_ROOT="$(mktemp -d)"
+	mkdir -p "$TEST_ROOT/home/we/update" "$TEST_ROOT/tmp"
+	REBOOT_FLAG="$TEST_ROOT/reboot.flag"
+	STATUS_FILE="$TEST_ROOT/tmp/norns-update-status"
+	make_update_shims
+}
+
+stage_ready() {
+	setup_update_test
+	make_bundle_with_script "$INSTALL_OK"
+	write_bundle_sha
+	place_installed_binary
+}
+
+stage_no_binary() {
+	setup_update_test
+	make_bundle_with_script "$INSTALL_OK"
+	write_bundle_sha
+}
+
+stage_bad_sha() {
+	setup_update_test
+	make_bundle_with_script "$INSTALL_OK"
+	write_bad_bundle_sha
+	place_installed_binary
+}
+
+stage_no_sha() {
+	setup_update_test
+	make_bundle_with_script "$INSTALL_OK"
+	place_installed_binary
+}
+
+stage_not_tarball() {
+	setup_update_test
+	printf 'not a tarball\n' > "$TEST_ROOT/home/we/update/bundle.tgz"
+	write_bundle_sha
+}
+
+stage_no_script() {
+	setup_update_test
+	make_bundle_without_script
+	write_bundle_sha
+}
+
+stage_bare() { setup_update_test; }
+stage_install_fail() {
+	setup_update_test
+	make_bundle_with_script "#!/bin/sh
+echo failed:units > $STATUS_FILE
+exit 1"
+	write_bundle_sha
+	place_installed_binary
+}
+stage_debris() {
+	stage_ready
+	cp "$UPDATE_SH" "$TEST_ROOT/home/we/update/update.sh"
+}
+
+stage_orphan_copy() {
+	setup_update_test
+	cp "$UPDATE_SH" "$TEST_ROOT/tmp/norns-update-staged.sh"
+	rm -rf "$TEST_ROOT/home/we/update"
+}
+stage_download() {
+	setup_update_test
+	make_bundle_with_script "$INSTALL_OK"
+	write_bundle_sha
+	mkdir -p "$TEST_ROOT/fixture"
+	mv "$TEST_ROOT/home/we/update/bundle.tgz" "$TEST_ROOT/home/we/update/bundle.tgz.sha256" "$TEST_ROOT/fixture/"
+	printf 'debris\n' > "$TEST_ROOT/home/we/update/junk"
+}
+stage_download_bad_sha() {
+	stage_download
+	printf '%064d  bundle.tgz\n' 0 > "$TEST_ROOT/fixture/bundle.tgz.sha256"
+}
+
+stage_two_tgz() {
+	stage_ready
+	cp "$TEST_ROOT/home/we/update/bundle.tgz" "$TEST_ROOT/home/we/update/extra.tgz"
+}
+
+#---------------------------------
+#--- case runners
+
+run_case() {
+	local name="$1" fault="$2" want_exit_code="$3" want_status="$4" want_live="$5" pre_hook="${6:-}"
+	local allow_leftover="${7:-}" check="${8:-}"
+	case "$name" in ${ONLY:-*}) ;; *) return ;; esac
+	cases=$((cases + 1))
+	setup_install_test
+	[ -n "$pre_hook" ] && "$pre_hook"
+
+	PATH="$TEST_ROOT/bin:$PATH" HOME="$TEST_ROOT/home/we" FAULT="$fault" \
+		NORNS_UPDATE_ROOT="$TEST_ROOT" NORNS_UPDATE_SUDO= \
+		bash "$RELEASE_DIR/update.sh" >"$TEST_ROOT/out.log" 2>&1
+	local exit_code=$?
+	local ok=1
+
+	if [ "$exit_code" != "$want_exit_code" ]; then
+		echo "  [$name] FAIL exit code: got $exit_code want $want_exit_code"; ok=0
+	fi
+
+	local live; live="$(cat "$TEST_ROOT/home/we/norns/$NORNS_BINARY" 2>/dev/null || echo MISSING)"
+	if [ "$live" != "$want_live" ]; then
+		echo "  [$name] FAIL installed binary: got '$live' want '$want_live'"; ok=0
+	fi
+
+	if [ -z "$want_status" ]; then
+		if [ -e "$STATUS_FILE" ]; then echo "  [$name] FAIL: status file present ($(cat "$STATUS_FILE")) want none"; ok=0; fi
+	else
+		local got; got="$(cat "$STATUS_FILE" 2>/dev/null || echo NONE)"
+		if [ "$got" != "$want_status" ]; then echo "  [$name] FAIL status: got '$got' want '$want_status'"; ok=0; fi
+	fi
+
+	for leftover in norns.old norns.new maiden.old maiden.new; do
+		case " $allow_leftover " in *" $leftover "*) continue ;; esac
+		if [ -e "$TEST_ROOT/home/we/$leftover" ]; then echo "  [$name] FAIL: leftover $leftover present"; ok=0; fi
+	done
+
+	if [ -n "$check" ] && ! "$check"; then
+		echo "  [$name] FAIL: post-run check $check"; ok=0
+	fi
+
+	if [ "$ok" = 1 ]; then
+		echo "  [$name] ok"
+		rm -rf "$TEST_ROOT"
+	else
+		fails=$((fails + 1))
+		tail -n 25 "$TEST_ROOT/out.log" 2>/dev/null | sed 's/^/  | /'
+		echo "  [$name] tree kept at $TEST_ROOT"
+	fi
+}
+
+run_update() {
+	local name="$1" fixture="$2" want_exit_code="$3" want_status="$4" want_reboot="$5"
+	shift 5
+	case "$name" in ${ONLY:-*}) ;; *) return ;; esac
+	cases=$((cases + 1))
+	local fault="" want="" check="" run=""
+	local -a passthru=()
+	while [ $# -gt 0 ]; do
+		case "$1" in
+		fault=*) fault="${1#fault=}" ;;
+		want=*) want="${1#want=}" ;;
+		check=*) check="${1#check=}" ;;
+		run=*) run="${1#run=}" ;;
+		--) shift; passthru=("$@"); break ;;
+		*) echo "  [$name] FAIL: unknown run_update token '$1'"; fails=$((fails + 1)); return ;;
+		esac
+		shift
+	done
+
+	"$fixture"
+	local run_script="$UPDATE_SH"
+	[ "$run" = update-dir ] && run_script="$TEST_ROOT/home/we/update/update.sh"
+	[ "$run" = staged ] && run_script="$TEST_ROOT/tmp/norns-update-staged.sh"
+
+	PATH="$TEST_ROOT/bin:$PATH" FAULT="$fault" \
+		NORNS_UPDATE_ROOT="$TEST_ROOT" NORNS_UPDATE_SUDO= \
+		bash "$run_script" "${passthru[@]}" >"$TEST_ROOT/run.log" 2>&1
+	local exit_code=$? ok=1
+	[ "$exit_code" = "$want_exit_code" ] || { echo "  [$name] FAIL exit code: got $exit_code want $want_exit_code"; ok=0; }
+	if [ -z "$want_status" ]; then
+		[ -e "$STATUS_FILE" ] && { echo "  [$name] FAIL: status file present ($(cat "$STATUS_FILE"))"; ok=0; }
+	else
+		local got; got="$(cat "$STATUS_FILE" 2>/dev/null || echo NONE)"
+		[ "$got" = "$want_status" ] || { echo "  [$name] FAIL status: got '$got' want '$want_status'"; ok=0; }
+	fi
+	if [ "$want_reboot" = yes ]; then
+		[ -e "$REBOOT_FLAG" ] || { echo "  [$name] FAIL: expected reboot, none recorded"; ok=0; }
+	else
+		[ -e "$REBOOT_FLAG" ] && { echo "  [$name] FAIL: reboot called when it must not be"; ok=0; }
+	fi
+	if [ -n "$want" ] && ! grep -qi "$want" "$TEST_ROOT/run.log"; then
+		echo "  [$name] FAIL: output does not mention '$want'"; ok=0
+	fi
+	if [ -n "$check" ] && ! "$check"; then
+		echo "  [$name] FAIL: post-run check $check"; ok=0
+	fi
+	if [ "$ok" = 1 ]; then
+		echo "  [$name] ok"
+		rm -rf "$TEST_ROOT"
+	else
+		fails=$((fails + 1))
+		tail -n 25 "$TEST_ROOT/run.log" 2>/dev/null | sed 's/^/  | /'
+		echo "  [$name] tree kept at $TEST_ROOT"
+	fi
+}
+
+#---------------------------------
+#--- cases
+
+echo "install step only, run from inside an unpacked release:"
+run_case good             ""        0 ""                   NEW "" "" check_install_complete
+run_case release-missing  ""        1 "failed:binary-swap" OLD remove_release_binary
+run_case libnng           libnng    1 "failed:libnng"      OLD
+run_case units            units     1 "failed:units"       OLD
+run_case maiden-empty     ""        1 "failed:maiden-swap" OLD empty_release_maiden
+run_case disk-space       disk      1 "failed:disk-space"  OLD
+run_case old-disk-image   ""        1 "failed:disk-image"  OLD old_disk_image
+run_case bad-version      ""        1 "failed:disk-image"  OLD garbage_version
+run_case launch           launch    1 "failed:binary-swap" OLD
+run_case launch-rollback  launch-restore 1 "failed:binary-swap-rollback" NEW "" norns.old
+run_case slow-step        slow      0 ""                   NEW "" "" check_progress_beat
+run_case common-audio     ""        0 ""                   NEW remove_common_audio "" check_common_audio_cwd
+run_case no-dust-audio    ""        0 ""                   NEW remove_dust_audio "" check_no_wget
+
+echo ""
+echo "whole update, from verifying the download to the reboot:"
+run_update update-good           stage_ready        0 ""                      yes  check=check_update_progress
+run_update update-stage-fail     stage_ready        1 "failed:env"            no   fault=stage
+run_update update-dir-missing    stage_orphan_copy  1 "failed:env"            no   run=staged
+run_update update-postcheck      stage_no_binary    1 "failed:postcheck"      no
+run_update update-launch         stage_ready        1 "failed:postcheck"      no   fault=launch
+run_update update-install-fail   stage_install_fail 1 "failed:units"          no
+run_update update-checksum       stage_bad_sha      1 "failed:checksum"       no
+run_update update-no-sha         stage_no_sha       1 "failed:checksum"       no
+run_update update-unpack         stage_not_tarball  1 "failed:unpack"         no
+run_update update-missing-script stage_no_script    1 "failed:missing-script" no
+run_update update-two-tgz        stage_two_tgz      1 "failed:unpack"         no   check=check_expected_one_tgz
+run_update update-usage          stage_bare         1 ""                      no   want=usage
+run_update update-stray-arg      stage_ready        1 ""                      no   want=usage -- stray
+run_update update-debris         stage_debris       1 ""                      no   want=usage run=update-dir
+
+echo ""
+echo "download subcommand:"
+run_update download-good           stage_download         0 "" no  check=check_download_result want="download: ok" -- download "$TGZ_URL" "$SHA_URL"
+run_update download-wget-fail      stage_download         1 "" no  fault=wget -- download "$TGZ_URL" "$SHA_URL"
+run_update download-bad-sha        stage_download_bad_sha 2 "" no  want=checksum -- download "$TGZ_URL" "$SHA_URL"
+run_update download-missing-arg    stage_bare             1 "" no  want=usage -- download "$TGZ_URL"
+run_update download-busy           stage_download         1 "" no  fault=busy want="already running" check=check_download_untouched -- download "$TGZ_URL" "$SHA_URL"
+
+echo ""
+if [ "$fails" = 0 ]; then
+	echo "PASS: $cases/$cases cases"
+	exit 0
+else
+	echo "FAIL: $fails/$cases cases failed"
+	exit 1
+fi

--- a/update/update.sh
+++ b/update/update.sh
@@ -1,103 +1,515 @@
 #!/usr/bin/env bash
-cd "$(dirname "$0")"
+# @name update.sh
+# @brief download, verify, install, and reboot into an updated norns release.
+# @description
+#   usage:
+#     update.sh download <tgz-url> <sha-url>   fetch a release and its checksum
+#                                              into /home/we/update and verify them
+#     update.sh   (currently installed copy)   verify the downloaded release,
+#                                              unpack, run its update.sh, reboot
+#     update.sh   (inside an unpacked release) install that release only
+#
+#   the SYSTEM>UPDATE menu drives download, then runs the installed copy
+#   detached. manual runs take the same paths.
+#
+#   output goes to UPDATE_LOG. the active norns binary shows PROGRESS_FILE and
+#   STATUS_FILE (failed:<step> when a critical step aborts) on screen.
+#   no failure path reboots.
 
-# only update new disk image
-version=$(cat ~/version.txt)
-if [ $version -lt 220306 ];
-then
-	echo "needs new disk image, aborting."
-	exit;
-fi;
+#---------------------------------
+#--- paths and constants
 
-# basic repo updates
-sudo rm -rf /home/we/norns
-cp -a norns /home/we/
-sudo rm -rf /home/we/maiden
-cp -a maiden /home/we/
-sudo rm -rf /home/we/bin/maiden-repl
-sudo cp -a /home/we/norns/build/maiden-repl/maiden-repl /home/we/bin/
+readonly ROOT="${NORNS_UPDATE_ROOT:-}"
+readonly SUDO="${NORNS_UPDATE_SUDO-sudo}" # bare - default, so an empty override means run without sudo
 
-# version/changelog
-cp version.txt /home/we/
-cp changelog.txt /home/we/
+readonly STATUS_FILE="$ROOT/tmp/norns-update-status"
+readonly PROGRESS_FILE="$ROOT/tmp/norns-update-progress"
+readonly UPDATE_LOG="$ROOT/tmp/norns-update.log"
+readonly STAGED_COPY="$ROOT/tmp/norns-update-staged.sh" # the updater runs from this copy, the install replaces the original
+readonly WE_DIR="$ROOT/home/we"
+readonly UPDATE_DIR="$WE_DIR/update"
+readonly NORNS_DIR="$WE_DIR/norns"
+readonly MAIDEN_DIR="$WE_DIR/maiden"
+readonly NORNS_BINARY=build/norns/norns # relative to a tree root
+readonly UPDATE_UNIT=norns-update
+readonly MIN_DISK_VERSION=220306 # older disk images need a reflash, not an update
+readonly MIN_SWAP_KB=200000      # headroom to stage norns.new (~149MB tree @260102 + growth)
+readonly LAUNCH_TIMEOUT=5
+readonly HEARTBEAT_SECS="${NORNS_UPDATE_HEARTBEAT_SECS:-15}" # override for the dry-run suite, positive seconds only
+readonly DUST_AUDIO_COMMON_TGZ=dust-audio-common.tgz
+readonly DUST_AUDIO_COMMON_URL=https://github.com/monome/norns/releases/download/v2.7.1/$DUST_AUDIO_COMMON_TGZ
 
-# update apt source
-sudo cp config/raspi.list /etc/apt/sources.list.d/
+#---------------------------------
+#--- status and progress
 
-# install nng
-sudo apt-get update && sudo apt-get -y install libnng1 libnng-dev
+# @description write failed:$1 to STATUS_FILE, log the reason, exit the script.
+# @arg $1 string step name used in the failed:<step> handoff
+# @arg $2 string human-readable reason
+# @stderr a FATAL line
+# @exitcode 1 always, this function never returns
+fail() {
+	echo "failed:$1" > "$STATUS_FILE"
+	echo "update: FATAL ($1): $2" >&2
+	exit 1
+}
 
-# remove logging
-sudo apt -y remove rsyslog
-sudo cp config/logrotate.conf /etc/
-sudo cp config/journald.conf /etc/systemd/
-sudo rm -rf /var/log/journal
-sudo rm -rf /var/log/daemon.log
-sudo rm -rf /var/log/user.log
+# @description write a step name and a mark to PROGRESS_FILE. the watching
+#   norns shows the name and treats a changed mark as proof of progress.
+# @arg $1 string progress text
+# @arg $2 int mark, counted up by the heartbeat
+# @exitcode 0 always, write errors are swallowed
+write_progress() {
+	printf '%s\n%s\n' "$1" "$2" 2>/dev/null > "$PROGRESS_FILE" || true
+}
 
-# disable hciuart
-sudo systemctl disable hciuart
+# @description stop the heartbeat started for the previous step, if any.
+# @noargs
+# @set HEARTBEAT_PID string emptied once the ticker is gone
+# @exitcode 0 always
+heartbeat_stop() {
+	[ -n "${HEARTBEAT_PID:-}" ] || return 0
+	kill "$HEARTBEAT_PID" 2>/dev/null
+	wait "$HEARTBEAT_PID" 2>/dev/null
+	HEARTBEAT_PID=""
+}
 
-# update services
-sudo systemctl disable norns-matron.service 2>/dev/null
-sudo systemctl disable norns-crone.service 2>/dev/null
-sudo rm -f /etc/systemd/system/norns-matron.service
-sudo rm -f /etc/systemd/system/norns-crone.service
-sudo cp --remove-destination config/norns-main.service /etc/systemd/system/norns-main.service
-sudo cp --remove-destination config/norns-sclang.service /etc/systemd/system/norns-sclang.service
-sudo cp --remove-destination config/norns.target /etc/systemd/system/norns.target
-sudo systemctl enable norns-main.service
-sudo systemctl enable norns-sclang.service
+# @description re-mark PROGRESS_FILE every HEARTBEAT_SECS until the step ends.
+#   apt, dpkg, and the various builds can run for many quiet moments, and
+#   without this the watching norns cannot tell them from a stalled install.
+# @arg $1 string progress text to keep writing
+# @set HEARTBEAT_PID int pid of the ticker
+# @exitcode 0 always
+heartbeat_start() {
+	(
+		beat=0
+		while sleep "$HEARTBEAT_SECS"; do
+			beat=$((beat + 1))
+			write_progress "$1" "$beat"
+		done
+	) &
+	HEARTBEAT_PID=$!
+}
 
-# add watcher
-sudo cp --remove-destination config/norns-watcher.service /etc/systemd/system/norns-watcher.service
-sudo systemctl enable norns-watcher
+# @description start a new step. writes its name to PROGRESS_FILE for the
+#   on-screen display, and keeps the step marked as alive until the next one
+#   begins.
+# @arg $1 string progress text
+# @exitcode 0 always, write errors are swallowed
+begin_step() {
+	heartbeat_stop
+	write_progress "$1" 0
+	heartbeat_start "$1"
+}
 
-# packages
-#sudo dpkg -i package/*.deb
+#---------------------------------
+#--- checks and swap
 
-# norns-image
-#cd /home/we/norns-image
-#./setup.sh
+# @description check a tree holds a usable norns binary.
+# @arg $1 path tree root
+# @exitcode 0 if the binary is present, executable, and non-empty
+# @exitcode 1 otherwise
+verify_norns_tree() {
+	[ -x "$1/$NORNS_BINARY" ] && [ -s "$1/$NORNS_BINARY" ]
+}
 
-# update jack systemd
-sudo cp --remove-destination config/norns-jack.service /etc/systemd/system/norns-jack.service
+# @description prove the norns binary starts. uses --check flag which exits
+#   before jack or hardware come up.
+# @arg $1 path tree root
+# @exitcode 0 if the binary launches within LAUNCH_TIMEOUT
+# @exitcode 1 otherwise
+launch_check() {
+	timeout "$LAUNCH_TIMEOUT" env LD_BIND_NOW=1 "$1/$NORNS_BINARY" --check >/dev/null 2>&1
+}
 
-# scrub invisibles
-find ~/dust -name .DS_Store -delete
-find ~/dust -name ._.DS_Store -delete
+# @description true when a dir holds at least one entry.
+# @arg $1 path dir to test
+# @exitcode 0 if the dir is non-empty
+# @exitcode 1 otherwise
+tree_nonempty() {
+	[ -n "$(ls -A "$1" 2>/dev/null)" ]
+}
 
-# set alsa volume
-amixer --device hw:sndrpimonome set Master 100% on
-sudo alsactl store
+# @description post-swap gate. the tree must verify and the binary must launch.
+# @arg $1 path tree root
+# @stdout the failed check name (verify or launch), for the abort message
+# @exitcode 0 if both checks pass
+# @exitcode 1 on the first failure
+verify_norns_live() {
+	verify_norns_tree "$1" || { echo "verify"; return 1; }
+	launch_check "$1" || { echo "launch"; return 1; }
+}
 
-# change boot/cmdline for screen
-sudo sed -e '/dtoverlay=ssd1322-spi/ s/^#*/#/' -i /boot/config.txt
-sudo sed -e '/spidev.bufsiz/! s/$/ spidev.bufsiz=8192/' -i /boot/cmdline.txt
+# @description move a tree to a path that must not already exist.
+# @arg $1 path source
+# @arg $2 path destination, must not exist
+# @exitcode 0 if the move happened
+# @exitcode 1 if the destination is already there, or the move failed
+move_tree() {
+	[ -e "$2" ] && return 1
+	mv "$1" "$2"
+}
 
-# install packages
-sudo dpkg -i package/*.deb
+# @description put the saved tree back after a failed swap.
+# @arg $1 path live dir
+# @exitcode 0 if there was nothing to restore, or the restore worked
+# @exitcode 1 if the saved tree is still sitting at $1.old
+restore_tree() {
+	[ -d "$1.old" ] || return 0
+	$SUDO rm -rf "$1"
+	move_tree "$1.old" "$1"
+}
 
-# clean slate
-rm /home/we/matronrc.lua
+# @description replace the live tree at a dir with a new source. any failure
+#   rolls back and aborts via fail. a rollback that cannot finish aborts with
+#   its own step name.
+# @arg $1 path source tree to install
+# @arg $2 path live dir to replace
+# @arg $3 string step name reported by fail on any error
+# @arg $4 function optional stage check, run on $dir.new before the swap
+# @arg $5 function optional live check, run on the swapped-in $dir. its stdout
+#   names the failed check in the abort message
+# @exitcode 0 on a completed swap
+# @exitcode 1 aborts via fail on any failure
+swap_tree() {
+	local src="$1" dir="$2" step="$3" stage_check="${4:-}" live_check="${5:-}"
+	local name
+	name="$(basename "$dir")"
+	begin_step "updating $name"
+	$SUDO rm -rf "$dir.old" "$dir.new"
+	cp -a "$src" "$dir.new" || { $SUDO rm -rf "$dir.new"; fail "$step" "could not stage $name.new"; }
+	if [ -n "$stage_check" ] && ! "$stage_check" "$dir.new"; then
+		$SUDO rm -rf "$dir.new"
+		fail "$step" "staged $name.new did not validate"
+	fi
+	if [ -d "$dir" ]; then
+		move_tree "$dir" "$dir.old" || { $SUDO rm -rf "$dir.new"; fail "$step" "could not move live $name aside"; }
+	fi
+	if ! move_tree "$dir.new" "$dir"; then
+		restore_tree "$dir" || fail "$step-rollback" "could not move $name.new into place, and $name could NOT be restored from $dir.old"
+		fail "$step" "could not move $name.new into place (rolled back)"
+	fi
+	if [ -n "$live_check" ]; then
+		local why
+		if ! why="$("$live_check" "$dir")"; then
+			[ -n "$why" ] || why="live"
+			restore_tree "$dir" || fail "$step-rollback" "post-swap $name $why check failed, and $name could NOT be restored from $dir.old"
+			fail "$step" "post-swap $name $why check failed (rolled back)"
+		fi
+	fi
+	$SUDO rm -rf "$dir.old"
+}
 
-# get common audio if not present
-if [ ! -d /home/we/dust/audio/common ]; then
-	echo "does not exist, downloading"
-	cd /home/we/dust/audio
-	wget https://github.com/monome/norns/releases/download/v2.7.1/dust-audio-common.tgz
-	tar xzvf dust-audio-common.tgz
-	rm dust-audio-common.tgz
+# @description check each .sha256 in the update dir against its file.
+# @noargs
+# @stdout sha256sum's per-file OK lines, then the mismatch reason on failure
+# @exitcode 0 if every file matches
+# @exitcode 1 on the first mismatch or missing .sha256
+verify_checksum() {
+	(
+		cd "$UPDATE_DIR" || { echo "$UPDATE_DIR missing"; exit 1; }
+		for sha_file in "$UPDATE_DIR"/*.sha256; do
+			[ -f "$sha_file" ] || { echo "no .sha256 file in $UPDATE_DIR"; exit 1; }
+			sha256sum -c "$sha_file" || { echo "download does not match $(basename "$sha_file")"; exit 1; }
+		done
+	)
+}
+
+#---------------------------------
+#--- usage and mode predicates
+
+# @description print how to run this script.
+# @noargs
+# @stderr the usage text
+usage() {
+	{
+		echo "norns update script usage:"
+		echo "  run from an unpacked release directory: installs that release"
+		echo "  run as the installed copy with a release .tgz and its .sha256"
+		echo "  waiting in $UPDATE_DIR: verifies, installs, reboots"
+		echo "  update.sh download <tgz-url> <sha-url>: fetches a release and its"
+		echo "  checksum into $UPDATE_DIR and verifies it"
+		echo "  progress is written to $UPDATE_LOG"
+		echo "  (SYSTEM>UPDATE downloads the release and runs the same path)"
+	} >&2
+}
+
+# @description true when a dir looks like an unpacked release.
+# @arg $1 path dir to test
+# @exitcode 0 if $1 holds a norns or maiden tree
+# @exitcode 1 otherwise
+is_release_dir() {
+	[ -d "$1/norns" ] || [ -d "$1/maiden" ]
+}
+
+# @description true when a downloaded release .tgz is waiting in the update dir.
+# @noargs
+# @exitcode 0 if a .tgz is present
+# @exitcode 1 otherwise
+is_release_downloaded() {
+	local tgz
+	for tgz in "$UPDATE_DIR"/*.tgz; do
+		[ -f "$tgz" ] && return 0
+	done
+	return 1
+}
+
+# @description true when a dir is inside the update dir.
+# @arg $1 path dir to test
+# @exitcode 0 if $1 is the update dir or below it
+# @exitcode 1 otherwise
+is_in_update_dir() {
+	case "$1" in
+	"$UPDATE_DIR" | "$UPDATE_DIR"/*) return 0 ;;
+	*) return 1 ;;
+	esac
+}
+
+
+# @description true while the detached updater is still running.
+# @noargs
+# @exitcode 0 if the update unit is running
+# @exitcode 1 otherwise
+update_in_progress() {
+	case "$(systemctl is-active "$UPDATE_UNIT" 2>/dev/null)" in
+	activ* | deactivating | reloading) return 0 ;;
+	*) return 1 ;;
+	esac
+}
+
+#---------------------------------
+#--- download subcommand
+
+# @description fetch the release and its .sha256 into the update dir. failures
+#   stay on stdout and in the exit code, not in STATUS_FILE.
+# @arg $1 string release .tgz url
+# @arg $2 string matching .sha256 url
+# @stdout wget progress, then a download: ok/failed line
+# @exitcode 0 on success
+# @exitcode 1 on a fetch failure, or when an update is already running
+# @exitcode 2 on a checksum mismatch
+do_download() {
+	if update_in_progress; then
+		echo "download: failed, an update is already running"
+		exit 1
+	fi
+	mkdir -p "$UPDATE_DIR"
+	rm -rf "$UPDATE_DIR"/*
+	local progress_style=dot:mega
+	[ -t 1 ] && progress_style=bar:force
+	if ! wget -T 180 --progress="$progress_style" -P "$UPDATE_DIR" "$1" "$2" 2>&1; then
+		echo "download: failed"
+		exit 1
+	fi
+	verify_checksum || { echo "download: failed checksum verification"; exit 2; }
+	echo "download: ok"
+	exit 0
+}
+
+
+#---------------------------------
+#--- update mode
+
+# @description copy this script to /tmp and exec the copy.
+# @noargs
+# @exitcode 1 if staging fails, otherwise this function execs and never returns
+stage_update() {
+	cp "$0" "$STAGED_COPY" || fail env "could not stage updater to $STAGED_COPY"
+	exec /bin/bash "$STAGED_COPY"
+}
+
+# @description verify the download, unpack it, run the release's own install,
+#   and reboot only into a verified binary.
+# @noargs
+# @stdout a pointer to UPDATE_LOG before output is redirected there
+# @exitcode 0 on success, after requesting a reboot
+# @exitcode 1 on failure, without rebooting (or the install script's exit code)
+do_update() {
+	local release_version install_script install_status
+	echo "update: progress in $UPDATE_LOG"
+	exec >>"$UPDATE_LOG" 2>&1
+	export HOME="$WE_DIR"
+	echo "update: starting: $(date)"
+	rm -f "$STATUS_FILE" "$PROGRESS_FILE"
+
+	cd "$UPDATE_DIR" || fail env "$UPDATE_DIR missing"
+
+	echo "update: verifying checksum..."
+	begin_step "verifying checksum"
+	verify_checksum || fail checksum "download did not verify against its .sha256"
+
+	echo "update: unpacking..."
+	begin_step "unpacking"
+	local -a tgz=("$UPDATE_DIR"/*.tgz)
+	if [ "${#tgz[@]}" -ne 1 ] || [ ! -f "${tgz[0]}" ]; then
+		fail unpack "expected exactly one release .tgz in $UPDATE_DIR"
+	fi
+	tar xzf "${tgz[0]}" -C "$UPDATE_DIR/" || fail unpack "unpack failed"
+
+	release_version="$(tar tzf "${tgz[0]}" 2>/dev/null | head -n 1 | sed 's|^\./||' | cut -d/ -f1)"
+	[ -n "$release_version" ] || fail missing-script "could not read a version directory from the download"
+	echo "update: found release $release_version"
+
+	install_script="$UPDATE_DIR/$release_version/update.sh"
+	[ -f "$install_script" ] || fail missing-script "$install_script not found after unpack"
+
+	echo "update: running install ($install_script)..."
+	begin_step "installing"
+	heartbeat_stop
+	if /bin/bash "$install_script"; then
+		if verify_norns_tree "$NORNS_DIR" && launch_check "$NORNS_DIR"; then
+			echo "update: ok, rebooting: $(date)"
+			sync
+			$SUDO systemctl reboot
+		else
+			fail postcheck "post-update binary missing/not launchable, NOT rebooting"
+		fi
+	else
+		install_status=$?
+		[ -s "$STATUS_FILE" ] || echo "failed:update-script" > "$STATUS_FILE"
+		echo "update: FAILED (exit $install_status), not rebooting, see $UPDATE_LOG"
+		exit "$install_status"
+	fi
+	exit 0
+}
+
+
+#---------------------------------
+#--- install mode
+
+# @description install the unpacked release this script sits in.
+# @noargs
+# @stdout progress lines
+# @exitcode 0 on success
+# @exitcode 1 if a check or critical step fails
+do_install() {
+	local version free_kb
+	cd "$SCRIPT_DIR" || fail env "cannot cd to the release directory"
+
+	version=$(cat "$WE_DIR/version.txt") || fail disk-image "cannot read $WE_DIR/version.txt"
+	case "$version" in
+	'' | *[!0-9]*) fail disk-image "no usable version in $WE_DIR/version.txt" ;;
+	esac
+	[ "$version" -ge "$MIN_DISK_VERSION" ] || fail disk-image "needs a new disk image ($version < $MIN_DISK_VERSION)"
+
+	[ -d norns ] || fail binary-swap "staged norns tree missing"
+	verify_norns_tree norns || fail binary-swap "staged norns binary missing/not executable"
+	[ -d maiden ] || fail maiden-swap "staged maiden tree missing"
+
+	free_kb=$(df -kP "$WE_DIR" | awk 'NR==2 {print $4}')
+	[ "${free_kb:-0}" -ge "$MIN_SWAP_KB" ] || fail disk-space "low disk: ${free_kb}KB free < ${MIN_SWAP_KB}KB needed to stage swap"
+
+	begin_step "installing packages"
+
+	$SUDO cp config/raspi.list "$ROOT/etc/apt/sources.list.d/"
+
+	$SUDO apt-get update && $SUDO apt-get -y install libnng1 libnng-dev
+	dpkg -s libnng1 >/dev/null 2>&1 || fail libnng "libnng1 not installed"
+
+	$SUDO systemctl disable norns-matron.service 2>/dev/null
+	$SUDO systemctl disable norns-crone.service 2>/dev/null
+	$SUDO rm -f "$ROOT/etc/systemd/system/norns-matron.service"
+	$SUDO rm -f "$ROOT/etc/systemd/system/norns-crone.service"
+	$SUDO cp --remove-destination config/norns-main.service "$ROOT/etc/systemd/system/norns-main.service" || fail units "install norns-main.service failed"
+	$SUDO cp --remove-destination config/norns-sclang.service "$ROOT/etc/systemd/system/norns-sclang.service" || fail units "install norns-sclang.service failed"
+	$SUDO cp --remove-destination config/norns.target "$ROOT/etc/systemd/system/norns.target" || fail units "install norns.target failed"
+	$SUDO systemctl enable norns-main.service || fail units "enable norns-main.service failed"
+	$SUDO systemctl enable norns-sclang.service || fail units "enable norns-sclang.service failed"
+
+	$SUDO cp --remove-destination config/norns-watcher.service "$ROOT/etc/systemd/system/norns-watcher.service" || fail units "install norns-watcher.service failed"
+	$SUDO systemctl enable norns-watcher || fail units "enable norns-watcher failed"
+
+	$SUDO cp --remove-destination config/norns-jack.service "$ROOT/etc/systemd/system/norns-jack.service" || fail units "install norns-jack.service failed"
+
+	swap_tree maiden "$MAIDEN_DIR" maiden-swap tree_nonempty
+
+	$SUDO rm -rf "$WE_DIR/bin/maiden-repl"
+	$SUDO cp -a norns/build/maiden-repl/maiden-repl "$WE_DIR/bin/" || fail maiden-swap "maiden-repl install failed"
+
+	swap_tree norns "$NORNS_DIR" binary-swap verify_norns_tree verify_norns_live
+	begin_step "finishing"
+
+	cp version.txt "$WE_DIR/"
+	cp changelog.txt "$WE_DIR/"
+
+	$SUDO apt -y remove rsyslog
+	$SUDO cp config/logrotate.conf "$ROOT/etc/"
+	$SUDO cp config/journald.conf "$ROOT/etc/systemd/"
+	$SUDO rm -rf "$ROOT/var/log/journal"
+	$SUDO rm -rf "$ROOT/var/log/daemon.log"
+	$SUDO rm -rf "$ROOT/var/log/user.log"
+
+	$SUDO systemctl disable hciuart
+
+	find "$WE_DIR/dust" -name .DS_Store -delete
+	find "$WE_DIR/dust" -name ._.DS_Store -delete
+
+	# set alsa mixer
+	amixer --device hw:sndrpimonome set Master 100% on
+	$SUDO alsactl store
+
+	# change boot/cmdline for screen
+	$SUDO sed -e '/dtoverlay=ssd1322-spi/ s/^#*/#/' -i "$ROOT/boot/config.txt"
+	$SUDO sed -e '/spidev.bufsiz/! s/$/ spidev.bufsiz=8192/' -i "$ROOT/boot/cmdline.txt"
+
+	# install packages
+	$SUDO dpkg -i package/*.deb
+
+	# clean slate
+	rm -f "$WE_DIR/matronrc.lua"
+
+	# get common audio if not present
+	if [ ! -d "$WE_DIR/dust/audio/common" ]; then
+		echo "common audio does not exist, downloading"
+		(
+			cd "$WE_DIR/dust/audio" &&
+				wget "$DUST_AUDIO_COMMON_URL" &&
+				tar xzvf "$DUST_AUDIO_COMMON_TGZ" &&
+				rm "$DUST_AUDIO_COMMON_TGZ"
+		)
+	fi
+
+	# update libmonome
+	if [ -d package/libmonome ]; then
+		( cd package/libmonome && ./waf configure && $SUDO ./waf install )
+	fi
+
+	# maiden project setups
+	( cd "$MAIDEN_DIR" && ./project-setup.sh )
+
+	# cleanup
+	rm -rf "$UPDATE_DIR"/*
+	echo "update: complete"
+	exit 0
+}
+
+
+#---------------------------------
+#--- mode routing
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+readonly SCRIPT_ABS_PATH="$SCRIPT_DIR/$(basename "$0")"
+
+trap heartbeat_stop EXIT
+
+# @description true when a release is downloaded and ready to stage.
+# @noargs
+# @exitcode 0 if a downloaded release is ready to stage
+# @exitcode 1 otherwise
+should_stage_update() {
+	is_release_downloaded && [ "$SCRIPT_ABS_PATH" != "$STAGED_COPY" ] &&
+		! is_release_dir "$SCRIPT_DIR" && ! is_in_update_dir "$SCRIPT_DIR"
+}
+
+if [ "${1:-}" = "download" ] && [ $# -eq 3 ]; then
+	do_download "$2" "$3"
+elif [ $# -eq 0 ] && should_stage_update; then
+	stage_update
+# the exec restarts the script from the top, routing the copy in to do the update
+elif [ $# -eq 0 ] && [ "$SCRIPT_ABS_PATH" = "$STAGED_COPY" ]; then
+	do_update
+elif [ $# -eq 0 ] && is_release_dir "$SCRIPT_DIR"; then
+	do_install
+else
+	usage
+	exit 1
 fi
-
-# update libmonome
-cd "$(dirname "$0")"/package/libmonome
-./waf configure
-sudo ./waf install
-
-# maiden project setup
-cd /home/we/maiden
-./project-setup.sh
-
-# cleanup
-rm -rf ~/update/*


### PR DESCRIPTION
_why_

with the current converged binary, updates and system commands such as restart are delegated to the sidecar. update fails completely and restart fails often... requiring manual reboot of the device.

update, restart, and shutdown all need privileged, detached execution. the existing update flow runs `tar` and `update.sh` as concurrent fire-and-forget shell calls, racing each other, then shows "done" before either has finished. when an update step stalls, the screen is stuck on its last message forever.

since the sidecar is norns' child process, any command that restarts norns also kills the sidecar and with it the command doing the restarting.

_what_

this PR reworks the sidecar around a typed, streaming transport with message framing (`norns/sidecar_msg`), line streaming (`norns/sidecar_lines`), and supervised execution (`norns/sidecar_shell`) as pure, separately tested pieces, and `sidecar.cpp` keeping the NNG glue. additionally, the sidecar gains the ability to launch detached system commands is added, which keep running after norns stops.

the SYSTEM>UPDATE flow is then reworked (using the sidecar transport improvements) into a fail-safe / fail-loud updater that replaces the norns binary and reboots only once the new binary proves launchable, rolling back otherwise. and importantly no longer stalls and fails spectacularly :).

sidecar's protocol can now launch work that outlives norns replacing/restarting itself, so we also got a much more reliable restart mechanism.

_highlights_

- sidecar - a stuck command can no longer tie up the sidecar (`norns/sidecar_shell`). commands run with limits. a command that goes quiet or floods output is cut off (each request sets its cap), stderr streams back alongside stdout, and stopping a command asks it to exit before forcing it.
- lua shell - lua's `os.execute` and `io.popen` are reimplemented over the sidecar, closing the last `fork()` opportunities in the JACK-holding converged binary process. `os.execute` keeps the exact lua contract. `io.popen` hands back a read-only handle (`read`/`lines`/`close`, see notes below). captured output is delivered through lua's `print`, so command output still lands in maiden.
- update - the SYSTEM>UPDATE menu guards against a failed or malformed `releases.txt` reply, which previously left the checking screen spinning forever.
- update - the SYSTEM>UPDATE menu shows the installer's current step on-screen as it runs, with a heartbeat that lets it tell a long quiet step from a stalled install.
- update - the new binary proves it launches using `norns --check` before the device reboots into it.
- update - the swap stages `.new` and keeps `.old`, so a failed check rolls back to the working install.
- update - a failed step writes status (`failed:<step>` is the format) used to present messaging on-screen, and returns to a clean pre-update state, rather than booting a broken build.
- update - `m.releases_url` override variable for local update testing (see _test running the update locally_ below).

_verification_

- tested on hardware end-to-end
    - download -> checksum -> verified swap -> reboot into the new version
    - failure paths (corrupt / checksum / missing-script / bad-binary -> correct `failed:<step>`, no reboot, on-screen failure)
    - an installer that dies without reporting
    - manual update flow (wget + tar + run `./update.sh`)
- new unit test coverage across the changes (c/c++ doctest, lua luaunit, and a bash-based dry-run test for update.sh).
- test-update.sh wired into a new `test-update` CI job.
- the test-update dry-run suite runs `update.sh`, aimed at a scratch tree through its `NORNS_UPDATE_ROOT` / `NORNS_UPDATE_SUDO` test-time overrides.

the rest of this pr is largely the cleanup that fell out of making this all possible:
- the system actions (shutdown, reset, update) are now a fixed allowlist at the C layer. each action name maps to a fixed command and a fixed transient systemd unit which is launched detached by the sidecar via `sudo -n systemd-run`. lua only ever supplies the action name, so no new shell execution capability is exposed to scripts.
- tidy: drops the dead `passdone` copy in `lua/core/menu/system.lua` (settings and wifi each own their own live copy).

_test running the update locally_

the SYSTEM>UPDATE menu page can now read its release manifest from an `m.releases_url` override variable, settable at runtime over the repl. otherwise it defaults to the monome `releases.txt` on github. with this override, the real download -> verify -> swap -> reboot path can be driven against a local http server for testing:

**1. serve a manifest + bundle.** `releases.txt` is lua that the menu `load()`s. it sets a global `releases`:

```lua
-- example releases.txt
releases = {}
releases.stable = {
  version = "999999", -- greater than the device's ~/version.txt so the menu shows it
  url = "http://<host>:8000/norns999999.tgz",
  sha = "http://<host>:8000/norns999999.sha256",
}
releases.beta = releases.stable -- the menu logic validates both channels
```

the bundle it points at is a release tarball which is a top dir named for the version, holding `update.sh`, the built `norns/` tree (`build/norns/norns` + `build/maiden-repl/maiden-repl`), `maiden/`, the `config/` systemd units, `version.txt`, and `changelog.txt`. `update/pack.sh <version>` tars that dir and writes the matching checksum:

```bash
update/pack.sh 999999    # tars ./999999/ -> norns999999.tgz + norns999999.sha256
```

the quickest valid bundle is a copy of an installed release tree with its version bumped. serve `releases.txt`, the `.tgz`, and the `.sha256` from one dir over the LAN — `python3 -m http.server 8000`.

**2. point the device at it** over the repl (any restart resets the override to upstream):

```lua
require("core/menu/update").releases_url = "http://<host>:8000/releases.txt"
```

note the menu still pings `github.com` (and wants 400M free on disk) before it reads the override, so the device needs working internet even though the release itself is served from the LAN.

**3. open SYSTEM>UPDATE and confirm.** the success bundle downloads, verifies, swaps, and reboots into the new version. for the fail-safe paths you don't even need a valid bundle — a corrupt `.tgz`, a wrong `.sha256`, or a bundle missing `update.sh` each surfaces its `failed:<step>` on screen with no reboot.

_notes_

- bug: lua `io.popen` is partially regressed... "w" mode intentionally fails with a loud error, and reads hand back the finished command's whole output rather than streaming it. this should be fixed in a follow-up PR. it requires additional changes to the sidecar to support it, and i'm intentionally not putting that work here, to keep this already massive amount of change as contained as possible at this point. the system cmd and sidecar work from this PR is already an excellent prefactoring for the changes required to get `io.popen` fully working.
- restart is now dependable as a mechanism, but jackd itself can still hang, across repeated restarts and around ssh sessions. this PR does not fix this issue. two potential causes found while working (ssh'ing and restarting **a lot**):
  - bug: `crone_cleanup()` → `jack_client_close` only runs when the event loop exits on its own. restart delivers SIGTERM, and with no handler installed the process dies before reaching it, so every restart is an unclean JACK client death. the fix _should_ be a SIGTERM handler that routes into the existing teardown path.
  - bug: closing the last ssh session makes systemd-logind purge the shared memory (`RemoveIPC=yes`), destroying jackd's shm while it runs. the next restart then fails until a power cycle. the fix here is likely a `RemoveIPC=no` logind addition. this belongs in norns-image for fresh flashes, but it should likely also ship through `update.sh`, so existing devices would pick it up on their next update without a reflash.
- async `norns.system_cmd` now has a ceiling upstream does not have. a command that stays silent for more than 4 minutes is killed and reported failed. the timeout bounds silence, not total runtime, so a command that keeps producing output can run as long as it needs. `os.execute` and `io.popen` pass no ceiling at all, keeping stdlib duration behavior for scripts that use them (this is on the script author).
- with this PR `update.sh` has indeed outgrown its bash beginnings at ~500 lines... with a rather silly (but kind of fun to write) hand-rolled test rig as an additional ~500 lines. this is fine, but the bash scripting seems to have reached its limit. it is fully functional and tested work, but further expansion should consider moving to python IMO.
- i'm really excited about this work. looking forward to review(s). thanks.