### PR TITLE
util.trim_string_to_width: fix infinite loop when nothing fits

### DIFF
--- a/lua/lib/util.lua
+++ b/lua/lib/util.lua
@@ -94,18 +94,36 @@ util.string_starts = function(s,start)
   return string.sub(s,1,string.len(start))==start
 end
 
---- trim string to a display width
+--- trim string to a display width.
+-- if the string is wider than `width`, characters are removed from the end
+-- and "..." is appended. if even "..." does not fit, as many dots as fit are
+-- returned (possibly an empty string).
 -- @tparam string s string to trim
--- @tparam number width maximum width
+-- @tparam number width maximum width, in pixels
 -- @treturn string trimmed string
 util.trim_string_to_width = function(s, width)
-  if _norns.screen_text_extents(s) > width then
-    while _norns.screen_text_extents(s .. "...") > width do
-      s = string.gsub(s, "[^\128-\191][\128-\191]*$", "")
-    end
-    s = s .. "..."
+  if _norns.screen_text_extents(s) <= width then
+    return s
   end
-  return s
+  local ellipsis = "..."
+  while #s > 0 and _norns.screen_text_extents(s .. ellipsis) > width do
+    -- drop the last utf-8 character (lead byte plus any continuation bytes)
+    local trimmed = string.gsub(s, "[^\128-\191][\128-\191]*$", "")
+    if trimmed == s then
+      -- malformed utf-8 (trailing continuation bytes only); drop one byte
+      trimmed = string.sub(s, 1, -2)
+    end
+    s = trimmed
+  end
+  if #s == 0 then
+    -- nothing of the original string fits alongside the ellipsis.
+    -- return however much of the ellipsis fits on its own.
+    while #ellipsis > 0 and _norns.screen_text_extents(ellipsis) > width do
+      ellipsis = string.sub(ellipsis, 1, -2)
+    end
+    return ellipsis
+  end
+  return s .. ellipsis
 end
 
 --- clamp values to min max.


### PR DESCRIPTION
Fixes #1636

## Problem

`util.trim_string_to_width("asdf", 2)` hung the Lua VM (maiden appeared to crash, and in one report the whole system locked up).

The `while` loop strips one character at a time until `s .. "..."` fits. Once `s` is empty, `gsub` makes no change, but `"..."` alone is still wider than 2px, so the loop never exits. This matches the diagnosis from @Dewb in the issue.

## Fix

- Stop the loop when `s` is empty.
- If `gsub` makes no progress (malformed UTF-8: trailing continuation bytes with no lead byte, so the pattern never matches), drop one raw byte instead. This closes a second potential hang.
- When nothing of the original string fits alongside the ellipsis, return as many dots as fit, possibly an empty string. Previously this case hung.
- Document that `width` is in pixels.

Behavior is unchanged for normal inputs. Both callers in `fileselect.lua` pass widths well above the ellipsis width.

## Testing

Ran under `lua5.4` with a stubbed `_norns.screen_text_extents` (5px per character):

| input | width | result |
|---|---|---|
| `"asdf"` | 2 | `""` (previously hung) |
| `"asdf"` | 20 | `"asdf"` |
| `"asdf"` | 15 | `"..."` |
| `"asdf"` | 10 | `".."` |
| `"asdf"` | 0 / -5 | `""` |
| `"abcdefghij"` | 30 | `"abc..."` |
| `"héllo wörld"` | 30 | `"hél..."` (multibyte chars kept whole) |
| `"\128\128\128"` | 3 | `""` (malformed UTF-8, no hang) |

Confirmed the old implementation hangs on `("asdf", 2)` under the same stub. Not yet tested on hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
