### PR TITLE
fix fd leak in pset_list (matron crash with many psets)

### DIFF
--- a/lua/core/menu/params.lua
+++ b/lua/core/menu/params.lua
@@ -81,7 +81,7 @@ local function pset_list(results)
     --print(file,n)
     local name = norns.state.shortname
     local f = io.open(file,"r")
-    io.input(file)
+    io.input(f)
     local line = io.read("*line")
     if util.string_starts(line, "-- ") then
       name = string.sub(line,4,-1)


### PR DESCRIPTION
## Summary

`pset_list` in `lua/core/menu/params.lua` leaks one file descriptor per pset file on every scan. With a large number of psets this exhausts the 1024 fd limit mid-session and crashes matron.

```lua
local f = io.open(file,"r")
io.input(file)          -- path string: Lua opens a *second* handle
local line = io.read("*line")
io.close(f)             -- only closes the first
```

`io.input(path)` opens the file itself and sets it as default input. That handle is never closed; `io.close(f)` closes the unused one. The leaked handles only go away when the GC happens to collect them, which with a handful of psets is fast enough to hide the bug.

This PR changes `io.input(file)` to `io.input(f)`, matching the idiom already used at the other three `io.input` call sites in core (`script.lua` pset-last, `norns.lua` version.txt, `wifi.lua`).

## Repro

Script with ~130 psets. Save a pset ~8 times in one session (each write triggers `init_pset()` which rescans). Journal:

```
lua: /home/we/norns/lua/core/menu/params.lua:84: cannot open file '.../dx100-20.pset' (Too many open files)
stack traceback:
        [C]: in function 'io.input'
        /home/we/norns/lua/core/menu/params.lua:84: in field 'callback'
        /home/we/norns/lua/core/norns.lua:224: in function </home/we/norns/lua/core/norns.lua:222>
Error opening pipe: temp read
child killed (signal 11)
```

Observed on 240911; the code is unchanged on `main` and v3.0.2.

## Side effect fixed

After the scan, Lua's default input was left pointing at the last pset file, still open. Harmless since matron doesn't read stdin from Lua, but not intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
