### PR TITLE
fileselect: resolve preview/select paths from real filenames, not display labels

### DIFF
--- a/lua/lib/fileselect.lua
+++ b/lua/lib/fileselect.lua
@@ -17,6 +17,7 @@ function fs.enter(folder, callback, filter_string)
   fs.folders = {}
   fs.list = {}
   fs.display_list = {}
+  fs.names = {}
   fs.lengths = {}
   fs.pos = 0
   fs.depth = 0
@@ -104,6 +105,7 @@ fs.getlist = function()
   local dir = fs.getdir()
   fs.list = util.scandir(dir)
   fs.display_list = {}
+  fs.names = {}
   fs.lengths = {}
   fs.visible = {}
   fs.pos = 0
@@ -144,6 +146,9 @@ fs.getlist = function()
     end
 
     if fs.visible[k] then
+      -- display_list holds the (possibly truncated) label; names holds the
+      -- real filename for the same row. always resolve paths through names.
+      table.insert(fs.names, v)
       line = util.trim_string_to_width(line, max_line_length)
       table.insert(fs.display_list, line)
       table.insert(fs.lengths, display_length)
@@ -202,12 +207,8 @@ fs.key = function(n, z)
     -- select
   elseif n == 3 and z == 1 then
     stop()
-    if #fs.list > 0 then
-      if string.sub(fs.display_list[fs.pos + 1], -3) == '...' then
-        fs.file = fs.list[fs.pos + 1]
-      else
-        fs.file = fs.display_list[fs.pos + 1]
-      end
+    if #fs.names > 0 then
+      fs.file = fs.names[fs.pos + 1]
       if fs.file == "../" then
         fs.folders[fs.depth] = nil
         fs.depth = fs.depth - 1
@@ -239,7 +240,7 @@ fs.enc = function(n, d)
     fs.pos = util.clamp(fs.pos + d, 0, #fs.display_list - 1)
     fs.redraw()
   elseif n == 3 and d > 0 then
-    fs.file = fs.display_list[fs.pos + 1]
+    fs.file = fs.names[fs.pos + 1]
     if fs.lengths[fs.pos + 1] ~= "" then
       start()
     end


### PR DESCRIPTION
## Problem
In TAPE > PLAY, files with long names never preview on E3, but play fine once selected with K3.

`fileselect.getlist()` builds `display_list` by passing each name through `util.trim_string_to_width` (97 px for audio rows so the duration fits), so anything wider becomes `some-long-na...`. The E3 preview handler passed that truncated **label** to `tape_play_open`, so the path didn't exist and nothing played. Dashes aren't involved; it's purely name width.

The K3 handler had a workaround (if the label ends in `...`, fall back to `fs.list[pos]`), which is why selection worked. That workaround is itself wrong once a filter hides rows: `display_list` only holds visible entries while `fs.list` holds everything, so the indices drift and K3 selects a different file from the one highlighted.

## Fix
Keep a parallel `fs.names` table holding the real filename for every visible row, and resolve both preview and selection through it. Drop the `...` heuristic.

## Verification
Stubbed-norns lua test (fake 5 px/char text extents, four files incl. two long `.wav` names and a `notes.txt`):

| case | before | after |
|---|---|---|
| E3 preview long name | opens `/audio/a-really-long-fi...` | opens real path |
| K3 select long name | ok (heuristic) | ok |
| E3 preview, `.wav` filter hides `notes.txt` | truncated path | ok |
| K3 select, `.wav` filter hides `notes.txt` | selects **`notes.txt`** | ok |

Deployed to a norns running 2.9.4 (the file is identical there) for hands-on confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
