### PR TITLE
Dev container: use raspbian site for all packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,10 @@ ENV LANG=C.UTF-8 \
     SUPERCOLLIDER_PLUGINS_VERSION=3.13.0 \
     NNG_VERSION=1.11
 
+RUN \
+    rm /etc/apt/sources.list && \
+    echo 'deb [trusted=yes] http://raspbian.raspberrypi.org/raspbian/ bullseye main contrib non-free rpi' > /etc/apt/sources.list
+
 RUN apt-get update -yq && apt-get install -y \
     bc \
     build-essential \


### PR DESCRIPTION
Debian Bullseye is now EOL'd and modifying `/etc/apt/sources.list` is now required to update packages. There appear to be some issues with the transition to archive.debian.org, so this commit switches the container's sources.list to the Raspbian deb archive, which better matches the norns hardware image anyway.

This should fix #1909.